### PR TITLE
Fix error 'cannot refer to other statics by value'

### DIFF
--- a/src/lib/core.rs
+++ b/src/lib/core.rs
@@ -32,8 +32,8 @@ use reflect::EnumDescriptor;
 use reflect::EnumValueDescriptor;
 
 pub mod wire_format {
-    pub static TAG_TYPE_BITS: u32 = 3;
-    pub static TAG_TYPE_MASK: u32 = (1u << TAG_TYPE_BITS as uint) as u32 - 1;
+    pub const TAG_TYPE_BITS: u32 = 3;
+    pub const TAG_TYPE_MASK: u32 = (1u << TAG_TYPE_BITS as uint) as u32 - 1;
 
     #[deriving(PartialEq, Eq, Clone, Show)]
     pub enum WireType {

--- a/src/lib/lazy.rs
+++ b/src/lib/lazy.rs
@@ -17,4 +17,4 @@ impl<T> Lazy<T> {
     }
 }
 
-pub static ONCE_INIT: one::Once = one::ONCE_INIT;
+pub const ONCE_INIT: one::Once = one::ONCE_INIT;


### PR DESCRIPTION
`rustc 0.13.0-nightly (f9fc49c06 2014-10-10 00:07:08 +0000)`

Fixes things broken with https://github.com/rust-lang/rust/commit/90d03d792669fed99b659d1efbe835d4b9b8873c
