### PR TITLE
Rename oneofs named "type."

### DIFF
--- a/src/lib/codegen.rs
+++ b/src/lib/codegen.rs
@@ -1070,7 +1070,10 @@ impl<'a> OneofContext<'a> {
     }
 
     fn name(&self) -> &str {
-        self.oneof.oneof.get_name()
+        match self.oneof.oneof.get_name() {
+            "type" => "field_type",
+            x => x,
+        }
     }
 
     fn variants(&'a self) -> Vec<OneofVariantContext<'a>> {

--- a/src/lib/descriptorx.rs
+++ b/src/lib/descriptorx.rs
@@ -313,7 +313,10 @@ pub struct OneofVariantWithContext<'a> {
 
 impl<'a> OneofVariantWithContext<'a> {
     pub fn field_name(&self) -> &str {
-        self.field.get_name()
+        match self.field.get_name() {
+            "type" => "field_type",
+            x => x,
+        }
     }
 }
 

--- a/src/lib/descriptorx.rs
+++ b/src/lib/descriptorx.rs
@@ -327,7 +327,10 @@ pub struct OneofWithContext<'a> {
 
 impl<'a> OneofWithContext<'a> {
     pub fn name(&'a self) -> &'a str {
-        self.oneof.get_name()
+        match self.oneof.get_name() {
+            "type" => "field_type",
+            x => x,
+        }
     }
 
     // rust type name of enum


### PR DESCRIPTION
This fixes #124!

I found it a little odd that I had to change both of these methods since one seems like it ought to be a wrapper for the other. However, one of them affected the name of the field in the struct definition and one of them affected how the field appeared when being read or written in methods (i.e. `self.type` --> `self.field_type`).

Normally I would add regression tests for any code I make, but there doesn't seem to be much precedent for tests in this project outside of helper modules, so I'm not sure how to approach it. Let me know if you have any guidelines for testing this!