### PR TITLE
Make pos() on CodedInputStream public

### DIFF
--- a/src/lib/stream.rs
+++ b/src/lib/stream.rs
@@ -152,7 +152,7 @@ impl<'a> CodedInputStream<'a> {
         self.buffer.slice(self.buffer_pos as usize, self.buffer_size as usize)
     }
 
-    fn pos(&self) -> u32 {
+    pub fn pos(&self) -> u32 {
         self.total_bytes_retired + self.buffer_pos
     }
 


### PR DESCRIPTION
I have a use case where I need to know how many bytes the delimiter occupied after reading it, so I am able to tell when enough bytes for the full messages have been received over a non-blocking stream. This `pos()` method serves this purpose perfectly.

Does it make sense to make it public?