### PR TITLE
Got rid of some unused variable warnings

### DIFF
--- a/src/lib/singular.rs
+++ b/src/lib/singular.rs
@@ -85,7 +85,7 @@ impl<T> SingularField<T> {
     pub fn as_mut_slice<'a>(&'a mut self) -> &'a mut [T] {
         match self.as_mut() {
             //Some(x) => slice::mut_ref_slice(x), // doesn't work I have no idea why
-            Some(x) => fail!(),
+            Some(..) => fail!(),
             None => &mut []
         }
     }
@@ -250,7 +250,7 @@ impl<T> SingularPtrField<T> {
     pub fn as_mut_slice<'a>(&'a mut self) -> &'a mut [T] {
         match self.as_mut() {
             //Some(x) => slice::mut_ref_slice(x), // doesn't work I have no idea why
-            Some(x) => fail!(),
+            Some(..) => fail!(),
             None => &mut []
         }
     }


### PR DESCRIPTION
```
88:19 warning: unused variable: `x`, #[warn(unused_variable)] on by default
253:19 warning: unused variable: `x`, #[warn(unused_variable)] on by default
```
