### PR TITLE
remove #[feature(core)] and #![feature(collections)] => stable compliant!

### DIFF
--- a/src/lib/codegen.rs
+++ b/src/lib/codegen.rs
@@ -19,6 +19,10 @@ use descriptorx::FileScope;
 use descriptorx::RootScope;
 use descriptorx::WithScope;
 
+fn escape_default(s: &str) -> String {
+    s.chars().flat_map(|c| c.escape_default()).collect()
+}
+
 #[derive(Clone,PartialEq,Eq)]
 enum RustType {
     Signed(u32),
@@ -702,7 +706,7 @@ impl Field {
                 // For booleans, "true" or "false"
                 FieldDescriptorProto_Type::TYPE_BOOL     => format!("{}", proto_default),
                 // For strings, contains the default text contents (not escaped in any way)
-                FieldDescriptorProto_Type::TYPE_STRING   => format!("\"{}\"", proto_default.escape_default()),
+                FieldDescriptorProto_Type::TYPE_STRING   => format!("\"{}\"", escape_default(proto_default)),
                 // For bytes, contains the C escaped value.  All bytes >= 128 are escaped
                 FieldDescriptorProto_Type::TYPE_BYTES    => format!("b\"{}\"", proto_default),
                 // TODO: resolve outer message prefix

--- a/src/lib/codegen.rs
+++ b/src/lib/codegen.rs
@@ -1947,6 +1947,10 @@ impl<'a> MessageContext<'a> {
                 w.write_line(format!("::std::any::TypeId::of::<{}>()", self.type_name));
             });
             w.write_line("");
+            w.def_fn("as_any(&self) -> &::std::any::Any", |w| {
+                w.write_line("self as &::std::any::Any");
+            });
+            w.write_line("");
             w.def_fn("descriptor(&self) -> &'static ::protobuf::reflect::MessageDescriptor", |w| {
                 w.write_line("::protobuf::MessageStatic::descriptor_static(None::<Self>)");
             });

--- a/src/lib/descriptor.rs
+++ b/src/lib/descriptor.rs
@@ -124,6 +124,10 @@ impl ::protobuf::Message for FileDescriptorSet {
         ::std::any::TypeId::of::<FileDescriptorSet>()
     }
 
+    fn as_any(&self) -> &::std::any::Any {
+        self as &::std::any::Any
+    }
+
     fn descriptor(&self) -> &'static ::protobuf::reflect::MessageDescriptor {
         ::protobuf::MessageStatic::descriptor_static(None::<Self>)
     }
@@ -721,6 +725,10 @@ impl ::protobuf::Message for FileDescriptorProto {
         ::std::any::TypeId::of::<FileDescriptorProto>()
     }
 
+    fn as_any(&self) -> &::std::any::Any {
+        self as &::std::any::Any
+    }
+
     fn descriptor(&self) -> &'static ::protobuf::reflect::MessageDescriptor {
         ::protobuf::MessageStatic::descriptor_static(None::<Self>)
     }
@@ -1250,6 +1258,10 @@ impl ::protobuf::Message for DescriptorProto {
         ::std::any::TypeId::of::<DescriptorProto>()
     }
 
+    fn as_any(&self) -> &::std::any::Any {
+        self as &::std::any::Any
+    }
+
     fn descriptor(&self) -> &'static ::protobuf::reflect::MessageDescriptor {
         ::protobuf::MessageStatic::descriptor_static(None::<Self>)
     }
@@ -1489,6 +1501,10 @@ impl ::protobuf::Message for DescriptorProto_ExtensionRange {
 
     fn type_id(&self) -> ::std::any::TypeId {
         ::std::any::TypeId::of::<DescriptorProto_ExtensionRange>()
+    }
+
+    fn as_any(&self) -> &::std::any::Any {
+        self as &::std::any::Any
     }
 
     fn descriptor(&self) -> &'static ::protobuf::reflect::MessageDescriptor {
@@ -2019,6 +2035,10 @@ impl ::protobuf::Message for FieldDescriptorProto {
         ::std::any::TypeId::of::<FieldDescriptorProto>()
     }
 
+    fn as_any(&self) -> &::std::any::Any {
+        self as &::std::any::Any
+    }
+
     fn descriptor(&self) -> &'static ::protobuf::reflect::MessageDescriptor {
         ::protobuf::MessageStatic::descriptor_static(None::<Self>)
     }
@@ -2360,6 +2380,10 @@ impl ::protobuf::Message for OneofDescriptorProto {
         ::std::any::TypeId::of::<OneofDescriptorProto>()
     }
 
+    fn as_any(&self) -> &::std::any::Any {
+        self as &::std::any::Any
+    }
+
     fn descriptor(&self) -> &'static ::protobuf::reflect::MessageDescriptor {
         ::protobuf::MessageStatic::descriptor_static(None::<Self>)
     }
@@ -2629,6 +2653,10 @@ impl ::protobuf::Message for EnumDescriptorProto {
 
     fn type_id(&self) -> ::std::any::TypeId {
         ::std::any::TypeId::of::<EnumDescriptorProto>()
+    }
+
+    fn as_any(&self) -> &::std::any::Any {
+        self as &::std::any::Any
     }
 
     fn descriptor(&self) -> &'static ::protobuf::reflect::MessageDescriptor {
@@ -2908,6 +2936,10 @@ impl ::protobuf::Message for EnumValueDescriptorProto {
 
     fn type_id(&self) -> ::std::any::TypeId {
         ::std::any::TypeId::of::<EnumValueDescriptorProto>()
+    }
+
+    fn as_any(&self) -> &::std::any::Any {
+        self as &::std::any::Any
     }
 
     fn descriptor(&self) -> &'static ::protobuf::reflect::MessageDescriptor {
@@ -3193,6 +3225,10 @@ impl ::protobuf::Message for ServiceDescriptorProto {
 
     fn type_id(&self) -> ::std::any::TypeId {
         ::std::any::TypeId::of::<ServiceDescriptorProto>()
+    }
+
+    fn as_any(&self) -> &::std::any::Any {
+        self as &::std::any::Any
     }
 
     fn descriptor(&self) -> &'static ::protobuf::reflect::MessageDescriptor {
@@ -3540,6 +3576,10 @@ impl ::protobuf::Message for MethodDescriptorProto {
 
     fn type_id(&self) -> ::std::any::TypeId {
         ::std::any::TypeId::of::<MethodDescriptorProto>()
+    }
+
+    fn as_any(&self) -> &::std::any::Any {
+        self as &::std::any::Any
     }
 
     fn descriptor(&self) -> &'static ::protobuf::reflect::MessageDescriptor {
@@ -4157,6 +4197,10 @@ impl ::protobuf::Message for FileOptions {
         ::std::any::TypeId::of::<FileOptions>()
     }
 
+    fn as_any(&self) -> &::std::any::Any {
+        self as &::std::any::Any
+    }
+
     fn descriptor(&self) -> &'static ::protobuf::reflect::MessageDescriptor {
         ::protobuf::MessageStatic::descriptor_static(None::<Self>)
     }
@@ -4539,6 +4583,10 @@ impl ::protobuf::Message for MessageOptions {
 
     fn type_id(&self) -> ::std::any::TypeId {
         ::std::any::TypeId::of::<MessageOptions>()
+    }
+
+    fn as_any(&self) -> &::std::any::Any {
+        self as &::std::any::Any
     }
 
     fn descriptor(&self) -> &'static ::protobuf::reflect::MessageDescriptor {
@@ -4951,6 +4999,10 @@ impl ::protobuf::Message for FieldOptions {
         ::std::any::TypeId::of::<FieldOptions>()
     }
 
+    fn as_any(&self) -> &::std::any::Any {
+        self as &::std::any::Any
+    }
+
     fn descriptor(&self) -> &'static ::protobuf::reflect::MessageDescriptor {
         ::protobuf::MessageStatic::descriptor_static(None::<Self>)
     }
@@ -5266,6 +5318,10 @@ impl ::protobuf::Message for EnumOptions {
         ::std::any::TypeId::of::<EnumOptions>()
     }
 
+    fn as_any(&self) -> &::std::any::Any {
+        self as &::std::any::Any
+    }
+
     fn descriptor(&self) -> &'static ::protobuf::reflect::MessageDescriptor {
         ::protobuf::MessageStatic::descriptor_static(None::<Self>)
     }
@@ -5482,6 +5538,10 @@ impl ::protobuf::Message for EnumValueOptions {
         ::std::any::TypeId::of::<EnumValueOptions>()
     }
 
+    fn as_any(&self) -> &::std::any::Any {
+        self as &::std::any::Any
+    }
+
     fn descriptor(&self) -> &'static ::protobuf::reflect::MessageDescriptor {
         ::protobuf::MessageStatic::descriptor_static(None::<Self>)
     }
@@ -5691,6 +5751,10 @@ impl ::protobuf::Message for ServiceOptions {
         ::std::any::TypeId::of::<ServiceOptions>()
     }
 
+    fn as_any(&self) -> &::std::any::Any {
+        self as &::std::any::Any
+    }
+
     fn descriptor(&self) -> &'static ::protobuf::reflect::MessageDescriptor {
         ::protobuf::MessageStatic::descriptor_static(None::<Self>)
     }
@@ -5898,6 +5962,10 @@ impl ::protobuf::Message for MethodOptions {
 
     fn type_id(&self) -> ::std::any::TypeId {
         ::std::any::TypeId::of::<MethodOptions>()
+    }
+
+    fn as_any(&self) -> &::std::any::Any {
+        self as &::std::any::Any
     }
 
     fn descriptor(&self) -> &'static ::protobuf::reflect::MessageDescriptor {
@@ -6330,6 +6398,10 @@ impl ::protobuf::Message for UninterpretedOption {
         ::std::any::TypeId::of::<UninterpretedOption>()
     }
 
+    fn as_any(&self) -> &::std::any::Any {
+        self as &::std::any::Any
+    }
+
     fn descriptor(&self) -> &'static ::protobuf::reflect::MessageDescriptor {
         ::protobuf::MessageStatic::descriptor_static(None::<Self>)
     }
@@ -6592,6 +6664,10 @@ impl ::protobuf::Message for UninterpretedOption_NamePart {
         ::std::any::TypeId::of::<UninterpretedOption_NamePart>()
     }
 
+    fn as_any(&self) -> &::std::any::Any {
+        self as &::std::any::Any
+    }
+
     fn descriptor(&self) -> &'static ::protobuf::reflect::MessageDescriptor {
         ::protobuf::MessageStatic::descriptor_static(None::<Self>)
     }
@@ -6766,6 +6842,10 @@ impl ::protobuf::Message for SourceCodeInfo {
 
     fn type_id(&self) -> ::std::any::TypeId {
         ::std::any::TypeId::of::<SourceCodeInfo>()
+    }
+
+    fn as_any(&self) -> &::std::any::Any {
+        self as &::std::any::Any
     }
 
     fn descriptor(&self) -> &'static ::protobuf::reflect::MessageDescriptor {
@@ -7079,6 +7159,10 @@ impl ::protobuf::Message for SourceCodeInfo_Location {
 
     fn type_id(&self) -> ::std::any::TypeId {
         ::std::any::TypeId::of::<SourceCodeInfo_Location>()
+    }
+
+    fn as_any(&self) -> &::std::any::Any {
+        self as &::std::any::Any
     }
 
     fn descriptor(&self) -> &'static ::protobuf::reflect::MessageDescriptor {

--- a/src/lib/protobuf.rs
+++ b/src/lib/protobuf.rs
@@ -2,7 +2,6 @@
 
 // warnings
 #![feature(collections)]
-#![feature(core)]
 
 pub use unknown::UnknownFields;
 pub use unknown::UnknownValues;

--- a/src/lib/protobuf.rs
+++ b/src/lib/protobuf.rs
@@ -1,8 +1,5 @@
 #![crate_type = "lib"]
 
-// warnings
-#![feature(collections)]
-
 pub use unknown::UnknownFields;
 pub use unknown::UnknownValues;
 pub use unknown::UnknownValue;

--- a/src/lib/rt.rs
+++ b/src/lib/rt.rs
@@ -99,16 +99,16 @@ impl<E:ProtobufEnum> ProtobufVarint for E {
 
 // Size of serialized data, excluding length and tag
 pub fn vec_packed_varint_data_size<T : ProtobufVarint>(vec: &[T]) -> u32 {
-    vec.iter().map(|v| v.len_varint()).sum()
+    vec.iter().map(|v| v.len_varint()).fold(0, |a, i| a + i)
 }
 
 // Size of serialized data, excluding length and tag
 pub fn vec_packed_varint_zigzag_data_size<T : ProtobufVarintZigzag>(vec: &[T]) -> u32 {
-    vec.iter().map(|v| v.len_varint_zigzag()).sum()
+    vec.iter().map(|v| v.len_varint_zigzag()).fold(0, |a, i| a + i)
 }
 
 pub fn vec_packed_enum_data_size<E : ProtobufEnum>(vec: &[E]) -> u32 {
-    vec.iter().map(|e| compute_raw_varint32_size(e.value() as u32)).sum()
+    vec.iter().map(|e| compute_raw_varint32_size(e.value() as u32)).fold(0, |a, i| a + i)
 }
 
 // Size of serialized data with length prefix and tag

--- a/src/lib/singular.rs
+++ b/src/lib/singular.rs
@@ -1,4 +1,3 @@
-use std::slice;
 use std::option;
 use std::default::Default;
 use std::fmt;
@@ -71,25 +70,6 @@ impl<T> SingularField<T> {
     #[inline]
     pub fn get_mut_ref<'a>(&'a mut self) -> &'a mut T {
         self.as_mut().unwrap()
-    }
-
-    #[inline]
-    pub fn as_slice<'a>(&'a self) -> &'a [T] {
-        // XXX: workaround since returning &[] doesn't seem to work
-        let tmp: &[T] = &[];
-        match self.as_ref() {
-            Some(x) => slice::ref_slice(x),
-            None => tmp,
-        }
-    }
-
-    #[inline]
-    pub fn as_mut_slice<'a>(&'a mut self) -> &'a mut [T] {
-        match self.as_mut() {
-            //Some(x) => slice::mut_ref_slice(x), // doesn't work I have no idea why
-            Some(_) => panic!(),
-            None => &mut []
-        }
     }
 
     #[inline]
@@ -242,25 +222,6 @@ impl<T> SingularPtrField<T> {
     #[inline]
     pub fn get_mut_ref<'a>(&'a mut self) -> &'a mut T {
         self.as_mut().unwrap()
-    }
-
-    #[inline]
-    pub fn as_slice<'a>(&'a self) -> &'a [T] {
-        // XXX: workaround since returning &[] doesn't seem to work
-        let tmp: &[T] = &[];
-        match self.as_ref() {
-            Some(x) => slice::ref_slice(x),
-            None => tmp,
-        }
-    }
-
-    #[inline]
-    pub fn as_mut_slice<'a>(&'a mut self) -> &'a mut [T] {
-        match self.as_mut() {
-            //Some(x) => slice::mut_ref_slice(x), // doesn't work I have no idea why
-            Some(_) => panic!(),
-            None => &mut []
-        }
     }
 
     #[inline]

--- a/src/perftest/perftest_data.rs
+++ b/src/perftest/perftest_data.rs
@@ -119,6 +119,10 @@ impl ::protobuf::Message for Test1 {
         ::std::any::TypeId::of::<Test1>()
     }
 
+    fn as_any(&self) -> &::std::any::Any {
+        self as &::std::any::Any
+    }
+
     fn descriptor(&self) -> &'static ::protobuf::reflect::MessageDescriptor {
         ::protobuf::MessageStatic::descriptor_static(None::<Self>)
     }
@@ -281,6 +285,10 @@ impl ::protobuf::Message for TestRepeatedBool {
 
     fn type_id(&self) -> ::std::any::TypeId {
         ::std::any::TypeId::of::<TestRepeatedBool>()
+    }
+
+    fn as_any(&self) -> &::std::any::Any {
+        self as &::std::any::Any
     }
 
     fn descriptor(&self) -> &'static ::protobuf::reflect::MessageDescriptor {
@@ -451,6 +459,10 @@ impl ::protobuf::Message for TestRepeatedPackedInt32 {
 
     fn type_id(&self) -> ::std::any::TypeId {
         ::std::any::TypeId::of::<TestRepeatedPackedInt32>()
+    }
+
+    fn as_any(&self) -> &::std::any::Any {
+        self as &::std::any::Any
     }
 
     fn descriptor(&self) -> &'static ::protobuf::reflect::MessageDescriptor {
@@ -697,6 +709,10 @@ impl ::protobuf::Message for TestRepeatedMessages {
 
     fn type_id(&self) -> ::std::any::TypeId {
         ::std::any::TypeId::of::<TestRepeatedMessages>()
+    }
+
+    fn as_any(&self) -> &::std::any::Any {
+        self as &::std::any::Any
     }
 
     fn descriptor(&self) -> &'static ::protobuf::reflect::MessageDescriptor {
@@ -991,6 +1007,10 @@ impl ::protobuf::Message for TestOptionalMessages {
 
     fn type_id(&self) -> ::std::any::TypeId {
         ::std::any::TypeId::of::<TestOptionalMessages>()
+    }
+
+    fn as_any(&self) -> &::std::any::Any {
+        self as &::std::any::Any
     }
 
     fn descriptor(&self) -> &'static ::protobuf::reflect::MessageDescriptor {
@@ -1288,6 +1308,10 @@ impl ::protobuf::Message for TestStrings {
 
     fn type_id(&self) -> ::std::any::TypeId {
         ::std::any::TypeId::of::<TestStrings>()
+    }
+
+    fn as_any(&self) -> &::std::any::Any {
+        self as &::std::any::Any
     }
 
     fn descriptor(&self) -> &'static ::protobuf::reflect::MessageDescriptor {
@@ -1666,6 +1690,10 @@ impl ::protobuf::Message for PerftestData {
 
     fn type_id(&self) -> ::std::any::TypeId {
         ::std::any::TypeId::of::<PerftestData>()
+    }
+
+    fn as_any(&self) -> &::std::any::Any {
+        self as &::std::any::Any
     }
 
     fn descriptor(&self) -> &'static ::protobuf::reflect::MessageDescriptor {

--- a/src/plugin.rs
+++ b/src/plugin.rs
@@ -229,6 +229,10 @@ impl ::protobuf::Message for CodeGeneratorRequest {
         ::std::any::TypeId::of::<CodeGeneratorRequest>()
     }
 
+    fn as_any(&self) -> &::std::any::Any {
+        self as &::std::any::Any
+    }
+
     fn descriptor(&self) -> &'static ::protobuf::reflect::MessageDescriptor {
         ::protobuf::MessageStatic::descriptor_static(None::<Self>)
     }
@@ -459,6 +463,10 @@ impl ::protobuf::Message for CodeGeneratorResponse {
 
     fn type_id(&self) -> ::std::any::TypeId {
         ::std::any::TypeId::of::<CodeGeneratorResponse>()
+    }
+
+    fn as_any(&self) -> &::std::any::Any {
+        self as &::std::any::Any
     }
 
     fn descriptor(&self) -> &'static ::protobuf::reflect::MessageDescriptor {
@@ -748,6 +756,10 @@ impl ::protobuf::Message for CodeGeneratorResponse_File {
 
     fn type_id(&self) -> ::std::any::TypeId {
         ::std::any::TypeId::of::<CodeGeneratorResponse_File>()
+    }
+
+    fn as_any(&self) -> &::std::any::Any {
+        self as &::std::any::Any
     }
 
     fn descriptor(&self) -> &'static ::protobuf::reflect::MessageDescriptor {

--- a/src/test/lib.rs
+++ b/src/test/lib.rs
@@ -1,7 +1,3 @@
-#![feature(collections)]
-#![feature(core)]
-#![feature(convert)]
-
 extern crate protobuf;
 
 mod shrug;

--- a/src/test/text_format_test.rs
+++ b/src/test/text_format_test.rs
@@ -7,7 +7,7 @@ use protobuf::text_format::print_to_string;
 fn t<F : FnMut(&mut TestTypes)>(expected: &str, mut setter: F) {
     let mut m = TestTypes::new();
     setter(&mut m);
-    assert_eq!(print_to_string(&m).as_slice(), expected);
+    assert_eq!(&*print_to_string(&m), expected);
 }
 
 #[test]
@@ -48,7 +48,7 @@ fn test_repeated_one() {
     t("sfixed32_repeated: 99",    |m| m.mut_sfixed32_repeated().push(99));
     t("sfixed64_repeated: 99",    |m| m.mut_sfixed64_repeated().push(99));
     t("bool_repeated: false",     |m| m.mut_bool_repeated().push(false));
-    t("string_repeated: \"abc\"", |m| m.mut_string_repeated().push(String::from_str("abc")));
+    t("string_repeated: \"abc\"", |m| m.mut_string_repeated().push("abc".to_string()));
     t("bytes_repeated: \"def\"",  |m| m.mut_bytes_repeated().push(b"def".to_vec()));
     t("test_enum_repeated: DARK", |m| m.mut_test_enum_repeated().push(TestEnum::DARK));
     t("test_message_repeated {}", |m| { m.mut_test_message_repeated().push(Default::default()); });
@@ -72,5 +72,5 @@ fn test_complex_message() {
 fn test_show() {
     let mut m = TestTypes::new();
     m.set_bool_singular(true);
-    assert_eq!("bool_singular: true", format!("{:?}", m).as_slice());
+    assert_eq!("bool_singular: true", &*format!("{:?}", m));
 }


### PR DESCRIPTION
* make core.rs stable compatible by using generated as_any method
* remove usage of unstable std::iter::Iterator::sum()
* remove Singular[Ptr]Field::as_[mut_]slice()
* remove #![feature(collections)] by copying escape_default() into source

fix #94 \o/