### PR TITLE
Fix compilation

### DIFF
--- a/src/lib/descriptor.rs
+++ b/src/lib/descriptor.rs
@@ -2096,7 +2096,7 @@ impl ::protobuf::ProtobufEnum for FieldDescriptorProto_Type {
     }
 }
 
-impl ::std::kinds::Copy for FieldDescriptorProto_Type {
+impl ::std::marker::Copy for FieldDescriptorProto_Type {
 }
 
 #[derive(Clone,PartialEq,Eq,Show)]
@@ -2133,7 +2133,7 @@ impl ::protobuf::ProtobufEnum for FieldDescriptorProto_Label {
     }
 }
 
-impl ::std::kinds::Copy for FieldDescriptorProto_Label {
+impl ::std::marker::Copy for FieldDescriptorProto_Label {
 }
 
 #[derive(Clone,Default)]
@@ -3951,7 +3951,7 @@ impl ::protobuf::ProtobufEnum for FileOptions_OptimizeMode {
     }
 }
 
-impl ::std::kinds::Copy for FileOptions_OptimizeMode {
+impl ::std::marker::Copy for FileOptions_OptimizeMode {
 }
 
 #[derive(Clone,Default)]
@@ -4665,7 +4665,7 @@ impl ::protobuf::ProtobufEnum for FieldOptions_CType {
     }
 }
 
-impl ::std::kinds::Copy for FieldOptions_CType {
+impl ::std::marker::Copy for FieldOptions_CType {
 }
 
 #[derive(Clone,Default)]

--- a/src/lib/hex.rs
+++ b/src/lib/hex.rs
@@ -35,7 +35,7 @@ pub fn decode_hex(hex: &str) -> Vec<u8> {
 }
 
 fn encode_hex_digit(digit: u8) -> char {
-    match char::from_digit(digit as uint, 16) {
+    match char::from_digit(digit as usize, 16) {
         Some(c) => c,
         _ => panic!()
     }

--- a/src/lib/maybe_owned_slice.rs
+++ b/src/lib/maybe_owned_slice.rs
@@ -25,19 +25,19 @@ impl<'a, T : 'a> MaybeOwnedSlice<'a, T> {
     }
 
     #[inline]
-    pub fn slice<'b>(&'b self, start: uint, end: uint) -> &'b [T] {
+    pub fn slice<'b>(&'b self, start: usize, end: usize) -> &'b [T] {
         self.as_slice().slice(start, end)
     }
 
     #[allow(dead_code)]
     #[inline]
-    pub fn slice_from<'b>(&'b self, start: uint) -> &'b [T] {
+    pub fn slice_from<'b>(&'b self, start: usize) -> &'b [T] {
         self.as_slice().slice_from(start)
     }
 
     #[allow(dead_code)]
     #[inline]
-    pub fn slice_to<'b>(&'b self, end: uint) -> &'b [T] {
+    pub fn slice_to<'b>(&'b self, end: usize) -> &'b [T] {
         self.as_slice().slice_to(end)
     }
 }
@@ -51,20 +51,20 @@ impl<'a, T : 'a> AsSlice<T> for MaybeOwnedSlice<'a, T> {
     }
 }
 
-impl<'a, T : 'a> Index<uint> for MaybeOwnedSlice<'a, T> {
+impl<'a, T : 'a> Index<usize> for MaybeOwnedSlice<'a, T> {
     type Output = T;
 
     #[inline]
-    fn index<'b>(&'b self, index: &uint) -> &'b T {
+    fn index<'b>(&'b self, index: &usize) -> &'b T {
         &self.as_slice()[*index]
     }
 }
 
-impl<'a, T : 'a> IndexMut<uint> for MaybeOwnedSlice<'a, T> {
+impl<'a, T : 'a> IndexMut<usize> for MaybeOwnedSlice<'a, T> {
     type Output = T;
 
     #[inline]
-    fn index_mut<'b>(&'b mut self, index: &uint) -> &'b mut T {
+    fn index_mut<'b>(&'b mut self, index: &usize) -> &'b mut T {
         &mut self.as_mut_slice()[*index]
     }
 }

--- a/src/lib/paginate.rs
+++ b/src/lib/paginate.rs
@@ -1,9 +1,9 @@
 pub trait PaginatableIterator<T> {
-    fn paginate(self, page: uint) -> Paginate<Self>;
+    fn paginate(self, page: usize) -> Paginate<Self>;
 }
 
 impl<T, U : Iterator<Item = T>> PaginatableIterator<T> for U {
-    fn paginate(self, page: uint) -> Paginate<U> {
+    fn paginate(self, page: usize) -> Paginate<U> {
         Paginate {
             iter: self,
             page: page,
@@ -13,7 +13,7 @@ impl<T, U : Iterator<Item = T>> PaginatableIterator<T> for U {
 
 struct Paginate<I> {
     iter: I,
-    page: uint,
+    page: usize,
 }
 
 impl<E, I : Iterator<Item = E>> Iterator for Paginate<I> {

--- a/src/lib/protobuf.rs
+++ b/src/lib/protobuf.rs
@@ -1,7 +1,4 @@
 #![crate_type = "lib"]
-#![feature(associated_types)]
-#![feature(globs)]
-#![feature(slicing_syntax)]
 #![allow(non_camel_case_types)]
 
 extern crate collections;

--- a/src/lib/protobuf.rs
+++ b/src/lib/protobuf.rs
@@ -1,5 +1,6 @@
 #![crate_type = "lib"]
-#![allow(non_camel_case_types)]
+#![allow(non_camel_case_types, unstable)]
+#![feature(box_syntax)]
 
 extern crate collections;
 

--- a/src/lib/reflect/accessor.rs
+++ b/src/lib/reflect/accessor.rs
@@ -8,11 +8,11 @@ use reflect::EnumValueDescriptor;
 pub trait FieldAccessor {
     fn name_generic(&self) -> &'static str;
     fn has_field_generic(&self, m: &Message) -> bool;
-    fn len_field_generic(&self, m: &Message) -> uint;
+    fn len_field_generic(&self, m: &Message) -> usize;
     fn get_message_generic<'a>(&self, m: &'a Message) -> &'a Message;
-    fn get_rep_message_item_generic<'a>(&self, m: &'a Message, index: uint) -> &'a Message;
+    fn get_rep_message_item_generic<'a>(&self, m: &'a Message, index: usize) -> &'a Message;
     fn get_enum_generic(&self, m: &Message) -> &'static EnumValueDescriptor;
-    fn get_rep_enum_item_generic(&self, m: &Message, index: uint) -> &'static EnumValueDescriptor;
+    fn get_rep_enum_item_generic(&self, m: &Message, index: usize) -> &'static EnumValueDescriptor;
     fn get_str_generic<'a>(&self, m: &'a Message) -> &'a str;
     fn get_rep_str_generic<'a>(&self, m: &'a Message) -> &'a [String];
     fn get_bytes_generic<'a>(&self, m: &'a Message) -> &'a [u8];
@@ -65,8 +65,8 @@ impl<M : Message, E : ProtobufEnum> GetSingularEnum<M> for GetSingularEnumImpl<M
 
 
 trait GetRepeatedMessage<M> {
-    fn len_field(&self, m: &M) -> uint;
-    fn get_message_item<'a>(&self, m: &'a M, index: uint) -> &'a Message;
+    fn len_field(&self, m: &M) -> usize;
+    fn get_message_item<'a>(&self, m: &'a M, index: usize) -> &'a Message;
 }
 
 struct GetRepeatedMessageImpl<M, N> {
@@ -74,19 +74,19 @@ struct GetRepeatedMessageImpl<M, N> {
 }
 
 impl<M : Message, N : Message> GetRepeatedMessage<M> for GetRepeatedMessageImpl<M, N> {
-    fn len_field(&self, m: &M) -> uint {
+    fn len_field(&self, m: &M) -> usize {
         (self.get)(m).len()
     }
 
-    fn get_message_item<'a>(&self, m: &'a M, index: uint) -> &'a Message {
+    fn get_message_item<'a>(&self, m: &'a M, index: usize) -> &'a Message {
         &(self.get)(m)[index] as &Message
     }
 }
 
 
 trait GetRepeatedEnum<M> {
-    fn len_field(&self, m: &M) -> uint;
-    fn get_enum_item(&self, m: &M, index: uint) -> &'static EnumValueDescriptor;
+    fn len_field(&self, m: &M) -> usize;
+    fn get_enum_item(&self, m: &M, index: usize) -> &'static EnumValueDescriptor;
 }
 
 struct GetRepeatedEnumImpl<M, E> {
@@ -94,11 +94,11 @@ struct GetRepeatedEnumImpl<M, E> {
 }
 
 impl<M : Message, E : ProtobufEnum> GetRepeatedEnum<M> for GetRepeatedEnumImpl<M, E> {
-    fn len_field(&self, m: &M) -> uint {
+    fn len_field(&self, m: &M) -> usize {
         (self.get)(m).len()
     }
 
-    fn get_enum_item(&self, m: &M, index: uint) -> &'static EnumValueDescriptor {
+    fn get_enum_item(&self, m: &M, index: usize) -> &'static EnumValueDescriptor {
         (self.get)(m)[index].descriptor()
     }
 }
@@ -133,7 +133,7 @@ enum RepeatedGet<M> {
 }
 
 impl<M : Message> RepeatedGet<M> {
-    fn len_field(&self, m: &M) -> uint {
+    fn len_field(&self, m: &M) -> usize {
         match *self {
             RepeatedGet::U32(get) => get(m).len(),
             RepeatedGet::U64(get) => get(m).len(),
@@ -172,7 +172,7 @@ impl<M : Message + 'static> FieldAccessor for FieldAccessorImpl<M> {
         }
     }
 
-    fn len_field_generic(&self, m: &Message) -> uint {
+    fn len_field_generic(&self, m: &Message) -> usize {
         match self.fns {
             FieldAccessorFunctions::Repeated(ref r) => r.len_field(message_down_cast(m)),
             _ => panic!(),
@@ -267,7 +267,7 @@ impl<M : Message + 'static> FieldAccessor for FieldAccessorImpl<M> {
         }
     }
 
-    fn get_rep_message_item_generic<'a>(&self, m: &'a Message, index: uint) -> &'a Message {
+    fn get_rep_message_item_generic<'a>(&self, m: &'a Message, index: usize) -> &'a Message {
         match self.fns {
             FieldAccessorFunctions::Repeated(RepeatedGet::Message(ref get)) =>
                 get.get_message_item(message_down_cast(m), index),
@@ -275,7 +275,7 @@ impl<M : Message + 'static> FieldAccessor for FieldAccessorImpl<M> {
         }
     }
 
-    fn get_rep_enum_item_generic(&self, m: &Message, index: uint) -> &'static EnumValueDescriptor {
+    fn get_rep_enum_item_generic(&self, m: &Message, index: usize) -> &'static EnumValueDescriptor {
         match self.fns {
             FieldAccessorFunctions::Repeated(RepeatedGet::Enum(ref get)) =>
                 get.get_enum_item(message_down_cast(m), index),

--- a/src/lib/reflect/mod.rs
+++ b/src/lib/reflect/mod.rs
@@ -50,7 +50,7 @@ impl FieldDescriptor {
         self.accessor.has_field_generic(m)
     }
 
-    pub fn len_field(&self, m: &Message) -> uint {
+    pub fn len_field(&self, m: &Message) -> usize {
         self.accessor.len_field_generic(m)
     }
 
@@ -58,7 +58,7 @@ impl FieldDescriptor {
         self.accessor.get_message_generic(m)
     }
 
-    pub fn get_rep_message_item<'a>(&self, m: &'a Message, index: uint) -> &'a Message {
+    pub fn get_rep_message_item<'a>(&self, m: &'a Message, index: usize) -> &'a Message {
         self.accessor.get_rep_message_item_generic(m, index)
     }
 
@@ -66,7 +66,7 @@ impl FieldDescriptor {
         self.accessor.get_enum_generic(m)
     }
 
-    pub fn get_rep_enum_item(&self, m: &Message, index: uint) -> &'static EnumValueDescriptor {
+    pub fn get_rep_enum_item(&self, m: &Message, index: usize) -> &'static EnumValueDescriptor {
         self.accessor.get_rep_enum_item_generic(m, index)
     }
 
@@ -78,7 +78,7 @@ impl FieldDescriptor {
         self.accessor.get_rep_str_generic(m)
     }
 
-    pub fn get_rep_str_item<'a>(&self, m: &'a Message, index: uint) -> &'a str {
+    pub fn get_rep_str_item<'a>(&self, m: &'a Message, index: usize) -> &'a str {
         self.get_rep_str(m)[index].as_slice()
     }
 
@@ -90,7 +90,7 @@ impl FieldDescriptor {
         self.accessor.get_rep_bytes_generic(m)
     }
 
-    pub fn get_rep_bytes_item<'a>(&self, m: &'a Message, index: uint) -> &'a [u8] {
+    pub fn get_rep_bytes_item<'a>(&self, m: &'a Message, index: usize) -> &'a [u8] {
         self.get_rep_bytes(m)[index].as_slice()
     }
 
@@ -180,8 +180,8 @@ pub struct MessageDescriptor {
     factory: Box<MessageFactory + 'static>,
     fields: Vec<FieldDescriptor>,
 
-    index_by_name: HashMap<String, uint>,
-    index_by_number: HashMap<u32, uint>,
+    index_by_name: HashMap<String, usize>,
+    index_by_number: HashMap<u32, usize>,
 }
 
 impl MessageDescriptor {
@@ -267,8 +267,8 @@ pub struct EnumDescriptor {
     proto: &'static EnumDescriptorProto,
     values: Vec<EnumValueDescriptor>,
 
-    index_by_name: HashMap<String, uint>,
-    index_by_number: HashMap<i32, uint>,
+    index_by_name: HashMap<String, usize>,
+    index_by_number: HashMap<i32, usize>,
 }
 
 impl EnumDescriptor {

--- a/src/lib/repeated.rs
+++ b/src/lib/repeated.rs
@@ -11,12 +11,12 @@ use clear::Clear;
 
 pub struct RepeatedField<T> {
     vec: Vec<T>,
-    len: uint,
+    len: usize,
 }
 
 impl<T> RepeatedField<T> {
     #[inline]
-    fn len(&self) -> uint {
+    fn len(&self) -> usize {
         self.len
     }
 
@@ -66,7 +66,7 @@ impl<T> RepeatedField<T> {
     }
 
     #[inline]
-    pub fn capacity(&self) -> uint {
+    pub fn capacity(&self) -> usize {
         self.vec.capacity()
     }
 
@@ -76,42 +76,42 @@ impl<T> RepeatedField<T> {
     }
 
     #[inline]
-    pub fn slice<'a>(&'a self, start: uint, end: uint) -> &'a [T] {
+    pub fn slice<'a>(&'a self, start: usize, end: usize) -> &'a [T] {
         self.as_slice().slice(start, end)
     }
 
     #[inline]
-    pub fn slice_mut<'a>(&'a mut self, start: uint, end: uint) -> &'a mut [T] {
+    pub fn slice_mut<'a>(&'a mut self, start: usize, end: usize) -> &'a mut [T] {
         self.as_mut_slice().slice_mut(start, end)
     }
 
     #[inline]
-    pub fn slice_from<'a>(&'a self, start: uint) -> &'a [T] {
+    pub fn slice_from<'a>(&'a self, start: usize) -> &'a [T] {
         self.as_slice().slice_from(start)
     }
 
     #[inline]
-    pub fn slice_from_mut<'a>(&'a mut self, start: uint) -> &'a mut [T] {
+    pub fn slice_from_mut<'a>(&'a mut self, start: usize) -> &'a mut [T] {
         self.as_mut_slice().slice_from_mut(start)
     }
 
     #[inline]
-    pub fn slice_to<'a>(&'a self, end: uint) -> &'a [T] {
+    pub fn slice_to<'a>(&'a self, end: usize) -> &'a [T] {
         self.as_slice().slice_to(end)
     }
 
     #[inline]
-    pub fn slice_to_mut<'a>(&'a mut self, end: uint) -> &'a mut [T] {
+    pub fn slice_to_mut<'a>(&'a mut self, end: usize) -> &'a mut [T] {
         self.as_mut_slice().slice_to_mut(end)
     }
 
     #[inline]
-    pub fn split_at<'a>(&'a self, mid: uint) -> (&'a [T], &'a [T]) {
+    pub fn split_at<'a>(&'a self, mid: usize) -> (&'a [T], &'a [T]) {
         self.as_slice().split_at(mid)
     }
 
     #[inline]
-    pub fn split_at_mut<'a>(&'a mut self, mid: uint) -> (&'a mut [T], &'a mut [T]) {
+    pub fn split_at_mut<'a>(&'a mut self, mid: usize) -> (&'a mut [T], &'a mut [T]) {
         self.as_mut_slice().split_at_mut(mid)
     }
 
@@ -157,21 +157,21 @@ impl<T> RepeatedField<T> {
     }
 
     #[inline]
-    pub fn insert(&mut self, index: uint, value: T) {
+    pub fn insert(&mut self, index: usize, value: T) {
         assert!(index <= self.len);
         self.vec.insert(index, value);
         self.len += 1;
     }
 
     #[inline]
-    pub fn remove(&mut self, index: uint) -> T {
+    pub fn remove(&mut self, index: usize) -> T {
         assert!(index < self.len);
         self.len -= 1;
         self.vec.remove(index)
     }
 
     #[inline]
-    pub fn truncate(&mut self, len: uint) {
+    pub fn truncate(&mut self, len: usize) {
         if self.len > len {
             self.len = len;
         }
@@ -190,13 +190,13 @@ impl<T> RepeatedField<T> {
 
     #[deprecated = "use `foo[index]` instead"]
     #[inline]
-    pub fn get<'a>(&'a self, index: uint) -> &'a T {
+    pub fn get<'a>(&'a self, index: usize) -> &'a T {
         &self.as_slice()[index]
     }
 
     #[deprecated = "use `foo[index] = bar` instead"]
     #[inline]
-    pub fn get_mut<'a>(&'a mut self, index: uint) -> &'a mut T {
+    pub fn get_mut<'a>(&'a mut self, index: usize) -> &'a mut T {
         &mut self.as_mut_slice()[index]
     }
 
@@ -286,20 +286,20 @@ impl<T> AsSlice<T> for RepeatedField<T> {
     }
 }
 
-impl<T> Index<uint> for RepeatedField<T> {
+impl<T> Index<usize> for RepeatedField<T> {
     type Output = T;
 
     #[inline]
-    fn index<'a>(&'a self, index: &uint) -> &'a T {
+    fn index<'a>(&'a self, index: &usize) -> &'a T {
         &self.as_slice()[*index]
     }
 }
 
-impl<T> IndexMut<uint> for RepeatedField<T> {
+impl<T> IndexMut<usize> for RepeatedField<T> {
     type Output = T;
 
     #[inline]
-    fn index_mut<'a>(&'a mut self, index: &uint) -> &'a mut T {
+    fn index_mut<'a>(&'a mut self, index: &usize) -> &'a mut T {
         &mut self.as_mut_slice()[*index]
     }
 }

--- a/src/lib/singular.rs
+++ b/src/lib/singular.rs
@@ -405,7 +405,7 @@ impl<T : fmt::Show> fmt::Show for SingularField<T> {
     #[inline]
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         if self.is_some() {
-            write!(f, "Some({})", *self.as_ref().unwrap())
+            write!(f, "Some({:?})", *self.as_ref().unwrap())
         } else {
             write!(f, "None")
         }
@@ -416,7 +416,7 @@ impl<T : fmt::Show> fmt::Show for SingularPtrField<T> {
     #[inline]
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         if self.is_some() {
-            write!(f, "Some({})", *self.as_ref().unwrap())
+            write!(f, "Some({:?})", *self.as_ref().unwrap())
         } else {
             write!(f, "None")
         }
@@ -451,7 +451,7 @@ mod test {
     fn test_set_default_clears() {
         #[derive(Default)]
         struct Foo {
-            b: int,
+            b: isize,
         }
 
         impl Clear for Foo {

--- a/src/lib/unknown.rs
+++ b/src/lib/unknown.rs
@@ -126,7 +126,7 @@ impl UnknownFields {
     fn find_field<'a>(&'a mut self, number: &'a u32) -> &'a mut UnknownValues {
         self.init_map();
 
-        match self.fields.as_mut().unwrap().entry(number) {
+        match self.fields.as_mut().unwrap().entry(*number) {
             hash_map::Entry::Occupied(e) => e.into_mut(),
             hash_map::Entry::Vacant(e) => e.insert(Default::default()),
         }

--- a/src/protoc-gen-rust.rs
+++ b/src/protoc-gen-rust.rs
@@ -1,5 +1,4 @@
 #![crate_type = "bin"]
-#![feature(globs)]
 #![allow(non_camel_case_types)]
 
 extern crate protobuf;


### PR DESCRIPTION
Fixed compilation on latest Rust.

Few considerations that may be taken, instead of using `fmt::Show` and `{:?}` use `fmt::String`, I didn't make that change because maybe you prefer to keep `fmt::Show`, in any case it's now much easier to find what should be moved to `fmt::String` since you can look for `{:?}` in the code.

Another is I disabled warns about `unstable` APIs, because it was literally a wall of text caused by the alpha status.