### PR TITLE
Remove compiler warnings and migrate to new std::io module.

### DIFF
--- a/src/lib/codegen.rs
+++ b/src/lib/codegen.rs
@@ -1,7 +1,7 @@
-use std::old_io::Writer;
-use std::mem;
-use std::fmt;
 use std::collections::hash_map::HashMap;
+use std::fmt;
+use std::io::Write;
+use std::mem;
 
 use descriptor::*;
 use misc::*;
@@ -755,7 +755,7 @@ impl EnumValue {
 
 struct IndentWriter<'a> {
     // TODO: add mut
-    writer: &'a (Writer + 'a),
+    writer: &'a (Write + 'a),
     indent: String,
     msg: Option<&'a MessageInfo>,
     field: Option<&'a Field>,
@@ -763,7 +763,7 @@ struct IndentWriter<'a> {
 }
 
 impl<'a> IndentWriter<'a> {
-    fn new(writer: &'a mut Writer) -> IndentWriter<'a> {
+    fn new(writer: &'a mut Write) -> IndentWriter<'a> {
         IndentWriter {
             writer: writer,
             indent: "".to_string(),
@@ -996,7 +996,7 @@ impl<'a> IndentWriter<'a> {
     }
 
     fn write_line<S : Str>(&self, line: S) {
-        let mut_writer: &mut Writer = unsafe { mem::transmute(self.writer) };
+        let mut_writer: &mut Write = unsafe { mem::transmute(self.writer) };
         (if line.as_slice().is_empty() {
             mut_writer.write_all("\n".as_bytes())
         } else {
@@ -1858,7 +1858,7 @@ pub fn gen(file_descriptors: &[FileDescriptorProto], files_to_generate: &[String
 
         {
             let mut os = VecWriter::new(&mut v);
-            let mut w = IndentWriter::new(&mut os as &mut Writer);
+            let mut w = IndentWriter::new(&mut os as &mut Write);
 
             w.write_line("// This file is generated. Do not edit");
 

--- a/src/lib/core.rs
+++ b/src/lib/core.rs
@@ -1,10 +1,12 @@
 // TODO: drop all panic!
 
+use std::any::TypeId;
+use std::default::Default;
+use std::fmt;
+use std::io::Read;
+use std::io::Write;
 use std::mem;
 use std::raw;
-use std::fmt;
-use std::default::Default;
-use std::any::TypeId;
 
 use clear::Clear;
 use reflect::MessageDescriptor;
@@ -88,7 +90,7 @@ pub trait Message : fmt::Debug + Clear {
         assert!(self.is_initialized());
     }
 
-    fn write_to_writer(&self, w: &mut Writer) -> ProtobufResult<()> {
+    fn write_to_writer(&self, w: &mut Write) -> ProtobufResult<()> {
         w.with_coded_output_stream(|os| {
             self.write_to(os)
         })
@@ -107,7 +109,7 @@ pub trait Message : fmt::Debug + Clear {
         Ok(v)
     }
 
-    fn write_length_delimited_to_writer(&self, w: &mut Writer) -> ProtobufResult<()> {
+    fn write_length_delimited_to_writer(&self, w: &mut Write) -> ProtobufResult<()> {
         w.with_coded_output_stream(|os| {
             self.write_length_delimited_to(os)
         })
@@ -172,7 +174,7 @@ pub fn parse_from<M : Message + MessageStatic>(is: &mut CodedInputStream) -> Pro
     Ok(r)
 }
 
-pub fn parse_from_reader<M : Message + MessageStatic>(reader: &mut Reader) -> ProtobufResult<M> {
+pub fn parse_from_reader<M : Message + MessageStatic>(reader: &mut Read) -> ProtobufResult<M> {
     reader.with_coded_input_stream(|is| {
         parse_from::<M>(is)
     })
@@ -190,7 +192,7 @@ pub fn parse_length_delimited_from<M : Message + MessageStatic>(is: &mut CodedIn
     is.read_message::<M>()
 }
 
-pub fn parse_length_delimited_from_reader<M : Message + MessageStatic>(r: &mut Reader) -> ProtobufResult<M> {
+pub fn parse_length_delimited_from_reader<M : Message + MessageStatic>(r: &mut Read) -> ProtobufResult<M> {
     // TODO: wrong: we may read length first, and then read exact number of bytes needed
     r.with_coded_input_stream(|is| {
         is.read_message::<M>()

--- a/src/lib/descriptorx.rs
+++ b/src/lib/descriptorx.rs
@@ -19,13 +19,13 @@ impl<'a> RootScope<'a> {
 
     pub fn find_enum(&'a self, fqn: &str) -> EnumWithScope<'a> {
         assert!(fqn.starts_with("."));
-        let fqn1 = fqn.slice_from(1);
+        let fqn1 = &fqn[1..];
         self.packages().into_iter()
             .flat_map(|p| {
                 (if p.get_package().is_empty() {
                     p.find_enum(fqn1)
                 } else if fqn1.starts_with((p.get_package().to_string() + ".").as_slice()) {
-                    let remaining = fqn1.slice_from(p.get_package().len() + 1);
+                    let remaining = &fqn1[(p.get_package().len() + 1)..];
                     p.find_enum(remaining)
                 } else {
                     None

--- a/src/lib/error.rs
+++ b/src/lib/error.rs
@@ -1,4 +1,4 @@
-use std::old_io::IoError;
+use std::io;
 use std::error::Error;
 use std::fmt;
 
@@ -6,7 +6,7 @@ pub type ProtobufResult<T> = Result<T, ProtobufError>;
 
 #[derive(Debug,Eq,PartialEq)]
 pub enum ProtobufError {
-    IoError(IoError),
+    IoError(io::Error),
     WireError(String),
 }
 

--- a/src/lib/maybe_owned_slice.rs
+++ b/src/lib/maybe_owned_slice.rs
@@ -26,19 +26,19 @@ impl<'a, T : 'a> MaybeOwnedSlice<'a, T> {
 
     #[inline]
     pub fn slice<'b>(&'b self, start: usize, end: usize) -> &'b [T] {
-        self.as_slice().slice(start, end)
+        &self.as_slice()[start..end]
     }
 
     #[allow(dead_code)]
     #[inline]
     pub fn slice_from<'b>(&'b self, start: usize) -> &'b [T] {
-        self.as_slice().slice_from(start)
+        &self.as_slice()[start..]
     }
 
     #[allow(dead_code)]
     #[inline]
     pub fn slice_to<'b>(&'b self, end: usize) -> &'b [T] {
-        self.as_slice().slice_to(end)
+        &self.as_slice()[..end]
     }
 }
 

--- a/src/lib/misc.rs
+++ b/src/lib/misc.rs
@@ -1,5 +1,4 @@
-use std::old_io::Writer;
-use std::old_io as io;
+use std::io;
 
 pub struct VecWriter<'a> {
     vec: &'a mut Vec<u8>,
@@ -13,9 +12,13 @@ impl<'a> VecWriter<'a> {
     }
 }
 
-impl<'a> Writer for VecWriter<'a> {
-    fn write_all(&mut self, v: &[u8]) -> io::IoResult<()> {
+impl<'a> io::Write for VecWriter<'a> {
+    fn write(&mut self, v: &[u8]) -> io::Result<usize> {
         self.vec.push_all(v);
+        Ok(v.len())
+    }
+
+    fn flush(&mut self) -> io::Result<()> {
         Ok(())
     }
 }
@@ -23,7 +26,7 @@ impl<'a> Writer for VecWriter<'a> {
 #[cfg(test)]
 mod test {
 
-    use std::old_io::Writer;
+    use std::io;
     use misc::VecWriter;
 
     #[test]
@@ -31,10 +34,10 @@ mod test {
         let mut v = Vec::new();
         {
             let mut w = VecWriter::new(&mut v);
-            fn foo(writer: &mut Writer) {
+            fn foo(writer: &mut io::Write) {
                 writer.write(b"hi").unwrap();
             }
-            foo(&mut w as &mut Writer);
+            foo(&mut w as &mut io::Write);
         }
         assert_eq!(b"hi".to_vec(), v);
     }

--- a/src/lib/protobuf.rs
+++ b/src/lib/protobuf.rs
@@ -5,7 +5,7 @@
 // warnings
 #![feature(collections)]
 #![feature(core)]
-#![feature(io)]
+#![feature(old_io)]
 #![feature(std_misc)]
 
 

--- a/src/lib/protobuf.rs
+++ b/src/lib/protobuf.rs
@@ -5,7 +5,7 @@
 // warnings
 #![feature(collections)]
 #![feature(core)]
-#![feature(old_io)]
+#![feature(io)]
 #![feature(std_misc)]
 
 

--- a/src/lib/repeated.rs
+++ b/src/lib/repeated.rs
@@ -78,32 +78,32 @@ impl<T> RepeatedField<T> {
 
     #[inline]
     pub fn slice<'a>(&'a self, start: usize, end: usize) -> &'a [T] {
-        self.as_slice().slice(start, end)
+        &self.as_slice()[start..end]
     }
 
     #[inline]
     pub fn slice_mut<'a>(&'a mut self, start: usize, end: usize) -> &'a mut [T] {
-        self.as_mut_slice().slice_mut(start, end)
+        &mut self.as_mut_slice()[start..end]
     }
 
     #[inline]
     pub fn slice_from<'a>(&'a self, start: usize) -> &'a [T] {
-        self.as_slice().slice_from(start)
+        &self.as_slice()[start..]
     }
 
     #[inline]
     pub fn slice_from_mut<'a>(&'a mut self, start: usize) -> &'a mut [T] {
-        self.as_mut_slice().slice_from_mut(start)
+        &mut self.as_mut_slice()[start..]
     }
 
     #[inline]
     pub fn slice_to<'a>(&'a self, end: usize) -> &'a [T] {
-        self.as_slice().slice_to(end)
+        &self.as_slice()[..end]
     }
 
     #[inline]
     pub fn slice_to_mut<'a>(&'a mut self, end: usize) -> &'a mut [T] {
-        self.as_mut_slice().slice_to_mut(end)
+        &mut self.as_mut_slice()[..end]
     }
 
     #[inline]
@@ -283,7 +283,7 @@ impl<T : PartialEq> RepeatedField<T> {
 impl<T> AsSlice<T> for RepeatedField<T> {
     #[inline]
     fn as_slice<'a>(&'a self) -> &'a [T] {
-        self.vec.slice_to(self.len)
+        &self.vec[..self.len]
     }
 }
 

--- a/src/lib/stream.rs
+++ b/src/lib/stream.rs
@@ -737,7 +737,7 @@ impl<'a> CodedOutputStream<'a> {
     fn refresh_buffer(&mut self) -> ProtobufResult<()> {
         match self.writer {
             Some(ref mut writer) => {
-                try!(writer.write(self.buffer.slice(0, self.position as usize))
+                try!(writer.write_all(&self.buffer[0..self.position as usize])
                     .map_err(|e| ProtobufError::IoError(e)));
             },
             None => panic!()
@@ -766,7 +766,7 @@ impl<'a> CodedOutputStream<'a> {
         try!(self.refresh_buffer());
         // TODO: write into buffer if enough capacity
         match self.writer {
-            Some(ref mut writer) => try!(writer.write(bytes).map_err(|e| ProtobufError::IoError(e))),
+            Some(ref mut writer) => try!(writer.write_all(bytes).map_err(|e| ProtobufError::IoError(e))),
             None => panic!()
         };
         Ok(())

--- a/src/lib/strx.rs
+++ b/src/lib/strx.rs
@@ -1,6 +1,6 @@
 pub fn remove_to<'s>(s: &'s str, c: char) -> &'s str {
     match s.rfind(c) {
-        Some(pos) => s.slice_from(pos + 1),
+        Some(pos) => &s[(pos + 1)..],
         None => s
     }
 }
@@ -8,7 +8,7 @@ pub fn remove_to<'s>(s: &'s str, c: char) -> &'s str {
 #[allow(dead_code)]
 pub fn remove_from_last<'s>(s: &'s str, c: char) -> &'s str {
     match s.rfind(c) {
-        Some(pos) => s.slice_to(pos),
+        Some(pos) => &s[..pos],
         None => s,
     }
 }
@@ -17,14 +17,14 @@ pub fn remove_suffix<'s>(s: &'s str, suffix: &str) -> &'s str {
     if !s.ends_with(suffix) {
         panic!();
     }
-    s.slice_to(s.len() - suffix.len())
+    &s[..(s.len() - suffix.len())]
 }
 
 pub fn remove_prefix<'s>(s: &'s str, prefix: &str) -> &'s str {
     if !s.starts_with(prefix) {
         panic!();
     }
-    s.slice_from(prefix.len())
+    &s[prefix.len()..]
 }
 
 #[cfg(test)]

--- a/src/perftest/perftest.rs
+++ b/src/perftest/perftest.rs
@@ -1,14 +1,13 @@
 #![feature(core)]
-#![feature(io)]
 #![feature(path)]
-#![feature(env)]
 
 extern crate protobuf;
 extern crate rand;
 extern crate time;
 
-use std::old_io::File;
 use std::default::Default;
+use std::fs::File;
+use std::path::Path;
 
 use rand::Rng;
 use rand::StdRng;
@@ -108,7 +107,7 @@ fn main() {
 
     let mut runner = TestRunner { selected: selected, any_matched: false };
 
-    let mut is = File::open(&Path::new("perftest_data.pbbin"));
+    let mut is = File::open(&Path::new("perftest_data.pbbin")).unwrap();
     let test_data = protobuf::parse_from_reader::<PerftestData>(&mut is).unwrap();
 
     runner.test("test1", test_data.get_test1());

--- a/src/protoc-gen-rust.rs
+++ b/src/protoc-gen-rust.rs
@@ -1,14 +1,14 @@
 #![crate_type = "bin"]
 #![allow(non_camel_case_types)]
-#![feature(old_io)]
+#![feature(io)]
 #![feature(core)]
 
 extern crate protobuf;
 
-use std::old_io::Reader;
-use std::old_io::Writer;
-use std::old_io::stdin;
-use std::old_io::stdout;
+use std::io::Read;
+use std::io::Write;
+use std::io::stdin;
+use std::io::stdout;
 use std::str;
 use plugin::*;
 use protobuf::parse_from_reader;
@@ -22,7 +22,7 @@ mod descriptor {
 mod plugin;
 
 fn main() {
-    let req = parse_from_reader::<CodeGeneratorRequest>(&mut stdin() as &mut Reader).unwrap();
+    let req = parse_from_reader::<CodeGeneratorRequest>(&mut stdin() as &mut Read).unwrap();
     let gen_options = GenOptions {
         dummy: false,
     };
@@ -34,5 +34,5 @@ fn main() {
         r.set_content(str::from_utf8(file.content.as_slice()).unwrap().to_string());
         r
     }).collect());
-    resp.write_to_writer(&mut stdout() as &mut Writer).unwrap();
+    resp.write_to_writer(&mut stdout() as &mut Write).unwrap();
 }

--- a/src/protoc-gen-rust.rs
+++ b/src/protoc-gen-rust.rs
@@ -1,6 +1,6 @@
 #![crate_type = "bin"]
 #![allow(non_camel_case_types)]
-#![feature(io)]
+#![feature(old_io)]
 #![feature(core)]
 
 extern crate protobuf;


### PR DESCRIPTION
_Allow rust-protobuf to build with recent nightlies without warnings, and migrate from std::old_io -> std::io._

#### Changes
* Move from std::old_io -> std::io
  * old_io::Reader -> io::Read, old_io::Writer -> io::Writer
  * std::fs::File, std::path::Path
* Use new slicing syntax where appropriate