### PR TITLE
Add full_name to MessageDescriptor

### DIFF
--- a/src/lib/reflect/mod.rs
+++ b/src/lib/reflect/mod.rs
@@ -179,6 +179,7 @@ impl<M : 'static + Message + Default> MessageFactory for MessageFactoryTyped<M> 
 }
 
 pub struct MessageDescriptor {
+    full_name: String,
     proto: &'static DescriptorProto,
     factory: Box<MessageFactory + 'static>,
     fields: Vec<FieldDescriptor>,
@@ -212,7 +213,14 @@ impl MessageDescriptor {
             index_by_name.insert(f.get_name().to_string(), i);
         }
 
+        let mut full_name = file.get_package().to_string();
+        if full_name.len() > 0 {
+            full_name.push('.');
+        }
+        full_name.push_str(proto.message.get_name());
+
         MessageDescriptor {
+            full_name: full_name,
             proto: proto.message,
             factory: Box::new(MessageFactoryTyped::<M>::new()),
             fields: fields.into_iter()
@@ -232,6 +240,10 @@ impl MessageDescriptor {
 
     pub fn name(&self) -> &'static str {
         self.proto.get_name()
+    }
+
+    pub fn full_name(&self) -> &str {
+        &self.full_name[..]
     }
 
     pub fn fields<'a>(&'a self) -> &'a [FieldDescriptor] {

--- a/src/test/test.rs
+++ b/src/test/test.rs
@@ -209,6 +209,7 @@ fn test_message_descriptor() {
 
     let d = reflect::MessageDescriptor::for_type::<TestDescriptor>();
     assert_eq!("TestDescriptor", d.name());
+    assert_eq!("shrug.TestDescriptor", d.full_name());
 
     let mut t = TestDescriptor::new();
     t.set_stuff(55);


### PR DESCRIPTION
On the analogy of:
https://developers.google.com/protocol-buffers/docs/reference/java/com/google/protobuf/Descriptors.Descriptor#getFullName()
I have also added a test for it.