### PR TITLE
Fix compilation

### DIFF
--- a/src/lib/codegen.rs
+++ b/src/lib/codegen.rs
@@ -36,7 +36,7 @@ enum RustType {
     Enum(String),
 }
 
-impl fmt::Show for RustType {
+impl fmt::Debug for RustType {
     #[inline]
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         match *self {
@@ -1273,7 +1273,7 @@ fn write_message_struct(w: &mut IndentWriter) {
     let msg = w.msg.unwrap();
     let mut derive = vec!["Clone", "Default"];
     if msg.lite_runtime {
-        derive.push("Show");
+        derive.push("Debug");
     }
     w.derive(derive.as_slice());
     w.pub_struct(msg.type_name.as_slice(), |w| {
@@ -1653,8 +1653,8 @@ fn write_message_impl_message(w: &mut IndentWriter) {
         w.write_line("");
         write_message_unknown_fields(w);
         w.write_line("");
-        w.def_fn("type_id(&self) -> ::std::intrinsics::TypeId", |w| {
-            w.write_line(format!("::std::intrinsics::TypeId::of::<{}>()", msg.type_name));
+        w.def_fn("type_id(&self) -> ::std::any::TypeId", |w| {
+            w.write_line(format!("::std::any::TypeId::of::<{}>()", msg.type_name));
         });
         w.write_line("");
         w.def_fn("descriptor(&self) -> &'static ::protobuf::reflect::MessageDescriptor", |w| {
@@ -1678,7 +1678,7 @@ fn write_message_impl_message_static(w: &mut IndentWriter) {
 
 fn write_message_impl_show(w: &mut IndentWriter) {
     let msg = w.msg.unwrap();
-    w.impl_for_block("::std::fmt::Show", msg.type_name.as_slice(), |w| {
+    w.impl_for_block("::std::fmt::Debug", msg.type_name.as_slice(), |w| {
         w.def_fn("fmt(&self, f: &mut ::std::fmt::Formatter) -> ::std::fmt::Result", |w| {
             w.write_line("::protobuf::text_format::fmt(self, f)");
         });
@@ -1745,7 +1745,7 @@ fn write_message(m2: &MessageWithScope, root_scope: &RootScope, w: &mut IndentWr
 }
 
 fn write_enum_struct(w: &mut IndentWriter) {
-    w.derive(&["Clone", "PartialEq", "Eq", "Show"]);
+    w.derive(&["Clone", "PartialEq", "Eq", "Debug"]);
     w.expr_block(format!("pub enum {}", w.en().type_name), |w| {
         for value in w.en().values.iter() {
             w.write_line(format!("{} = {},", value.rust_name_inner(), value.number()));

--- a/src/lib/core.rs
+++ b/src/lib/core.rs
@@ -4,7 +4,7 @@ use std::mem;
 use std::raw;
 use std::fmt;
 use std::default::Default;
-use std::intrinsics::TypeId;
+use std::any::TypeId;
 
 use clear::Clear;
 use reflect::MessageDescriptor;
@@ -35,7 +35,7 @@ pub trait MessageStatic : Message + Clone + Default {
 }
 
 
-pub trait Message : PartialEq + fmt::Show + Clear {
+pub trait Message : PartialEq + fmt::Debug + Clear {
     // All generated Message types also implement MessageStatic.
     // However, rust doesn't allow these types to be extended by
     // Message.
@@ -127,7 +127,7 @@ pub trait Message : PartialEq + fmt::Show + Clear {
     }
 
     // Rust does not allow implementation of trait for trait:
-    // impl<M : Message> fmt::Show for M {
+    // impl<M : Message> fmt::Debug for M {
     // ...
     // }
 }

--- a/src/lib/descriptor.rs
+++ b/src/lib/descriptor.rs
@@ -117,8 +117,8 @@ impl ::protobuf::Message for FileDescriptorSet {
         &mut self.unknown_fields
     }
 
-    fn type_id(&self) -> ::std::intrinsics::TypeId {
-        ::std::intrinsics::TypeId::of::<FileDescriptorSet>()
+    fn type_id(&self) -> ::std::any::TypeId {
+        ::std::any::TypeId::of::<FileDescriptorSet>()
     }
 
     fn descriptor(&self) -> &'static ::protobuf::reflect::MessageDescriptor {
@@ -168,7 +168,7 @@ impl ::std::cmp::PartialEq for FileDescriptorSet {
     }
 }
 
-impl ::std::fmt::Show for FileDescriptorSet {
+impl ::std::fmt::Debug for FileDescriptorSet {
     fn fmt(&self, f: &mut ::std::fmt::Formatter) -> ::std::fmt::Result {
         ::protobuf::text_format::fmt(self, f)
     }
@@ -712,8 +712,8 @@ impl ::protobuf::Message for FileDescriptorProto {
         &mut self.unknown_fields
     }
 
-    fn type_id(&self) -> ::std::intrinsics::TypeId {
-        ::std::intrinsics::TypeId::of::<FileDescriptorProto>()
+    fn type_id(&self) -> ::std::any::TypeId {
+        ::std::any::TypeId::of::<FileDescriptorProto>()
     }
 
     fn descriptor(&self) -> &'static ::protobuf::reflect::MessageDescriptor {
@@ -827,7 +827,7 @@ impl ::std::cmp::PartialEq for FileDescriptorProto {
     }
 }
 
-impl ::std::fmt::Show for FileDescriptorProto {
+impl ::std::fmt::Debug for FileDescriptorProto {
     fn fmt(&self, f: &mut ::std::fmt::Formatter) -> ::std::fmt::Result {
         ::protobuf::text_format::fmt(self, f)
     }
@@ -1200,8 +1200,8 @@ impl ::protobuf::Message for DescriptorProto {
         &mut self.unknown_fields
     }
 
-    fn type_id(&self) -> ::std::intrinsics::TypeId {
-        ::std::intrinsics::TypeId::of::<DescriptorProto>()
+    fn type_id(&self) -> ::std::any::TypeId {
+        ::std::any::TypeId::of::<DescriptorProto>()
     }
 
     fn descriptor(&self) -> &'static ::protobuf::reflect::MessageDescriptor {
@@ -1289,7 +1289,7 @@ impl ::std::cmp::PartialEq for DescriptorProto {
     }
 }
 
-impl ::std::fmt::Show for DescriptorProto {
+impl ::std::fmt::Debug for DescriptorProto {
     fn fmt(&self, f: &mut ::std::fmt::Formatter) -> ::std::fmt::Result {
         ::protobuf::text_format::fmt(self, f)
     }
@@ -1433,8 +1433,8 @@ impl ::protobuf::Message for DescriptorProto_ExtensionRange {
         &mut self.unknown_fields
     }
 
-    fn type_id(&self) -> ::std::intrinsics::TypeId {
-        ::std::intrinsics::TypeId::of::<DescriptorProto_ExtensionRange>()
+    fn type_id(&self) -> ::std::any::TypeId {
+        ::std::any::TypeId::of::<DescriptorProto_ExtensionRange>()
     }
 
     fn descriptor(&self) -> &'static ::protobuf::reflect::MessageDescriptor {
@@ -1492,7 +1492,7 @@ impl ::std::cmp::PartialEq for DescriptorProto_ExtensionRange {
     }
 }
 
-impl ::std::fmt::Show for DescriptorProto_ExtensionRange {
+impl ::std::fmt::Debug for DescriptorProto_ExtensionRange {
     fn fmt(&self, f: &mut ::std::fmt::Formatter) -> ::std::fmt::Result {
         ::protobuf::text_format::fmt(self, f)
     }
@@ -1925,8 +1925,8 @@ impl ::protobuf::Message for FieldDescriptorProto {
         &mut self.unknown_fields
     }
 
-    fn type_id(&self) -> ::std::intrinsics::TypeId {
-        ::std::intrinsics::TypeId::of::<FieldDescriptorProto>()
+    fn type_id(&self) -> ::std::any::TypeId {
+        ::std::any::TypeId::of::<FieldDescriptorProto>()
     }
 
     fn descriptor(&self) -> &'static ::protobuf::reflect::MessageDescriptor {
@@ -2026,13 +2026,13 @@ impl ::std::cmp::PartialEq for FieldDescriptorProto {
     }
 }
 
-impl ::std::fmt::Show for FieldDescriptorProto {
+impl ::std::fmt::Debug for FieldDescriptorProto {
     fn fmt(&self, f: &mut ::std::fmt::Formatter) -> ::std::fmt::Result {
         ::protobuf::text_format::fmt(self, f)
     }
 }
 
-#[derive(Clone,PartialEq,Eq,Show)]
+#[derive(Clone,PartialEq,Eq,Debug)]
 pub enum FieldDescriptorProto_Type {
     TYPE_DOUBLE = 1,
     TYPE_FLOAT = 2,
@@ -2099,7 +2099,7 @@ impl ::protobuf::ProtobufEnum for FieldDescriptorProto_Type {
 impl ::std::marker::Copy for FieldDescriptorProto_Type {
 }
 
-#[derive(Clone,PartialEq,Eq,Show)]
+#[derive(Clone,PartialEq,Eq,Debug)]
 pub enum FieldDescriptorProto_Label {
     LABEL_OPTIONAL = 1,
     LABEL_REQUIRED = 2,
@@ -2347,8 +2347,8 @@ impl ::protobuf::Message for EnumDescriptorProto {
         &mut self.unknown_fields
     }
 
-    fn type_id(&self) -> ::std::intrinsics::TypeId {
-        ::std::intrinsics::TypeId::of::<EnumDescriptorProto>()
+    fn type_id(&self) -> ::std::any::TypeId {
+        ::std::any::TypeId::of::<EnumDescriptorProto>()
     }
 
     fn descriptor(&self) -> &'static ::protobuf::reflect::MessageDescriptor {
@@ -2412,7 +2412,7 @@ impl ::std::cmp::PartialEq for EnumDescriptorProto {
     }
 }
 
-impl ::std::fmt::Show for EnumDescriptorProto {
+impl ::std::fmt::Debug for EnumDescriptorProto {
     fn fmt(&self, f: &mut ::std::fmt::Formatter) -> ::std::fmt::Result {
         ::protobuf::text_format::fmt(self, f)
     }
@@ -2624,8 +2624,8 @@ impl ::protobuf::Message for EnumValueDescriptorProto {
         &mut self.unknown_fields
     }
 
-    fn type_id(&self) -> ::std::intrinsics::TypeId {
-        ::std::intrinsics::TypeId::of::<EnumValueDescriptorProto>()
+    fn type_id(&self) -> ::std::any::TypeId {
+        ::std::any::TypeId::of::<EnumValueDescriptorProto>()
     }
 
     fn descriptor(&self) -> &'static ::protobuf::reflect::MessageDescriptor {
@@ -2690,7 +2690,7 @@ impl ::std::cmp::PartialEq for EnumValueDescriptorProto {
     }
 }
 
-impl ::std::fmt::Show for EnumValueDescriptorProto {
+impl ::std::fmt::Debug for EnumValueDescriptorProto {
     fn fmt(&self, f: &mut ::std::fmt::Formatter) -> ::std::fmt::Result {
         ::protobuf::text_format::fmt(self, f)
     }
@@ -2907,8 +2907,8 @@ impl ::protobuf::Message for ServiceDescriptorProto {
         &mut self.unknown_fields
     }
 
-    fn type_id(&self) -> ::std::intrinsics::TypeId {
-        ::std::intrinsics::TypeId::of::<ServiceDescriptorProto>()
+    fn type_id(&self) -> ::std::any::TypeId {
+        ::std::any::TypeId::of::<ServiceDescriptorProto>()
     }
 
     fn descriptor(&self) -> &'static ::protobuf::reflect::MessageDescriptor {
@@ -2972,7 +2972,7 @@ impl ::std::cmp::PartialEq for ServiceDescriptorProto {
     }
 }
 
-impl ::std::fmt::Show for ServiceDescriptorProto {
+impl ::std::fmt::Debug for ServiceDescriptorProto {
     fn fmt(&self, f: &mut ::std::fmt::Formatter) -> ::std::fmt::Result {
         ::protobuf::text_format::fmt(self, f)
     }
@@ -3252,8 +3252,8 @@ impl ::protobuf::Message for MethodDescriptorProto {
         &mut self.unknown_fields
     }
 
-    fn type_id(&self) -> ::std::intrinsics::TypeId {
-        ::std::intrinsics::TypeId::of::<MethodDescriptorProto>()
+    fn type_id(&self) -> ::std::any::TypeId {
+        ::std::any::TypeId::of::<MethodDescriptorProto>()
     }
 
     fn descriptor(&self) -> &'static ::protobuf::reflect::MessageDescriptor {
@@ -3325,7 +3325,7 @@ impl ::std::cmp::PartialEq for MethodDescriptorProto {
     }
 }
 
-impl ::std::fmt::Show for MethodDescriptorProto {
+impl ::std::fmt::Debug for MethodDescriptorProto {
     fn fmt(&self, f: &mut ::std::fmt::Formatter) -> ::std::fmt::Result {
         ::protobuf::text_format::fmt(self, f)
     }
@@ -3797,8 +3797,8 @@ impl ::protobuf::Message for FileOptions {
         &mut self.unknown_fields
     }
 
-    fn type_id(&self) -> ::std::intrinsics::TypeId {
-        ::std::intrinsics::TypeId::of::<FileOptions>()
+    fn type_id(&self) -> ::std::any::TypeId {
+        ::std::any::TypeId::of::<FileOptions>()
     }
 
     fn descriptor(&self) -> &'static ::protobuf::reflect::MessageDescriptor {
@@ -3911,13 +3911,13 @@ impl ::std::cmp::PartialEq for FileOptions {
     }
 }
 
-impl ::std::fmt::Show for FileOptions {
+impl ::std::fmt::Debug for FileOptions {
     fn fmt(&self, f: &mut ::std::fmt::Formatter) -> ::std::fmt::Result {
         ::protobuf::text_format::fmt(self, f)
     }
 }
 
-#[derive(Clone,PartialEq,Eq,Show)]
+#[derive(Clone,PartialEq,Eq,Debug)]
 pub enum FileOptions_OptimizeMode {
     SPEED = 1,
     CODE_SIZE = 2,
@@ -4131,8 +4131,8 @@ impl ::protobuf::Message for MessageOptions {
         &mut self.unknown_fields
     }
 
-    fn type_id(&self) -> ::std::intrinsics::TypeId {
-        ::std::intrinsics::TypeId::of::<MessageOptions>()
+    fn type_id(&self) -> ::std::any::TypeId {
+        ::std::any::TypeId::of::<MessageOptions>()
     }
 
     fn descriptor(&self) -> &'static ::protobuf::reflect::MessageDescriptor {
@@ -4196,7 +4196,7 @@ impl ::std::cmp::PartialEq for MessageOptions {
     }
 }
 
-impl ::std::fmt::Show for MessageOptions {
+impl ::std::fmt::Debug for MessageOptions {
     fn fmt(&self, f: &mut ::std::fmt::Formatter) -> ::std::fmt::Result {
         ::protobuf::text_format::fmt(self, f)
     }
@@ -4532,8 +4532,8 @@ impl ::protobuf::Message for FieldOptions {
         &mut self.unknown_fields
     }
 
-    fn type_id(&self) -> ::std::intrinsics::TypeId {
-        ::std::intrinsics::TypeId::of::<FieldOptions>()
+    fn type_id(&self) -> ::std::any::TypeId {
+        ::std::any::TypeId::of::<FieldOptions>()
     }
 
     fn descriptor(&self) -> &'static ::protobuf::reflect::MessageDescriptor {
@@ -4625,13 +4625,13 @@ impl ::std::cmp::PartialEq for FieldOptions {
     }
 }
 
-impl ::std::fmt::Show for FieldOptions {
+impl ::std::fmt::Debug for FieldOptions {
     fn fmt(&self, f: &mut ::std::fmt::Formatter) -> ::std::fmt::Result {
         ::protobuf::text_format::fmt(self, f)
     }
 }
 
-#[derive(Clone,PartialEq,Eq,Show)]
+#[derive(Clone,PartialEq,Eq,Debug)]
 pub enum FieldOptions_CType {
     STRING = 0,
     CORD = 1,
@@ -4811,8 +4811,8 @@ impl ::protobuf::Message for EnumOptions {
         &mut self.unknown_fields
     }
 
-    fn type_id(&self) -> ::std::intrinsics::TypeId {
-        ::std::intrinsics::TypeId::of::<EnumOptions>()
+    fn type_id(&self) -> ::std::any::TypeId {
+        ::std::any::TypeId::of::<EnumOptions>()
     }
 
     fn descriptor(&self) -> &'static ::protobuf::reflect::MessageDescriptor {
@@ -4869,7 +4869,7 @@ impl ::std::cmp::PartialEq for EnumOptions {
     }
 }
 
-impl ::std::fmt::Show for EnumOptions {
+impl ::std::fmt::Debug for EnumOptions {
     fn fmt(&self, f: &mut ::std::fmt::Formatter) -> ::std::fmt::Result {
         ::protobuf::text_format::fmt(self, f)
     }
@@ -4984,8 +4984,8 @@ impl ::protobuf::Message for EnumValueOptions {
         &mut self.unknown_fields
     }
 
-    fn type_id(&self) -> ::std::intrinsics::TypeId {
-        ::std::intrinsics::TypeId::of::<EnumValueOptions>()
+    fn type_id(&self) -> ::std::any::TypeId {
+        ::std::any::TypeId::of::<EnumValueOptions>()
     }
 
     fn descriptor(&self) -> &'static ::protobuf::reflect::MessageDescriptor {
@@ -5035,7 +5035,7 @@ impl ::std::cmp::PartialEq for EnumValueOptions {
     }
 }
 
-impl ::std::fmt::Show for EnumValueOptions {
+impl ::std::fmt::Debug for EnumValueOptions {
     fn fmt(&self, f: &mut ::std::fmt::Formatter) -> ::std::fmt::Result {
         ::protobuf::text_format::fmt(self, f)
     }
@@ -5150,8 +5150,8 @@ impl ::protobuf::Message for ServiceOptions {
         &mut self.unknown_fields
     }
 
-    fn type_id(&self) -> ::std::intrinsics::TypeId {
-        ::std::intrinsics::TypeId::of::<ServiceOptions>()
+    fn type_id(&self) -> ::std::any::TypeId {
+        ::std::any::TypeId::of::<ServiceOptions>()
     }
 
     fn descriptor(&self) -> &'static ::protobuf::reflect::MessageDescriptor {
@@ -5201,7 +5201,7 @@ impl ::std::cmp::PartialEq for ServiceOptions {
     }
 }
 
-impl ::std::fmt::Show for ServiceOptions {
+impl ::std::fmt::Debug for ServiceOptions {
     fn fmt(&self, f: &mut ::std::fmt::Formatter) -> ::std::fmt::Result {
         ::protobuf::text_format::fmt(self, f)
     }
@@ -5316,8 +5316,8 @@ impl ::protobuf::Message for MethodOptions {
         &mut self.unknown_fields
     }
 
-    fn type_id(&self) -> ::std::intrinsics::TypeId {
-        ::std::intrinsics::TypeId::of::<MethodOptions>()
+    fn type_id(&self) -> ::std::any::TypeId {
+        ::std::any::TypeId::of::<MethodOptions>()
     }
 
     fn descriptor(&self) -> &'static ::protobuf::reflect::MessageDescriptor {
@@ -5367,7 +5367,7 @@ impl ::std::cmp::PartialEq for MethodOptions {
     }
 }
 
-impl ::std::fmt::Show for MethodOptions {
+impl ::std::fmt::Debug for MethodOptions {
     fn fmt(&self, f: &mut ::std::fmt::Formatter) -> ::std::fmt::Result {
         ::protobuf::text_format::fmt(self, f)
     }
@@ -5737,8 +5737,8 @@ impl ::protobuf::Message for UninterpretedOption {
         &mut self.unknown_fields
     }
 
-    fn type_id(&self) -> ::std::intrinsics::TypeId {
-        ::std::intrinsics::TypeId::of::<UninterpretedOption>()
+    fn type_id(&self) -> ::std::any::TypeId {
+        ::std::any::TypeId::of::<UninterpretedOption>()
     }
 
     fn descriptor(&self) -> &'static ::protobuf::reflect::MessageDescriptor {
@@ -5830,7 +5830,7 @@ impl ::std::cmp::PartialEq for UninterpretedOption {
     }
 }
 
-impl ::std::fmt::Show for UninterpretedOption {
+impl ::std::fmt::Debug for UninterpretedOption {
     fn fmt(&self, f: &mut ::std::fmt::Formatter) -> ::std::fmt::Result {
         ::protobuf::text_format::fmt(self, f)
     }
@@ -5997,8 +5997,8 @@ impl ::protobuf::Message for UninterpretedOption_NamePart {
         &mut self.unknown_fields
     }
 
-    fn type_id(&self) -> ::std::intrinsics::TypeId {
-        ::std::intrinsics::TypeId::of::<UninterpretedOption_NamePart>()
+    fn type_id(&self) -> ::std::any::TypeId {
+        ::std::any::TypeId::of::<UninterpretedOption_NamePart>()
     }
 
     fn descriptor(&self) -> &'static ::protobuf::reflect::MessageDescriptor {
@@ -6056,7 +6056,7 @@ impl ::std::cmp::PartialEq for UninterpretedOption_NamePart {
     }
 }
 
-impl ::std::fmt::Show for UninterpretedOption_NamePart {
+impl ::std::fmt::Debug for UninterpretedOption_NamePart {
     fn fmt(&self, f: &mut ::std::fmt::Formatter) -> ::std::fmt::Result {
         ::protobuf::text_format::fmt(self, f)
     }
@@ -6171,8 +6171,8 @@ impl ::protobuf::Message for SourceCodeInfo {
         &mut self.unknown_fields
     }
 
-    fn type_id(&self) -> ::std::intrinsics::TypeId {
-        ::std::intrinsics::TypeId::of::<SourceCodeInfo>()
+    fn type_id(&self) -> ::std::any::TypeId {
+        ::std::any::TypeId::of::<SourceCodeInfo>()
     }
 
     fn descriptor(&self) -> &'static ::protobuf::reflect::MessageDescriptor {
@@ -6222,7 +6222,7 @@ impl ::std::cmp::PartialEq for SourceCodeInfo {
     }
 }
 
-impl ::std::fmt::Show for SourceCodeInfo {
+impl ::std::fmt::Debug for SourceCodeInfo {
     fn fmt(&self, f: &mut ::std::fmt::Formatter) -> ::std::fmt::Result {
         ::protobuf::text_format::fmt(self, f)
     }
@@ -6482,8 +6482,8 @@ impl ::protobuf::Message for SourceCodeInfo_Location {
         &mut self.unknown_fields
     }
 
-    fn type_id(&self) -> ::std::intrinsics::TypeId {
-        ::std::intrinsics::TypeId::of::<SourceCodeInfo_Location>()
+    fn type_id(&self) -> ::std::any::TypeId {
+        ::std::any::TypeId::of::<SourceCodeInfo_Location>()
     }
 
     fn descriptor(&self) -> &'static ::protobuf::reflect::MessageDescriptor {
@@ -6553,7 +6553,7 @@ impl ::std::cmp::PartialEq for SourceCodeInfo_Location {
     }
 }
 
-impl ::std::fmt::Show for SourceCodeInfo_Location {
+impl ::std::fmt::Debug for SourceCodeInfo_Location {
     fn fmt(&self, f: &mut ::std::fmt::Formatter) -> ::std::fmt::Result {
         ::protobuf::text_format::fmt(self, f)
     }

--- a/src/lib/error.rs
+++ b/src/lib/error.rs
@@ -1,12 +1,19 @@
 use std::io::IoError;
 use std::error::Error;
+use std::fmt;
 
 pub type ProtobufResult<T> = Result<T, ProtobufError>;
 
-#[derive(Show,Eq,PartialEq)]
+#[derive(Debug,Eq,PartialEq)]
 pub enum ProtobufError {
     IoError(IoError),
     WireError(String),
+}
+
+impl fmt::Display for ProtobufError {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        fmt::Debug::fmt(self, f)
+    }
 }
 
 impl Error for ProtobufError {

--- a/src/lib/repeated.rs
+++ b/src/lib/repeated.rs
@@ -304,7 +304,7 @@ impl<T> IndexMut<usize> for RepeatedField<T> {
     }
 }
 
-impl<T : fmt::Show> fmt::Show for RepeatedField<T> {
+impl<T : fmt::Debug> fmt::Debug for RepeatedField<T> {
     #[inline]
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         self.as_slice().fmt(f)

--- a/src/lib/singular.rs
+++ b/src/lib/singular.rs
@@ -401,7 +401,7 @@ impl<T : Clone> Clone for SingularPtrField<T> {
     }
 }
 
-impl<T : fmt::Show> fmt::Show for SingularField<T> {
+impl<T : fmt::Debug> fmt::Debug for SingularField<T> {
     #[inline]
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         if self.is_some() {
@@ -412,7 +412,7 @@ impl<T : fmt::Show> fmt::Show for SingularField<T> {
     }
 }
 
-impl<T : fmt::Show> fmt::Show for SingularPtrField<T> {
+impl<T : fmt::Debug> fmt::Debug for SingularPtrField<T> {
     #[inline]
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         if self.is_some() {

--- a/src/lib/stream.rs
+++ b/src/lib/stream.rs
@@ -25,7 +25,7 @@ pub mod wire_format {
     pub const TAG_TYPE_BITS: u32 = 3;
     pub const TAG_TYPE_MASK: u32 = (1u32 << TAG_TYPE_BITS as usize) as u32 - 1;
 
-    #[derive(PartialEq, Eq, Clone, Show)]
+    #[derive(PartialEq, Eq, Clone, Debug)]
     pub enum WireType {
         WireTypeVarint          = 0,
         WireTypeFixed64         = 1,

--- a/src/lib/unknown.rs
+++ b/src/lib/unknown.rs
@@ -5,7 +5,7 @@ use std::slice;
 use stream::wire_format;
 use clear::Clear;
 
-#[derive(Show)]
+#[derive(Debug)]
 pub enum UnknownValue {
     Fixed32(u32),
     Fixed64(u64),
@@ -46,7 +46,7 @@ impl<'o> UnknownValueRef<'o> {
     }
 }
 
-#[derive(Clone,PartialEq,Eq,Show,Default)]
+#[derive(Clone,PartialEq,Eq,Debug,Default)]
 pub struct UnknownValues {
     pub fixed32: Vec<u32>,
     pub fixed64: Vec<u64>,
@@ -105,7 +105,7 @@ impl<'o> Iterator for UnknownValuesIter<'o> {
     }
 }
 
-#[derive(Clone,PartialEq,Eq,Show,Default)]
+#[derive(Clone,PartialEq,Eq,Debug,Default)]
 pub struct UnknownFields {
     // option is needed, because HashMap constructor performs allocation,
     // and very expensive

--- a/src/perftest/perftest_data.rs
+++ b/src/perftest/perftest_data.rs
@@ -112,8 +112,8 @@ impl ::protobuf::Message for Test1 {
         &mut self.unknown_fields
     }
 
-    fn type_id(&self) -> ::std::intrinsics::TypeId {
-        ::std::intrinsics::TypeId::of::<Test1>()
+    fn type_id(&self) -> ::std::any::TypeId {
+        ::std::any::TypeId::of::<Test1>()
     }
 
     fn descriptor(&self) -> &'static ::protobuf::reflect::MessageDescriptor {
@@ -164,7 +164,7 @@ impl ::std::cmp::PartialEq for Test1 {
     }
 }
 
-impl ::std::fmt::Show for Test1 {
+impl ::std::fmt::Debug for Test1 {
     fn fmt(&self, f: &mut ::std::fmt::Formatter) -> ::std::fmt::Result {
         ::protobuf::text_format::fmt(self, f)
     }
@@ -274,8 +274,8 @@ impl ::protobuf::Message for TestRepeatedBool {
         &mut self.unknown_fields
     }
 
-    fn type_id(&self) -> ::std::intrinsics::TypeId {
-        ::std::intrinsics::TypeId::of::<TestRepeatedBool>()
+    fn type_id(&self) -> ::std::any::TypeId {
+        ::std::any::TypeId::of::<TestRepeatedBool>()
     }
 
     fn descriptor(&self) -> &'static ::protobuf::reflect::MessageDescriptor {
@@ -325,7 +325,7 @@ impl ::std::cmp::PartialEq for TestRepeatedBool {
     }
 }
 
-impl ::std::fmt::Show for TestRepeatedBool {
+impl ::std::fmt::Debug for TestRepeatedBool {
     fn fmt(&self, f: &mut ::std::fmt::Formatter) -> ::std::fmt::Result {
         ::protobuf::text_format::fmt(self, f)
     }
@@ -442,8 +442,8 @@ impl ::protobuf::Message for TestRepeatedPackedInt32 {
         &mut self.unknown_fields
     }
 
-    fn type_id(&self) -> ::std::intrinsics::TypeId {
-        ::std::intrinsics::TypeId::of::<TestRepeatedPackedInt32>()
+    fn type_id(&self) -> ::std::any::TypeId {
+        ::std::any::TypeId::of::<TestRepeatedPackedInt32>()
     }
 
     fn descriptor(&self) -> &'static ::protobuf::reflect::MessageDescriptor {
@@ -493,7 +493,7 @@ impl ::std::cmp::PartialEq for TestRepeatedPackedInt32 {
     }
 }
 
-impl ::std::fmt::Show for TestRepeatedPackedInt32 {
+impl ::std::fmt::Debug for TestRepeatedPackedInt32 {
     fn fmt(&self, f: &mut ::std::fmt::Formatter) -> ::std::fmt::Result {
         ::protobuf::text_format::fmt(self, f)
     }
@@ -686,8 +686,8 @@ impl ::protobuf::Message for TestRepeatedMessages {
         &mut self.unknown_fields
     }
 
-    fn type_id(&self) -> ::std::intrinsics::TypeId {
-        ::std::intrinsics::TypeId::of::<TestRepeatedMessages>()
+    fn type_id(&self) -> ::std::any::TypeId {
+        ::std::any::TypeId::of::<TestRepeatedMessages>()
     }
 
     fn descriptor(&self) -> &'static ::protobuf::reflect::MessageDescriptor {
@@ -749,7 +749,7 @@ impl ::std::cmp::PartialEq for TestRepeatedMessages {
     }
 }
 
-impl ::std::fmt::Show for TestRepeatedMessages {
+impl ::std::fmt::Debug for TestRepeatedMessages {
     fn fmt(&self, f: &mut ::std::fmt::Formatter) -> ::std::fmt::Result {
         ::protobuf::text_format::fmt(self, f)
     }
@@ -978,8 +978,8 @@ impl ::protobuf::Message for TestOptionalMessages {
         &mut self.unknown_fields
     }
 
-    fn type_id(&self) -> ::std::intrinsics::TypeId {
-        ::std::intrinsics::TypeId::of::<TestOptionalMessages>()
+    fn type_id(&self) -> ::std::any::TypeId {
+        ::std::any::TypeId::of::<TestOptionalMessages>()
     }
 
     fn descriptor(&self) -> &'static ::protobuf::reflect::MessageDescriptor {
@@ -1044,7 +1044,7 @@ impl ::std::cmp::PartialEq for TestOptionalMessages {
     }
 }
 
-impl ::std::fmt::Show for TestOptionalMessages {
+impl ::std::fmt::Debug for TestOptionalMessages {
     fn fmt(&self, f: &mut ::std::fmt::Formatter) -> ::std::fmt::Result {
         ::protobuf::text_format::fmt(self, f)
     }
@@ -1273,8 +1273,8 @@ impl ::protobuf::Message for TestStrings {
         &mut self.unknown_fields
     }
 
-    fn type_id(&self) -> ::std::intrinsics::TypeId {
-        ::std::intrinsics::TypeId::of::<TestStrings>()
+    fn type_id(&self) -> ::std::any::TypeId {
+        ::std::any::TypeId::of::<TestStrings>()
     }
 
     fn descriptor(&self) -> &'static ::protobuf::reflect::MessageDescriptor {
@@ -1339,7 +1339,7 @@ impl ::std::cmp::PartialEq for TestStrings {
     }
 }
 
-impl ::std::fmt::Show for TestStrings {
+impl ::std::fmt::Debug for TestStrings {
     fn fmt(&self, f: &mut ::std::fmt::Formatter) -> ::std::fmt::Result {
         ::protobuf::text_format::fmt(self, f)
     }
@@ -1649,8 +1649,8 @@ impl ::protobuf::Message for PerftestData {
         &mut self.unknown_fields
     }
 
-    fn type_id(&self) -> ::std::intrinsics::TypeId {
-        ::std::intrinsics::TypeId::of::<PerftestData>()
+    fn type_id(&self) -> ::std::any::TypeId {
+        ::std::any::TypeId::of::<PerftestData>()
     }
 
     fn descriptor(&self) -> &'static ::protobuf::reflect::MessageDescriptor {
@@ -1730,7 +1730,7 @@ impl ::std::cmp::PartialEq for PerftestData {
     }
 }
 
-impl ::std::fmt::Show for PerftestData {
+impl ::std::fmt::Debug for PerftestData {
     fn fmt(&self, f: &mut ::std::fmt::Formatter) -> ::std::fmt::Result {
         ::protobuf::text_format::fmt(self, f)
     }

--- a/src/plugin.rs
+++ b/src/plugin.rs
@@ -221,8 +221,8 @@ impl ::protobuf::Message for CodeGeneratorRequest {
         &mut self.unknown_fields
     }
 
-    fn type_id(&self) -> ::std::intrinsics::TypeId {
-        ::std::intrinsics::TypeId::of::<CodeGeneratorRequest>()
+    fn type_id(&self) -> ::std::any::TypeId {
+        ::std::any::TypeId::of::<CodeGeneratorRequest>()
     }
 
     fn descriptor(&self) -> &'static ::protobuf::reflect::MessageDescriptor {
@@ -285,7 +285,7 @@ impl ::std::cmp::PartialEq for CodeGeneratorRequest {
     }
 }
 
-impl ::std::fmt::Show for CodeGeneratorRequest {
+impl ::std::fmt::Debug for CodeGeneratorRequest {
     fn fmt(&self, f: &mut ::std::fmt::Formatter) -> ::std::fmt::Result {
         ::protobuf::text_format::fmt(self, f)
     }
@@ -451,8 +451,8 @@ impl ::protobuf::Message for CodeGeneratorResponse {
         &mut self.unknown_fields
     }
 
-    fn type_id(&self) -> ::std::intrinsics::TypeId {
-        ::std::intrinsics::TypeId::of::<CodeGeneratorResponse>()
+    fn type_id(&self) -> ::std::any::TypeId {
+        ::std::any::TypeId::of::<CodeGeneratorResponse>()
     }
 
     fn descriptor(&self) -> &'static ::protobuf::reflect::MessageDescriptor {
@@ -509,7 +509,7 @@ impl ::std::cmp::PartialEq for CodeGeneratorResponse {
     }
 }
 
-impl ::std::fmt::Show for CodeGeneratorResponse {
+impl ::std::fmt::Debug for CodeGeneratorResponse {
     fn fmt(&self, f: &mut ::std::fmt::Formatter) -> ::std::fmt::Result {
         ::protobuf::text_format::fmt(self, f)
     }
@@ -738,8 +738,8 @@ impl ::protobuf::Message for CodeGeneratorResponse_File {
         &mut self.unknown_fields
     }
 
-    fn type_id(&self) -> ::std::intrinsics::TypeId {
-        ::std::intrinsics::TypeId::of::<CodeGeneratorResponse_File>()
+    fn type_id(&self) -> ::std::any::TypeId {
+        ::std::any::TypeId::of::<CodeGeneratorResponse_File>()
     }
 
     fn descriptor(&self) -> &'static ::protobuf::reflect::MessageDescriptor {
@@ -804,7 +804,7 @@ impl ::std::cmp::PartialEq for CodeGeneratorResponse_File {
     }
 }
 
-impl ::std::fmt::Show for CodeGeneratorResponse_File {
+impl ::std::fmt::Debug for CodeGeneratorResponse_File {
     fn fmt(&self, f: &mut ::std::fmt::Formatter) -> ::std::fmt::Result {
         ::protobuf::text_format::fmt(self, f)
     }


### PR DESCRIPTION
Fixed compilation on latest Rust.

One thing you may want to look at is `error.rs`, it needs to implement `Display` which cannot be `derive`d, so I just forwarded to `Debug`.

If you don't know now `Show -> Debug` and `String -> Display`.

There are also a lot of warnings about the new slicing syntax, I can fix those too if you want.