### PR TITLE
Added example of basic I/O

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,6 +89,10 @@ Have a look at generated files, used internally in rust-protobuf:
 * [descriptor.rs](https://github.com/stepancheg/rust-protobuf/blob/master/src/lib/descriptor.rs)
   for [descriptor.proto](https://github.com/stepancheg/rust-protobuf/blob/master/src/proto/google/protobuf/descriptor.proto)
   (that is part of Google protobuf)
+  
+Also see `examples/basic.proto` and its output `examples/basicproto/mod.rs` for
+a simpler example, and `examples/basic.rs` for some example input / output using
+a protocol buffer.
 
 ## TODO
 

--- a/examples/basic.proto
+++ b/examples/basic.proto
@@ -1,0 +1,4 @@
+message BasicMessage {
+    optional string name = 1;
+    repeated double data = 2;
+}

--- a/examples/basic.rs
+++ b/examples/basic.rs
@@ -1,0 +1,80 @@
+/*!
+An example of basic I/O with rust-protobuf. Takes a protocol (basic.proto), compiles it, and then
+takes a message round-trip through either a file or a Vec<u8>.
+
+First, we use ./build-examples.sh to generate 'basicproto/mod.rs' and compile this example.
+*/
+
+extern crate protobuf;
+
+use protobuf::{Message,MessageStatic};
+use std::error::Error;
+use std::path::Path;
+
+mod basicproto;
+use basicproto::BasicMessage;
+
+/// Put a message in a file
+fn to_file<M: Message>(message: M, path: &Path) -> Result<(), Box<Error>> {
+    let mut buf = try!(std::fs::File::create(path));
+    Ok(try!(message.write_to_writer(&mut buf)))
+}
+
+/// Read a message from a file
+fn from_file<M: MessageStatic>(path: &Path) -> Result<M, Box<Error>> {
+    let mut buf = try!(std::fs::File::open(path));
+    Ok(try!(protobuf::parse_from_reader::<M>(&mut buf)))
+}
+
+/// Put a message in a buffer (Vec<u8>)
+fn to_vec<M: Message>(message: M) -> Result<Vec<u8>, Box<Error>> {
+    let mut buf : Vec<u8> = Vec::new();
+    try!(message.write_to_writer(&mut buf));
+    Ok(buf)
+}
+
+/// Read a message in a buffer (Vec<u8>)
+fn from_vec<M: MessageStatic>(buf: Vec<u8>) -> Result<M, Box<Error>> {
+    let mut read_buf = std::io::Cursor::new(buf);
+    Ok(try!(protobuf::parse_from_reader::<M>(&mut read_buf)))
+}
+
+fn main() {
+    // Let's make a message, so that we can send it or not, as we please
+    let mut message = BasicMessage::new();
+    message.set_name("Name Field!".to_owned());
+    message.set_data(vec![2.,3.,5.,7.,11.,13.,17.,19.]);
+    
+    println!("We start with the message:");
+    println!("    {:?}", message);
+    
+    let mut args = std::env::args();
+    let _ = args.next();
+    let (path_str, result) = match args.next() {
+        None => {
+            // We were not given a path, so we dump the message to a Vec, and then read it
+            // back from that Vec
+            ("Vec<u8>".to_owned(), to_vec(message)
+                .and_then(|vec| {from_vec::<BasicMessage>(vec)}))
+            }
+        Some(s) => {
+            // We got a path on the command-line, so we dump the message to that file, and then
+            // read it back from that file
+            let s_copy = s.clone();
+            let path = Path::new(&s_copy);
+            (s, to_file(message, path)
+                .and_then(|_| {from_file(path)}))
+        }
+    };
+    
+    match result {
+        Ok(message) => {
+            println!("After a round-trip to {}, we have the message:", path_str);
+            println!("    {:?}", message);
+        }
+        Err(e) => {
+            println!("We had an error on a round-trip to {}!", path_str);
+            println!("{}", e);
+        }
+    }
+}

--- a/examples/basicproto/mod.rs
+++ b/examples/basicproto/mod.rs
@@ -1,0 +1,271 @@
+// This file is generated. Do not edit
+// @generated
+
+#![allow(dead_code)]
+#![allow(non_camel_case_types)]
+#![allow(non_snake_case)]
+#![allow(non_upper_case_globals)]
+#![allow(unused_imports)]
+
+use protobuf::Message as Message_imported_for_functions;
+use protobuf::ProtobufEnum as ProtobufEnum_imported_for_functions;
+
+#[derive(Clone,Default)]
+pub struct BasicMessage {
+    // message fields
+    name: ::protobuf::SingularField<::std::string::String>,
+    data: ::std::vec::Vec<f64>,
+    // special fields
+    unknown_fields: ::protobuf::UnknownFields,
+    cached_size: ::std::cell::Cell<u32>,
+}
+
+impl BasicMessage {
+    pub fn new() -> BasicMessage {
+        ::std::default::Default::default()
+    }
+
+    pub fn default_instance() -> &'static BasicMessage {
+        static mut instance: ::protobuf::lazy::Lazy<BasicMessage> = ::protobuf::lazy::Lazy {
+            lock: ::protobuf::lazy::ONCE_INIT,
+            ptr: 0 as *const BasicMessage,
+        };
+        unsafe {
+            instance.get(|| {
+                BasicMessage {
+                    name: ::protobuf::SingularField::none(),
+                    data: ::std::vec::Vec::new(),
+                    unknown_fields: ::protobuf::UnknownFields::new(),
+                    cached_size: ::std::cell::Cell::new(0),
+                }
+            })
+        }
+    }
+
+    // optional string name = 1;
+
+    pub fn clear_name(&mut self) {
+        self.name.clear();
+    }
+
+    pub fn has_name(&self) -> bool {
+        self.name.is_some()
+    }
+
+    // Param is passed by value, moved
+    pub fn set_name(&mut self, v: ::std::string::String) {
+        self.name = ::protobuf::SingularField::some(v);
+    }
+
+    // Mutable pointer to the field.
+    // If field is not initialized, it is initialized with default value first.
+    pub fn mut_name<'a>(&'a mut self) -> &'a mut ::std::string::String {
+        if self.name.is_none() {
+            self.name.set_default();
+        };
+        self.name.as_mut().unwrap()
+    }
+
+    // Take field
+    pub fn take_name(&mut self) -> ::std::string::String {
+        self.name.take().unwrap_or_else(|| ::std::string::String::new())
+    }
+
+    pub fn get_name<'a>(&'a self) -> &'a str {
+        match self.name.as_ref() {
+            Some(v) => &v,
+            None => "",
+        }
+    }
+
+    // repeated double data = 2;
+
+    pub fn clear_data(&mut self) {
+        self.data.clear();
+    }
+
+    // Param is passed by value, moved
+    pub fn set_data(&mut self, v: ::std::vec::Vec<f64>) {
+        self.data = v;
+    }
+
+    // Mutable pointer to the field.
+    pub fn mut_data<'a>(&'a mut self) -> &'a mut ::std::vec::Vec<f64> {
+        &mut self.data
+    }
+
+    // Take field
+    pub fn take_data(&mut self) -> ::std::vec::Vec<f64> {
+        ::std::mem::replace(&mut self.data, ::std::vec::Vec::new())
+    }
+
+    pub fn get_data<'a>(&'a self) -> &'a [f64] {
+        &self.data
+    }
+}
+
+impl ::protobuf::Message for BasicMessage {
+    fn is_initialized(&self) -> bool {
+        true
+    }
+
+    fn merge_from(&mut self, is: &mut ::protobuf::CodedInputStream) -> ::protobuf::ProtobufResult<()> {
+        while !try!(is.eof()) {
+            let (field_number, wire_type) = try!(is.read_tag_unpack());
+            match field_number {
+                1 => {
+                    if wire_type != ::protobuf::wire_format::WireTypeLengthDelimited {
+                        return ::std::result::Result::Err(::protobuf::ProtobufError::WireError("unexpected wire type".to_string()));
+                    };
+                    let tmp = self.name.set_default();
+                    try!(is.read_string_into(tmp))
+                },
+                2 => {
+                    try!(::protobuf::rt::read_repeated_double_into(wire_type, is, &mut self.data));
+                },
+                _ => {
+                    let unknown = try!(is.read_unknown(wire_type));
+                    self.mut_unknown_fields().add_value(field_number, unknown);
+                },
+            };
+        }
+        ::std::result::Result::Ok(())
+    }
+
+    // Compute sizes of nested messages
+    #[allow(unused_variables)]
+    fn compute_size(&self) -> u32 {
+        let mut my_size = 0;
+        for value in self.name.iter() {
+            my_size += ::protobuf::rt::string_size(1, &value);
+        };
+        my_size += 9 * self.data.len() as u32;
+        my_size += ::protobuf::rt::unknown_fields_size(self.get_unknown_fields());
+        self.cached_size.set(my_size);
+        my_size
+    }
+
+    fn write_to_with_cached_sizes(&self, os: &mut ::protobuf::CodedOutputStream) -> ::protobuf::ProtobufResult<()> {
+        if let Some(v) = self.name.as_ref() {
+            try!(os.write_string(1, &v));
+        };
+        for v in self.data.iter() {
+            try!(os.write_double(2, *v));
+        };
+        try!(os.write_unknown_fields(self.get_unknown_fields()));
+        ::std::result::Result::Ok(())
+    }
+
+    fn get_cached_size(&self) -> u32 {
+        self.cached_size.get()
+    }
+
+    fn get_unknown_fields<'s>(&'s self) -> &'s ::protobuf::UnknownFields {
+        &self.unknown_fields
+    }
+
+    fn mut_unknown_fields<'s>(&'s mut self) -> &'s mut ::protobuf::UnknownFields {
+        &mut self.unknown_fields
+    }
+
+    fn type_id(&self) -> ::std::any::TypeId {
+        ::std::any::TypeId::of::<BasicMessage>()
+    }
+
+    fn as_any(&self) -> &::std::any::Any {
+        self as &::std::any::Any
+    }
+
+    fn descriptor(&self) -> &'static ::protobuf::reflect::MessageDescriptor {
+        ::protobuf::MessageStatic::descriptor_static(None::<Self>)
+    }
+}
+
+impl ::protobuf::MessageStatic for BasicMessage {
+    fn new() -> BasicMessage {
+        BasicMessage::new()
+    }
+
+    fn descriptor_static(_: ::std::option::Option<BasicMessage>) -> &'static ::protobuf::reflect::MessageDescriptor {
+        static mut descriptor: ::protobuf::lazy::Lazy<::protobuf::reflect::MessageDescriptor> = ::protobuf::lazy::Lazy {
+            lock: ::protobuf::lazy::ONCE_INIT,
+            ptr: 0 as *const ::protobuf::reflect::MessageDescriptor,
+        };
+        unsafe {
+            descriptor.get(|| {
+                let mut fields = ::std::vec::Vec::new();
+                fields.push(::protobuf::reflect::accessor::make_singular_string_accessor(
+                    "name",
+                    BasicMessage::has_name,
+                    BasicMessage::get_name,
+                ));
+                fields.push(::protobuf::reflect::accessor::make_repeated_f64_accessor(
+                    "data",
+                    BasicMessage::get_data,
+                ));
+                ::protobuf::reflect::MessageDescriptor::new::<BasicMessage>(
+                    "BasicMessage",
+                    fields,
+                    file_descriptor_proto()
+                )
+            })
+        }
+    }
+}
+
+impl ::protobuf::Clear for BasicMessage {
+    fn clear(&mut self) {
+        self.clear_name();
+        self.clear_data();
+        self.unknown_fields.clear();
+    }
+}
+
+impl ::std::cmp::PartialEq for BasicMessage {
+    fn eq(&self, other: &BasicMessage) -> bool {
+        self.name == other.name &&
+        self.data == other.data &&
+        self.unknown_fields == other.unknown_fields
+    }
+}
+
+impl ::std::fmt::Debug for BasicMessage {
+    fn fmt(&self, f: &mut ::std::fmt::Formatter) -> ::std::fmt::Result {
+        ::protobuf::text_format::fmt(self, f)
+    }
+}
+
+static file_descriptor_proto_data: &'static [u8] = &[
+    0x0a, 0x0b, 0x62, 0x61, 0x73, 0x69, 0x63, 0x2e, 0x70, 0x72, 0x6f, 0x74, 0x6f, 0x22, 0x2a, 0x0a,
+    0x0c, 0x42, 0x61, 0x73, 0x69, 0x63, 0x4d, 0x65, 0x73, 0x73, 0x61, 0x67, 0x65, 0x12, 0x0c, 0x0a,
+    0x04, 0x6e, 0x61, 0x6d, 0x65, 0x18, 0x01, 0x20, 0x01, 0x28, 0x09, 0x12, 0x0c, 0x0a, 0x04, 0x64,
+    0x61, 0x74, 0x61, 0x18, 0x02, 0x20, 0x03, 0x28, 0x01, 0x4a, 0xaa, 0x01, 0x0a, 0x06, 0x12, 0x04,
+    0x00, 0x00, 0x03, 0x01, 0x0a, 0x0a, 0x0a, 0x02, 0x04, 0x00, 0x12, 0x04, 0x00, 0x00, 0x03, 0x01,
+    0x0a, 0x0a, 0x0a, 0x03, 0x04, 0x00, 0x01, 0x12, 0x03, 0x00, 0x08, 0x14, 0x0a, 0x0b, 0x0a, 0x04,
+    0x04, 0x00, 0x02, 0x00, 0x12, 0x03, 0x01, 0x04, 0x1d, 0x0a, 0x0c, 0x0a, 0x05, 0x04, 0x00, 0x02,
+    0x00, 0x04, 0x12, 0x03, 0x01, 0x04, 0x0c, 0x0a, 0x0c, 0x0a, 0x05, 0x04, 0x00, 0x02, 0x00, 0x05,
+    0x12, 0x03, 0x01, 0x0d, 0x13, 0x0a, 0x0c, 0x0a, 0x05, 0x04, 0x00, 0x02, 0x00, 0x01, 0x12, 0x03,
+    0x01, 0x14, 0x18, 0x0a, 0x0c, 0x0a, 0x05, 0x04, 0x00, 0x02, 0x00, 0x03, 0x12, 0x03, 0x01, 0x1b,
+    0x1c, 0x0a, 0x0b, 0x0a, 0x04, 0x04, 0x00, 0x02, 0x01, 0x12, 0x03, 0x02, 0x04, 0x1d, 0x0a, 0x0c,
+    0x0a, 0x05, 0x04, 0x00, 0x02, 0x01, 0x04, 0x12, 0x03, 0x02, 0x04, 0x0c, 0x0a, 0x0c, 0x0a, 0x05,
+    0x04, 0x00, 0x02, 0x01, 0x05, 0x12, 0x03, 0x02, 0x0d, 0x13, 0x0a, 0x0c, 0x0a, 0x05, 0x04, 0x00,
+    0x02, 0x01, 0x01, 0x12, 0x03, 0x02, 0x14, 0x18, 0x0a, 0x0c, 0x0a, 0x05, 0x04, 0x00, 0x02, 0x01,
+    0x03, 0x12, 0x03, 0x02, 0x1b, 0x1c,
+];
+
+static mut file_descriptor_proto_lazy: ::protobuf::lazy::Lazy<::protobuf::descriptor::FileDescriptorProto> = ::protobuf::lazy::Lazy {
+    lock: ::protobuf::lazy::ONCE_INIT,
+    ptr: 0 as *const ::protobuf::descriptor::FileDescriptorProto,
+};
+
+fn parse_descriptor_proto() -> ::protobuf::descriptor::FileDescriptorProto {
+    ::protobuf::parse_from_bytes(file_descriptor_proto_data).unwrap()
+}
+
+pub fn file_descriptor_proto() -> &'static ::protobuf::descriptor::FileDescriptorProto {
+    unsafe {
+        file_descriptor_proto_lazy.get(|| {
+            parse_descriptor_proto()
+        })
+    }
+}

--- a/examples/build-examples.sh
+++ b/examples/build-examples.sh
@@ -1,0 +1,12 @@
+#!/bin/sh -ex
+
+where_am_i=$(cd "$(dirname "$0")/.."; pwd)
+PATH="$where_am_i/target/debug:$PATH"
+
+cd "$where_am_i/examples"
+
+mkdir -p basicproto
+protoc --rust_out basicproto basic.proto
+mv basicproto/basic.rs basicproto/mod.rs
+
+cargo build --example basic


### PR DESCRIPTION
When I first came across your library,I quickly caught on as to how to create a `.proto` file, transform it into a rust module, and use its messages as objects; however, I was still a little confused as to how to dump it to a buffer. As I played around and tested it, I realized I could make that an example file, so I did that; this is the result.
