### PR TITLE
(refs #34) fixed error "method 'as_slice' is not a member of trait Slice"

### DIFF
--- a/src/lib/repeated.rs
+++ b/src/lib/repeated.rs
@@ -277,7 +277,7 @@ impl<T : PartialEq> RepeatedField<T> {
     }
 }
 
-impl<T> Slice<T> for RepeatedField<T> {
+impl<T> AsSlice<T> for RepeatedField<T> {
     #[inline]
     fn as_slice<'a>(&'a self) -> &'a [T] {
         self.vec.slice_to(self.len)


### PR DESCRIPTION
It seems they have moved method 'as_slice' to trait AsSlice
http://doc.rust-lang.org/std/slice/trait.AsSlice.html

Fixed the error "method 'as_slice' is not a member of trait Slice" mentioned in #34 
