### PR TITLE
Fix private type in exported type paremater bound.

### DIFF
--- a/src/lib/rt.rs
+++ b/src/lib/rt.rs
@@ -26,12 +26,12 @@ pub fn compute_raw_varint32_size(value: u32) -> u32 {
     compute_raw_varint64_size(value as u64)
 }
 
-trait ProtobufVarint {
+pub trait ProtobufVarint {
     // size of self when written as varint
     fn len_varint(&self) -> u32;
 }
 
-trait ProtobufVarintZigzag {
+pub trait ProtobufVarintZigzag {
     fn len_varint_zigzag(&self) -> u32;
 }
 


### PR DESCRIPTION
With `rustc 0.12.0-nightly (94b0aace1 2014-09-27 23:12:54 +0000)` the following error occurs:

```
src/lib/rt.rs:91:36: 91:37 error: private type in exported type parameter bound
src/lib/rt.rs:91 pub fn vec_packed_varint_data_size<T : ProtobufVarint>(vec: &[T]) -> u32 {
                                                    ^
src/lib/rt.rs:96:43: 96:44 error: private type in exported type parameter bound
src/lib/rt.rs:96 pub fn vec_packed_varint_zigzag_data_size<T : ProtobufVarintZigzag>(vec: &[T]) -> u32 {
                                                           ^
src/lib/rt.rs:101:31: 101:32 error: private type in exported type parameter bound
src/lib/rt.rs:101 pub fn vec_packed_varint_size<T : ProtobufVarint>(field_number: u32, vec: &[T]) -> u32 {
                                                ^
src/lib/rt.rs:111:38: 111:39 error: private type in exported type parameter bound
src/lib/rt.rs:111 pub fn vec_packed_varint_zigzag_size<T : ProtobufVarintZigzag>(field_number: u32, vec: &[T]) -> u32 {
                                                       ^
src/lib/rt.rs:125:26: 125:27 error: private type in exported type parameter bound
src/lib/rt.rs:125 pub fn value_size_no_tag<T : ProtobufVarint>(value: T, wt: wire_format::WireType) -> u32 {
                                           ^
src/lib/rt.rs:134:19: 134:20 error: private type in exported type parameter bound
src/lib/rt.rs:134 pub fn value_size<T : ProtobufVarint>(field_number: u32, value: T, wt: wire_format::WireType) -> u32 {
                                    ^
error: aborting due to 6 previous errors
Could not compile `protobuf`.
```

This commit aims to fix it. The drawbacks are that `ProtobufVarint` and `ProtobufVarintZigzag` are now public, which is what the compiler is trying to enforce.
