### PR TITLE
Make sure to only create valid module names

### DIFF
--- a/src/lib/codegen.rs
+++ b/src/lib/codegen.rs
@@ -2203,11 +2203,28 @@ impl<'a> EnumContext<'a> {
 
 }
 
+// Copy-pasted from libsyntax.
+fn ident_start(c: char) -> bool {
+    (c >= 'a' && c <= 'z')
+        || (c >= 'A' && c <= 'Z')
+        || c == '_'
+}
+
+// Copy-pasted from libsyntax.
+fn ident_continue(c: char) -> bool {
+    (c >= 'a' && c <= 'z')
+        || (c >= 'A' && c <= 'Z')
+        || (c >= '0' && c <= '9')
+        || c == '_'
+}
 
 fn proto_path_to_rust_base(path: &str) -> String {
     let without_dir = remove_to(path, '/');
     let without_suffix = remove_suffix(without_dir, ".proto");
-    without_suffix.replace("-", "_")
+    without_suffix.chars().enumerate().map(|(i, c)| {
+        let valid = if i == 0 { ident_start(c) } else { ident_continue(c) };
+        if valid { c } else { '_' }
+    }).collect()
 }
 
 pub struct GenResult {

--- a/src/proto/test_special~characters file{name}.proto
+++ b/src/proto/test_special~characters file{name}.proto
@@ -1,0 +1,9 @@
+// More test that filenames are sanitized, even imports.
+
+package special;
+
+import "test_なんでやねん.proto";
+
+message Outer {
+	optional Inner inner = 1;
+}

--- a/src/proto/test_なんでやねん.proto
+++ b/src/proto/test_なんでやねん.proto
@@ -1,0 +1,7 @@
+// More test that filenames are sanitized, even imports.
+
+package special;
+
+message Inner {
+	optional int32 foo = 1;
+}

--- a/src/test/lib.rs
+++ b/src/test/lib.rs
@@ -12,5 +12,7 @@ mod text_format_test;
 mod text_format_test_data;
 mod test_oneof;
 mod test_oneof_proto;
+mod test_special_characters_file_name_;
+mod test_______;
 
 mod test;


### PR DESCRIPTION
All characters that are not valid identifiers are replaced by an
underscore. The validity check has been copy-pasted from libsyntax.

This change introduces a new dependency: unicode-xid, as the functions
that are included in the stdlib are unstable and will not work on stable
rust releases.

Side note: we should probably split the codegen part from the runtime part,
so not all users of protobuf have to pay for all dependencies needed to
generate them.

Fixes #111