### PR TITLE
Allow creating an element of a RepeatedField dynamically.

### DIFF
--- a/src/lib/repeated.rs
+++ b/src/lib/repeated.rs
@@ -13,6 +13,8 @@ use std::fmt;
 
 use clear::Clear;
 
+use core::MessageStatic;
+
 pub struct RepeatedField<T> {
     vec: Vec<T>,
     len: usize,
@@ -323,3 +325,11 @@ impl<T : fmt::Debug> fmt::Debug for RepeatedField<T> {
         self.as_ref().fmt(f)
     }
 }
+
+impl<T : MessageStatic> RepeatedField<T> {
+    #[inline]
+    pub fn create(&self) -> T {
+        MessageStatic::new()
+    }
+}
+


### PR DESCRIPTION
This PR lets you instantiate a new element of the correct type to be added to a `RepeatedField`. Note that the object is not added to the field. You mist still fill it and call `RepeatedField::push` 

I need this feature to implement a macro which simplifies initialization of protobuf messages.
For example :
```
let msg = protobuf_init!(foo::Foo::new(), {
    bar => {
        qux: 5,
        baz => [
            @{ quux: 3 },
            @{ quux: 4 },
        ]
    }
});
```

The problem is that the expansion is done too early to have any type information. This means I have no way of knowing the type of `Foo.bar.baz`. For normal nested objects I can call `mut_xxx` which gives me a default initialized object of the correct type. However this is not possible for repeated fields, hence this PR.

If you're interested my plugin is here : https://github.com/plietar/rust-protobuf-macros. It is still lacking docs.
It has a similar `protobuf_bind` which does the opposite.