### PR TITLE
Fixed built protoc-gen-rust's initial path

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ plugin for protoc.
 3) Add `protoc-gen-rust` to $PATH:
 
 ```
-PATH="`pwd`/target:$PATH"
+PATH="`pwd`/target/debug:$PATH"
 ```
 
 4) Generate .rs files:


### PR DESCRIPTION
By default cargo does debug builds, with ```cargo build --release``` target/debug should become target/release.