### PR TITLE
Tracking rust nightly

### DIFF
--- a/src/lib/maybe_owned_slice.rs
+++ b/src/lib/maybe_owned_slice.rs
@@ -43,14 +43,14 @@ impl<'a, T : 'a> Index<usize> for MaybeOwnedSlice<'a, T> {
     type Output = T;
 
     #[inline]
-    fn index<'b>(&'b self, index: &usize) -> &'b T {
-        &self.as_slice()[*index]
+    fn index<'b>(&'b self, index: usize) -> &'b T {
+        &self.as_slice()[index]
     }
 }
 
 impl<'a, T : 'a> IndexMut<usize> for MaybeOwnedSlice<'a, T> {
     #[inline]
-    fn index_mut<'b>(&'b mut self, index: &usize) -> &'b mut T {
-        &mut self.as_mut_slice()[*index]
+    fn index_mut<'b>(&'b mut self, index: usize) -> &'b mut T {
+        &mut self.as_mut_slice()[index]
     }
 }

--- a/src/lib/repeated.rs
+++ b/src/lib/repeated.rs
@@ -316,15 +316,15 @@ impl<T> Index<usize> for RepeatedField<T> {
     type Output = T;
 
     #[inline]
-    fn index<'a>(&'a self, index: &usize) -> &'a T {
-        &self.as_slice()[*index]
+    fn index<'a>(&'a self, index: usize) -> &'a T {
+        &self.as_slice()[index]
     }
 }
 
 impl<T> IndexMut<usize> for RepeatedField<T> {
     #[inline]
-    fn index_mut<'a>(&'a mut self, index: &usize) -> &'a mut T {
-        &mut self.as_mut_slice()[*index]
+    fn index_mut<'a>(&'a mut self, index: usize) -> &'a mut T {
+        &mut self.as_mut_slice()[index]
     }
 }
 


### PR DESCRIPTION
Changed Index trait implementations from &usize to usize. 
Some issues in lib/codegen.rs still remain: rustc says RustType::into doesn't take parameters although the definition is unchanged.