### PR TITLE
Update for rust language changes

### DIFF
--- a/src/lib/repeated.rs
+++ b/src/lib/repeated.rs
@@ -277,7 +277,7 @@ impl<T : PartialEq> RepeatedField<T> {
     }
 }
 
-impl<T> Vector<T> for RepeatedField<T> {
+impl<T> Slice<T> for RepeatedField<T> {
     #[inline]
     fn as_slice<'a>(&'a self) -> &'a [T] {
         self.vec.slice_to(self.len)


### PR DESCRIPTION
Rust's Vector<T> trait has been renamed to Slice<T>, as per https://github.com/rust-lang/rust/commit/fbc93082ec92c3534c4b27fef35d78d97bd77fd2

Required to make project build.
