### PR TITLE
Avoid unnecessary formatting.

### DIFF
--- a/src/lib/code_writer.rs
+++ b/src/lib/code_writer.rs
@@ -12,7 +12,7 @@ impl<'a> CodeWriter<'a> {
     pub fn new(writer: &'a mut Write) -> CodeWriter<'a> {
         CodeWriter {
             writer: writer,
-            indent: "".to_string(),
+            indent: String::new(),
         }
     }
 
@@ -62,7 +62,7 @@ impl<'a> CodeWriter<'a> {
         self.unsafe_expr(|w| {
             w.write_line(format!("{}.get(|| {{", name.as_ref()));
             w.indented(|w| init(w));
-            w.write_line(format!("}})"));
+            w.write_line("})");
         });
     }
 
@@ -221,7 +221,7 @@ impl<'a> CodeWriter<'a> {
 
     pub fn error_wire_type(&mut self, _wire_type: wire_format::WireType) {
         // TODO: write wire type
-        let message = "\"unexpected wire type\".to_string()";
+        let message = "\"unexpected wire type\".to_owned()";
         self.write_line(format!(
                 "return ::std::result::Result::Err(::protobuf::ProtobufError::WireError({}));",
                 message));

--- a/src/lib/codegen.rs
+++ b/src/lib/codegen.rs
@@ -158,18 +158,18 @@ impl RustType {
     // default value for type
     fn default_value(&self) -> String {
         match *self {
-            RustType::Ref(ref t) if t.is_str()       => "\"\"".to_string(),
-            RustType::Ref(ref t) if t.is_slice()     => "&[]".to_string(),
+            RustType::Ref(ref t) if t.is_str()       => "\"\"".to_owned(),
+            RustType::Ref(ref t) if t.is_slice()     => "&[]".to_owned(),
             RustType::Signed(..)                     |
-            RustType::Unsigned(..)                   => "0".to_string(),
-            RustType::Float(..)                      => "0.".to_string(),
-            RustType::Bool(..)                       => "false".to_string(),
-            RustType::Vec(..)                        => "::std::vec::Vec::new()".to_string(),
-            RustType::String                         => "::std::string::String::new()".to_string(),
-            RustType::Option(..)                     => "::std::option::Option::None".to_string(),
-            RustType::SingularField(..)              => "::protobuf::SingularField::none()".to_string(),
-            RustType::SingularPtrField(..)           => "::protobuf::SingularPtrField::none()".to_string(),
-            RustType::RepeatedField(..)              => "::protobuf::RepeatedField::new()".to_string(),
+            RustType::Unsigned(..)                   => "0".to_owned(),
+            RustType::Float(..)                      => "0.".to_owned(),
+            RustType::Bool(..)                       => "false".to_owned(),
+            RustType::Vec(..)                        => "::std::vec::Vec::new()".to_owned(),
+            RustType::String                         => "::std::string::String::new()".to_owned(),
+            RustType::Option(..)                     => "::std::option::Option::None".to_owned(),
+            RustType::SingularField(..)              => "::protobuf::SingularField::none()".to_owned(),
+            RustType::SingularPtrField(..)           => "::protobuf::SingularPtrField::none()".to_owned(),
+            RustType::RepeatedField(..)              => "::protobuf::RepeatedField::new()".to_owned(),
             RustType::Message(ref name)              => format!("{}::new()", name),
             RustType::Ref(ref m) if m.is_message()   => match **m {
                 RustType::Message(ref name) => format!("{}::default_instance()", name),
@@ -392,10 +392,10 @@ fn field_type_size(field_type: FieldDescriptorProto_Type) -> Option<u32> {
 
 fn field_type_name_scope_prefix(field: &FieldDescriptorProto, pkg: &str) -> String {
     if !field.has_type_name() {
-        return "".to_string();
+        return String::new();
     }
     let current_pkg_prefix = if pkg.is_empty() {
-        ".".to_string()
+        ".".to_owned()
     } else {
         format!(".{}.", pkg)
     };
@@ -403,18 +403,18 @@ fn field_type_name_scope_prefix(field: &FieldDescriptorProto, pkg: &str) -> Stri
         let mut tn = remove_prefix(field.get_type_name(), &current_pkg_prefix).to_string();
         match tn.rfind('.') {
             Some(pos) => { tn.truncate(pos + 1); tn }.replace(".", "_"),
-            None => "".to_string(),
+            None => String::new(),
         }
     } else {
         // TODO: package prefix
-        "".to_string()
+        String::new()
     }
 }
 
 fn field_type_name(field: &FieldDescriptorProto, pkg: &str) -> RustType {
     if field.has_type_name() {
         let current_pkg_prefix = if pkg.is_empty() {
-            ".".to_string()
+            ".".to_owned()
         } else {
             format!(".{}.", pkg)
         };
@@ -483,7 +483,7 @@ impl Field {
             FieldDescriptorProto_Label::LABEL_REQUIRED => false,
         };
         let name = match field.field.get_name() {
-            "type" => "field_type".to_string(),
+            "type" => "field_type".to_owned(),
             x => x.to_string(),
         };
         let packed =
@@ -756,10 +756,10 @@ impl Field {
         };
         let suffix = match &self.type_name {
             t if t.is_primitive()                     => format!("{}", t),
-            &RustType::String                         => "string".to_string(),
-            &RustType::Vec(ref t) if t.is_u8()        => "bytes".to_string(),
-            &RustType::Enum(..)                       => "enum".to_string(),
-            &RustType::Message(..)                    => "message".to_string(),
+            &RustType::String                         => "string".to_owned(),
+            &RustType::Vec(ref t) if t.is_u8()        => "bytes".to_owned(),
+            &RustType::Enum(..)                       => "enum".to_owned(),
+            &RustType::Message(..)                    => "message".to_owned(),
             t => panic!("unexpected field type: {}", t),
         };
         format!("make_{}_{}_accessor", repeated_or_signular, suffix)
@@ -969,7 +969,7 @@ impl Field {
     fn self_field_vec_packed_varint_data_size(&self) -> String {
         assert!(!self.is_fixed());
         let fn_name = if self.is_enum() {
-            "vec_packed_enum_data_size".to_string()
+            "vec_packed_enum_data_size".to_owned()
         } else {
             let zigzag_suffix = if self.is_zigzag() { "_zigzag" } else { "" };
             format!("vec_packed_varint{}_data_size", zigzag_suffix)
@@ -999,7 +999,7 @@ impl Field {
         // zero is filtered outside
         assert!(!self.is_fixed());
         let fn_name = if self.is_enum() {
-            "vec_packed_enum_size".to_string()
+            "vec_packed_enum_size".to_owned()
         } else {
             let zigzag_suffix = if self.is_zigzag() { "_zigzag" } else { "" };
             format!("vec_packed_varint{}_size", zigzag_suffix)
@@ -1492,7 +1492,7 @@ impl<'a> MessageContext<'a> {
                 w.expr_block(format!("{}", self.type_name), |w| {
                     for field in self.fields_except_oneof() {
                         let init = field.full_storage_type().default_value();
-                        w.field_entry(field.name.to_string(), init);
+                        w.field_entry(field.name.to_owned(), init);
                     }
                     for oneof in self.oneofs() {
                         let init = oneof.full_storage_type().default_value();
@@ -1593,9 +1593,9 @@ impl<'a> MessageContext<'a> {
     }
 
     fn write_merge_from(&self, w: &mut CodeWriter) {
-        w.def_fn(format!("merge_from(&mut self, is: &mut ::protobuf::CodedInputStream) -> ::protobuf::ProtobufResult<()>"), |w| {
+        w.def_fn("merge_from(&mut self, is: &mut ::protobuf::CodedInputStream) -> ::protobuf::ProtobufResult<()>".to_owned(), |w| {
             w.while_block("!try!(is.eof())", |w| {
-                w.write_line(format!("let (field_number, wire_type) = try!(is.read_tag_unpack());"));
+                w.write_line("let (field_number, wire_type) = try!(is.read_tag_unpack());".to_owned());
                 w.match_block("field_number", |w| {
                     for f in &self.fields {
                         let number = f.number;
@@ -1617,9 +1617,9 @@ impl<'a> MessageContext<'a> {
         w.def_fn(format!("descriptor_static(_: ::std::option::Option<{}>) -> &'static ::protobuf::reflect::MessageDescriptor", self.type_name), |w| {
             w.lazy_static_decl_get("descriptor", "::protobuf::reflect::MessageDescriptor", |w| {
                 if self.fields.is_empty() {
-                    w.write_line(format!("let fields = ::std::vec::Vec::new();"));
+                    w.write_line("let fields = ::std::vec::Vec::new();".to_owned());
                 } else {
-                    w.write_line(format!("let mut fields = ::std::vec::Vec::new();"));
+                    w.write_line("let mut fields = ::std::vec::Vec::new();".to_owned());
                 }
                 for field in self.fields.iter() {
                     w.write_line(format!("fields.push(::protobuf::reflect::accessor::{}(", field.make_accessor_fn()));
@@ -1649,7 +1649,7 @@ impl<'a> MessageContext<'a> {
 
     fn write_impl_message(&self, w: &mut CodeWriter) {
         w.impl_for_block("::protobuf::Message", &self.type_name, |w| {
-            w.def_fn(format!("is_initialized(&self) -> bool"), |w| {
+            w.def_fn("is_initialized(&self) -> bool".to_owned(), |w| {
                 for f in self.required_fields() {
                     f.write_if_self_field_is_none(w, |w| {
                         w.write_line("return false;");
@@ -1908,7 +1908,7 @@ impl<'a> EnumContext<'a> {
                         w.write_line(format!("{} => ::std::option::Option::Some({}),",
                             value.number(), value.rust_name_outer()));
                     }
-                    w.write_line(format!("_ => ::std::option::Option::None"));
+                    w.write_line("_ => ::std::option::Option::None".to_owned());
                 });
             });
             if !self.lite_runtime {

--- a/src/lib/descriptor.rs
+++ b/src/lib/descriptor.rs
@@ -557,14 +557,14 @@ impl ::protobuf::Message for FileDescriptorProto {
             match field_number {
                 1 => {
                     if wire_type != ::protobuf::wire_format::WireTypeLengthDelimited {
-                        return ::std::result::Result::Err(::protobuf::ProtobufError::WireError("unexpected wire type".to_string()));
+                        return ::std::result::Result::Err(::protobuf::ProtobufError::WireError("unexpected wire type".to_owned()));
                     };
                     let tmp = self.name.set_default();
                     try!(is.read_string_into(tmp))
                 },
                 2 => {
                     if wire_type != ::protobuf::wire_format::WireTypeLengthDelimited {
-                        return ::std::result::Result::Err(::protobuf::ProtobufError::WireError("unexpected wire type".to_string()));
+                        return ::std::result::Result::Err(::protobuf::ProtobufError::WireError("unexpected wire type".to_owned()));
                     };
                     let tmp = self.package.set_default();
                     try!(is.read_string_into(tmp))
@@ -592,14 +592,14 @@ impl ::protobuf::Message for FileDescriptorProto {
                 },
                 8 => {
                     if wire_type != ::protobuf::wire_format::WireTypeLengthDelimited {
-                        return ::std::result::Result::Err(::protobuf::ProtobufError::WireError("unexpected wire type".to_string()));
+                        return ::std::result::Result::Err(::protobuf::ProtobufError::WireError("unexpected wire type".to_owned()));
                     };
                     let tmp = self.options.set_default();
                     try!(is.merge_message(tmp))
                 },
                 9 => {
                     if wire_type != ::protobuf::wire_format::WireTypeLengthDelimited {
-                        return ::std::result::Result::Err(::protobuf::ProtobufError::WireError("unexpected wire type".to_string()));
+                        return ::std::result::Result::Err(::protobuf::ProtobufError::WireError("unexpected wire type".to_owned()));
                     };
                     let tmp = self.source_code_info.set_default();
                     try!(is.merge_message(tmp))
@@ -1122,7 +1122,7 @@ impl ::protobuf::Message for DescriptorProto {
             match field_number {
                 1 => {
                     if wire_type != ::protobuf::wire_format::WireTypeLengthDelimited {
-                        return ::std::result::Result::Err(::protobuf::ProtobufError::WireError("unexpected wire type".to_string()));
+                        return ::std::result::Result::Err(::protobuf::ProtobufError::WireError("unexpected wire type".to_owned()));
                     };
                     let tmp = self.name.set_default();
                     try!(is.read_string_into(tmp))
@@ -1147,7 +1147,7 @@ impl ::protobuf::Message for DescriptorProto {
                 },
                 7 => {
                     if wire_type != ::protobuf::wire_format::WireTypeLengthDelimited {
-                        return ::std::result::Result::Err(::protobuf::ProtobufError::WireError("unexpected wire type".to_string()));
+                        return ::std::result::Result::Err(::protobuf::ProtobufError::WireError("unexpected wire type".to_owned()));
                     };
                     let tmp = self.options.set_default();
                     try!(is.merge_message(tmp))
@@ -1442,14 +1442,14 @@ impl ::protobuf::Message for DescriptorProto_ExtensionRange {
             match field_number {
                 1 => {
                     if wire_type != ::protobuf::wire_format::WireTypeVarint {
-                        return ::std::result::Result::Err(::protobuf::ProtobufError::WireError("unexpected wire type".to_string()));
+                        return ::std::result::Result::Err(::protobuf::ProtobufError::WireError("unexpected wire type".to_owned()));
                     };
                     let tmp = try!(is.read_int32());
                     self.start = ::std::option::Option::Some(tmp);
                 },
                 2 => {
                     if wire_type != ::protobuf::wire_format::WireTypeVarint {
-                        return ::std::result::Result::Err(::protobuf::ProtobufError::WireError("unexpected wire type".to_string()));
+                        return ::std::result::Result::Err(::protobuf::ProtobufError::WireError("unexpected wire type".to_owned()));
                     };
                     let tmp = try!(is.read_int32());
                     self.end = ::std::option::Option::Some(tmp);
@@ -1880,63 +1880,63 @@ impl ::protobuf::Message for FieldDescriptorProto {
             match field_number {
                 1 => {
                     if wire_type != ::protobuf::wire_format::WireTypeLengthDelimited {
-                        return ::std::result::Result::Err(::protobuf::ProtobufError::WireError("unexpected wire type".to_string()));
+                        return ::std::result::Result::Err(::protobuf::ProtobufError::WireError("unexpected wire type".to_owned()));
                     };
                     let tmp = self.name.set_default();
                     try!(is.read_string_into(tmp))
                 },
                 3 => {
                     if wire_type != ::protobuf::wire_format::WireTypeVarint {
-                        return ::std::result::Result::Err(::protobuf::ProtobufError::WireError("unexpected wire type".to_string()));
+                        return ::std::result::Result::Err(::protobuf::ProtobufError::WireError("unexpected wire type".to_owned()));
                     };
                     let tmp = try!(is.read_int32());
                     self.number = ::std::option::Option::Some(tmp);
                 },
                 4 => {
                     if wire_type != ::protobuf::wire_format::WireTypeVarint {
-                        return ::std::result::Result::Err(::protobuf::ProtobufError::WireError("unexpected wire type".to_string()));
+                        return ::std::result::Result::Err(::protobuf::ProtobufError::WireError("unexpected wire type".to_owned()));
                     };
                     let tmp = try!(is.read_enum());
                     self.label = ::std::option::Option::Some(tmp);
                 },
                 5 => {
                     if wire_type != ::protobuf::wire_format::WireTypeVarint {
-                        return ::std::result::Result::Err(::protobuf::ProtobufError::WireError("unexpected wire type".to_string()));
+                        return ::std::result::Result::Err(::protobuf::ProtobufError::WireError("unexpected wire type".to_owned()));
                     };
                     let tmp = try!(is.read_enum());
                     self.field_type = ::std::option::Option::Some(tmp);
                 },
                 6 => {
                     if wire_type != ::protobuf::wire_format::WireTypeLengthDelimited {
-                        return ::std::result::Result::Err(::protobuf::ProtobufError::WireError("unexpected wire type".to_string()));
+                        return ::std::result::Result::Err(::protobuf::ProtobufError::WireError("unexpected wire type".to_owned()));
                     };
                     let tmp = self.type_name.set_default();
                     try!(is.read_string_into(tmp))
                 },
                 2 => {
                     if wire_type != ::protobuf::wire_format::WireTypeLengthDelimited {
-                        return ::std::result::Result::Err(::protobuf::ProtobufError::WireError("unexpected wire type".to_string()));
+                        return ::std::result::Result::Err(::protobuf::ProtobufError::WireError("unexpected wire type".to_owned()));
                     };
                     let tmp = self.extendee.set_default();
                     try!(is.read_string_into(tmp))
                 },
                 7 => {
                     if wire_type != ::protobuf::wire_format::WireTypeLengthDelimited {
-                        return ::std::result::Result::Err(::protobuf::ProtobufError::WireError("unexpected wire type".to_string()));
+                        return ::std::result::Result::Err(::protobuf::ProtobufError::WireError("unexpected wire type".to_owned()));
                     };
                     let tmp = self.default_value.set_default();
                     try!(is.read_string_into(tmp))
                 },
                 9 => {
                     if wire_type != ::protobuf::wire_format::WireTypeVarint {
-                        return ::std::result::Result::Err(::protobuf::ProtobufError::WireError("unexpected wire type".to_string()));
+                        return ::std::result::Result::Err(::protobuf::ProtobufError::WireError("unexpected wire type".to_owned()));
                     };
                     let tmp = try!(is.read_int32());
                     self.oneof_index = ::std::option::Option::Some(tmp);
                 },
                 8 => {
                     if wire_type != ::protobuf::wire_format::WireTypeLengthDelimited {
-                        return ::std::result::Result::Err(::protobuf::ProtobufError::WireError("unexpected wire type".to_string()));
+                        return ::std::result::Result::Err(::protobuf::ProtobufError::WireError("unexpected wire type".to_owned()));
                     };
                     let tmp = self.options.set_default();
                     try!(is.merge_message(tmp))
@@ -2332,7 +2332,7 @@ impl ::protobuf::Message for OneofDescriptorProto {
             match field_number {
                 1 => {
                     if wire_type != ::protobuf::wire_format::WireTypeLengthDelimited {
-                        return ::std::result::Result::Err(::protobuf::ProtobufError::WireError("unexpected wire type".to_string()));
+                        return ::std::result::Result::Err(::protobuf::ProtobufError::WireError("unexpected wire type".to_owned()));
                     };
                     let tmp = self.name.set_default();
                     try!(is.read_string_into(tmp))
@@ -2579,7 +2579,7 @@ impl ::protobuf::Message for EnumDescriptorProto {
             match field_number {
                 1 => {
                     if wire_type != ::protobuf::wire_format::WireTypeLengthDelimited {
-                        return ::std::result::Result::Err(::protobuf::ProtobufError::WireError("unexpected wire type".to_string()));
+                        return ::std::result::Result::Err(::protobuf::ProtobufError::WireError("unexpected wire type".to_owned()));
                     };
                     let tmp = self.name.set_default();
                     try!(is.read_string_into(tmp))
@@ -2589,7 +2589,7 @@ impl ::protobuf::Message for EnumDescriptorProto {
                 },
                 3 => {
                     if wire_type != ::protobuf::wire_format::WireTypeLengthDelimited {
-                        return ::std::result::Result::Err(::protobuf::ProtobufError::WireError("unexpected wire type".to_string()));
+                        return ::std::result::Result::Err(::protobuf::ProtobufError::WireError("unexpected wire type".to_owned()));
                     };
                     let tmp = self.options.set_default();
                     try!(is.merge_message(tmp))
@@ -2861,21 +2861,21 @@ impl ::protobuf::Message for EnumValueDescriptorProto {
             match field_number {
                 1 => {
                     if wire_type != ::protobuf::wire_format::WireTypeLengthDelimited {
-                        return ::std::result::Result::Err(::protobuf::ProtobufError::WireError("unexpected wire type".to_string()));
+                        return ::std::result::Result::Err(::protobuf::ProtobufError::WireError("unexpected wire type".to_owned()));
                     };
                     let tmp = self.name.set_default();
                     try!(is.read_string_into(tmp))
                 },
                 2 => {
                     if wire_type != ::protobuf::wire_format::WireTypeVarint {
-                        return ::std::result::Result::Err(::protobuf::ProtobufError::WireError("unexpected wire type".to_string()));
+                        return ::std::result::Result::Err(::protobuf::ProtobufError::WireError("unexpected wire type".to_owned()));
                     };
                     let tmp = try!(is.read_int32());
                     self.number = ::std::option::Option::Some(tmp);
                 },
                 3 => {
                     if wire_type != ::protobuf::wire_format::WireTypeLengthDelimited {
-                        return ::std::result::Result::Err(::protobuf::ProtobufError::WireError("unexpected wire type".to_string()));
+                        return ::std::result::Result::Err(::protobuf::ProtobufError::WireError("unexpected wire type".to_owned()));
                     };
                     let tmp = self.options.set_default();
                     try!(is.merge_message(tmp))
@@ -3151,7 +3151,7 @@ impl ::protobuf::Message for ServiceDescriptorProto {
             match field_number {
                 1 => {
                     if wire_type != ::protobuf::wire_format::WireTypeLengthDelimited {
-                        return ::std::result::Result::Err(::protobuf::ProtobufError::WireError("unexpected wire type".to_string()));
+                        return ::std::result::Result::Err(::protobuf::ProtobufError::WireError("unexpected wire type".to_owned()));
                     };
                     let tmp = self.name.set_default();
                     try!(is.read_string_into(tmp))
@@ -3161,7 +3161,7 @@ impl ::protobuf::Message for ServiceDescriptorProto {
                 },
                 3 => {
                     if wire_type != ::protobuf::wire_format::WireTypeLengthDelimited {
-                        return ::std::result::Result::Err(::protobuf::ProtobufError::WireError("unexpected wire type".to_string()));
+                        return ::std::result::Result::Err(::protobuf::ProtobufError::WireError("unexpected wire type".to_owned()));
                     };
                     let tmp = self.options.set_default();
                     try!(is.merge_message(tmp))
@@ -3488,28 +3488,28 @@ impl ::protobuf::Message for MethodDescriptorProto {
             match field_number {
                 1 => {
                     if wire_type != ::protobuf::wire_format::WireTypeLengthDelimited {
-                        return ::std::result::Result::Err(::protobuf::ProtobufError::WireError("unexpected wire type".to_string()));
+                        return ::std::result::Result::Err(::protobuf::ProtobufError::WireError("unexpected wire type".to_owned()));
                     };
                     let tmp = self.name.set_default();
                     try!(is.read_string_into(tmp))
                 },
                 2 => {
                     if wire_type != ::protobuf::wire_format::WireTypeLengthDelimited {
-                        return ::std::result::Result::Err(::protobuf::ProtobufError::WireError("unexpected wire type".to_string()));
+                        return ::std::result::Result::Err(::protobuf::ProtobufError::WireError("unexpected wire type".to_owned()));
                     };
                     let tmp = self.input_type.set_default();
                     try!(is.read_string_into(tmp))
                 },
                 3 => {
                     if wire_type != ::protobuf::wire_format::WireTypeLengthDelimited {
-                        return ::std::result::Result::Err(::protobuf::ProtobufError::WireError("unexpected wire type".to_string()));
+                        return ::std::result::Result::Err(::protobuf::ProtobufError::WireError("unexpected wire type".to_owned()));
                     };
                     let tmp = self.output_type.set_default();
                     try!(is.read_string_into(tmp))
                 },
                 4 => {
                     if wire_type != ::protobuf::wire_format::WireTypeLengthDelimited {
-                        return ::std::result::Result::Err(::protobuf::ProtobufError::WireError("unexpected wire type".to_string()));
+                        return ::std::result::Result::Err(::protobuf::ProtobufError::WireError("unexpected wire type".to_owned()));
                     };
                     let tmp = self.options.set_default();
                     try!(is.merge_message(tmp))
@@ -4007,77 +4007,77 @@ impl ::protobuf::Message for FileOptions {
             match field_number {
                 1 => {
                     if wire_type != ::protobuf::wire_format::WireTypeLengthDelimited {
-                        return ::std::result::Result::Err(::protobuf::ProtobufError::WireError("unexpected wire type".to_string()));
+                        return ::std::result::Result::Err(::protobuf::ProtobufError::WireError("unexpected wire type".to_owned()));
                     };
                     let tmp = self.java_package.set_default();
                     try!(is.read_string_into(tmp))
                 },
                 8 => {
                     if wire_type != ::protobuf::wire_format::WireTypeLengthDelimited {
-                        return ::std::result::Result::Err(::protobuf::ProtobufError::WireError("unexpected wire type".to_string()));
+                        return ::std::result::Result::Err(::protobuf::ProtobufError::WireError("unexpected wire type".to_owned()));
                     };
                     let tmp = self.java_outer_classname.set_default();
                     try!(is.read_string_into(tmp))
                 },
                 10 => {
                     if wire_type != ::protobuf::wire_format::WireTypeVarint {
-                        return ::std::result::Result::Err(::protobuf::ProtobufError::WireError("unexpected wire type".to_string()));
+                        return ::std::result::Result::Err(::protobuf::ProtobufError::WireError("unexpected wire type".to_owned()));
                     };
                     let tmp = try!(is.read_bool());
                     self.java_multiple_files = ::std::option::Option::Some(tmp);
                 },
                 20 => {
                     if wire_type != ::protobuf::wire_format::WireTypeVarint {
-                        return ::std::result::Result::Err(::protobuf::ProtobufError::WireError("unexpected wire type".to_string()));
+                        return ::std::result::Result::Err(::protobuf::ProtobufError::WireError("unexpected wire type".to_owned()));
                     };
                     let tmp = try!(is.read_bool());
                     self.java_generate_equals_and_hash = ::std::option::Option::Some(tmp);
                 },
                 27 => {
                     if wire_type != ::protobuf::wire_format::WireTypeVarint {
-                        return ::std::result::Result::Err(::protobuf::ProtobufError::WireError("unexpected wire type".to_string()));
+                        return ::std::result::Result::Err(::protobuf::ProtobufError::WireError("unexpected wire type".to_owned()));
                     };
                     let tmp = try!(is.read_bool());
                     self.java_string_check_utf8 = ::std::option::Option::Some(tmp);
                 },
                 9 => {
                     if wire_type != ::protobuf::wire_format::WireTypeVarint {
-                        return ::std::result::Result::Err(::protobuf::ProtobufError::WireError("unexpected wire type".to_string()));
+                        return ::std::result::Result::Err(::protobuf::ProtobufError::WireError("unexpected wire type".to_owned()));
                     };
                     let tmp = try!(is.read_enum());
                     self.optimize_for = ::std::option::Option::Some(tmp);
                 },
                 11 => {
                     if wire_type != ::protobuf::wire_format::WireTypeLengthDelimited {
-                        return ::std::result::Result::Err(::protobuf::ProtobufError::WireError("unexpected wire type".to_string()));
+                        return ::std::result::Result::Err(::protobuf::ProtobufError::WireError("unexpected wire type".to_owned()));
                     };
                     let tmp = self.go_package.set_default();
                     try!(is.read_string_into(tmp))
                 },
                 16 => {
                     if wire_type != ::protobuf::wire_format::WireTypeVarint {
-                        return ::std::result::Result::Err(::protobuf::ProtobufError::WireError("unexpected wire type".to_string()));
+                        return ::std::result::Result::Err(::protobuf::ProtobufError::WireError("unexpected wire type".to_owned()));
                     };
                     let tmp = try!(is.read_bool());
                     self.cc_generic_services = ::std::option::Option::Some(tmp);
                 },
                 17 => {
                     if wire_type != ::protobuf::wire_format::WireTypeVarint {
-                        return ::std::result::Result::Err(::protobuf::ProtobufError::WireError("unexpected wire type".to_string()));
+                        return ::std::result::Result::Err(::protobuf::ProtobufError::WireError("unexpected wire type".to_owned()));
                     };
                     let tmp = try!(is.read_bool());
                     self.java_generic_services = ::std::option::Option::Some(tmp);
                 },
                 18 => {
                     if wire_type != ::protobuf::wire_format::WireTypeVarint {
-                        return ::std::result::Result::Err(::protobuf::ProtobufError::WireError("unexpected wire type".to_string()));
+                        return ::std::result::Result::Err(::protobuf::ProtobufError::WireError("unexpected wire type".to_owned()));
                     };
                     let tmp = try!(is.read_bool());
                     self.py_generic_services = ::std::option::Option::Some(tmp);
                 },
                 23 => {
                     if wire_type != ::protobuf::wire_format::WireTypeVarint {
-                        return ::std::result::Result::Err(::protobuf::ProtobufError::WireError("unexpected wire type".to_string()));
+                        return ::std::result::Result::Err(::protobuf::ProtobufError::WireError("unexpected wire type".to_owned()));
                     };
                     let tmp = try!(is.read_bool());
                     self.deprecated = ::std::option::Option::Some(tmp);
@@ -4499,21 +4499,21 @@ impl ::protobuf::Message for MessageOptions {
             match field_number {
                 1 => {
                     if wire_type != ::protobuf::wire_format::WireTypeVarint {
-                        return ::std::result::Result::Err(::protobuf::ProtobufError::WireError("unexpected wire type".to_string()));
+                        return ::std::result::Result::Err(::protobuf::ProtobufError::WireError("unexpected wire type".to_owned()));
                     };
                     let tmp = try!(is.read_bool());
                     self.message_set_wire_format = ::std::option::Option::Some(tmp);
                 },
                 2 => {
                     if wire_type != ::protobuf::wire_format::WireTypeVarint {
-                        return ::std::result::Result::Err(::protobuf::ProtobufError::WireError("unexpected wire type".to_string()));
+                        return ::std::result::Result::Err(::protobuf::ProtobufError::WireError("unexpected wire type".to_owned()));
                     };
                     let tmp = try!(is.read_bool());
                     self.no_standard_descriptor_accessor = ::std::option::Option::Some(tmp);
                 },
                 3 => {
                     if wire_type != ::protobuf::wire_format::WireTypeVarint {
-                        return ::std::result::Result::Err(::protobuf::ProtobufError::WireError("unexpected wire type".to_string()));
+                        return ::std::result::Result::Err(::protobuf::ProtobufError::WireError("unexpected wire type".to_owned()));
                     };
                     let tmp = try!(is.read_bool());
                     self.deprecated = ::std::option::Option::Some(tmp);
@@ -4874,42 +4874,42 @@ impl ::protobuf::Message for FieldOptions {
             match field_number {
                 1 => {
                     if wire_type != ::protobuf::wire_format::WireTypeVarint {
-                        return ::std::result::Result::Err(::protobuf::ProtobufError::WireError("unexpected wire type".to_string()));
+                        return ::std::result::Result::Err(::protobuf::ProtobufError::WireError("unexpected wire type".to_owned()));
                     };
                     let tmp = try!(is.read_enum());
                     self.ctype = ::std::option::Option::Some(tmp);
                 },
                 2 => {
                     if wire_type != ::protobuf::wire_format::WireTypeVarint {
-                        return ::std::result::Result::Err(::protobuf::ProtobufError::WireError("unexpected wire type".to_string()));
+                        return ::std::result::Result::Err(::protobuf::ProtobufError::WireError("unexpected wire type".to_owned()));
                     };
                     let tmp = try!(is.read_bool());
                     self.packed = ::std::option::Option::Some(tmp);
                 },
                 5 => {
                     if wire_type != ::protobuf::wire_format::WireTypeVarint {
-                        return ::std::result::Result::Err(::protobuf::ProtobufError::WireError("unexpected wire type".to_string()));
+                        return ::std::result::Result::Err(::protobuf::ProtobufError::WireError("unexpected wire type".to_owned()));
                     };
                     let tmp = try!(is.read_bool());
                     self.lazy = ::std::option::Option::Some(tmp);
                 },
                 3 => {
                     if wire_type != ::protobuf::wire_format::WireTypeVarint {
-                        return ::std::result::Result::Err(::protobuf::ProtobufError::WireError("unexpected wire type".to_string()));
+                        return ::std::result::Result::Err(::protobuf::ProtobufError::WireError("unexpected wire type".to_owned()));
                     };
                     let tmp = try!(is.read_bool());
                     self.deprecated = ::std::option::Option::Some(tmp);
                 },
                 9 => {
                     if wire_type != ::protobuf::wire_format::WireTypeLengthDelimited {
-                        return ::std::result::Result::Err(::protobuf::ProtobufError::WireError("unexpected wire type".to_string()));
+                        return ::std::result::Result::Err(::protobuf::ProtobufError::WireError("unexpected wire type".to_owned()));
                     };
                     let tmp = self.experimental_map_key.set_default();
                     try!(is.read_string_into(tmp))
                 },
                 10 => {
                     if wire_type != ::protobuf::wire_format::WireTypeVarint {
-                        return ::std::result::Result::Err(::protobuf::ProtobufError::WireError("unexpected wire type".to_string()));
+                        return ::std::result::Result::Err(::protobuf::ProtobufError::WireError("unexpected wire type".to_owned()));
                     };
                     let tmp = try!(is.read_bool());
                     self.weak = ::std::option::Option::Some(tmp);
@@ -5245,14 +5245,14 @@ impl ::protobuf::Message for EnumOptions {
             match field_number {
                 2 => {
                     if wire_type != ::protobuf::wire_format::WireTypeVarint {
-                        return ::std::result::Result::Err(::protobuf::ProtobufError::WireError("unexpected wire type".to_string()));
+                        return ::std::result::Result::Err(::protobuf::ProtobufError::WireError("unexpected wire type".to_owned()));
                     };
                     let tmp = try!(is.read_bool());
                     self.allow_alias = ::std::option::Option::Some(tmp);
                 },
                 3 => {
                     if wire_type != ::protobuf::wire_format::WireTypeVarint {
-                        return ::std::result::Result::Err(::protobuf::ProtobufError::WireError("unexpected wire type".to_string()));
+                        return ::std::result::Result::Err(::protobuf::ProtobufError::WireError("unexpected wire type".to_owned()));
                     };
                     let tmp = try!(is.read_bool());
                     self.deprecated = ::std::option::Option::Some(tmp);
@@ -5478,7 +5478,7 @@ impl ::protobuf::Message for EnumValueOptions {
             match field_number {
                 1 => {
                     if wire_type != ::protobuf::wire_format::WireTypeVarint {
-                        return ::std::result::Result::Err(::protobuf::ProtobufError::WireError("unexpected wire type".to_string()));
+                        return ::std::result::Result::Err(::protobuf::ProtobufError::WireError("unexpected wire type".to_owned()));
                     };
                     let tmp = try!(is.read_bool());
                     self.deprecated = ::std::option::Option::Some(tmp);
@@ -5691,7 +5691,7 @@ impl ::protobuf::Message for ServiceOptions {
             match field_number {
                 33 => {
                     if wire_type != ::protobuf::wire_format::WireTypeVarint {
-                        return ::std::result::Result::Err(::protobuf::ProtobufError::WireError("unexpected wire type".to_string()));
+                        return ::std::result::Result::Err(::protobuf::ProtobufError::WireError("unexpected wire type".to_owned()));
                     };
                     let tmp = try!(is.read_bool());
                     self.deprecated = ::std::option::Option::Some(tmp);
@@ -5904,7 +5904,7 @@ impl ::protobuf::Message for MethodOptions {
             match field_number {
                 33 => {
                     if wire_type != ::protobuf::wire_format::WireTypeVarint {
-                        return ::std::result::Result::Err(::protobuf::ProtobufError::WireError("unexpected wire type".to_string()));
+                        return ::std::result::Result::Err(::protobuf::ProtobufError::WireError("unexpected wire type".to_owned()));
                     };
                     let tmp = try!(is.read_bool());
                     self.deprecated = ::std::option::Option::Some(tmp);
@@ -6276,42 +6276,42 @@ impl ::protobuf::Message for UninterpretedOption {
                 },
                 3 => {
                     if wire_type != ::protobuf::wire_format::WireTypeLengthDelimited {
-                        return ::std::result::Result::Err(::protobuf::ProtobufError::WireError("unexpected wire type".to_string()));
+                        return ::std::result::Result::Err(::protobuf::ProtobufError::WireError("unexpected wire type".to_owned()));
                     };
                     let tmp = self.identifier_value.set_default();
                     try!(is.read_string_into(tmp))
                 },
                 4 => {
                     if wire_type != ::protobuf::wire_format::WireTypeVarint {
-                        return ::std::result::Result::Err(::protobuf::ProtobufError::WireError("unexpected wire type".to_string()));
+                        return ::std::result::Result::Err(::protobuf::ProtobufError::WireError("unexpected wire type".to_owned()));
                     };
                     let tmp = try!(is.read_uint64());
                     self.positive_int_value = ::std::option::Option::Some(tmp);
                 },
                 5 => {
                     if wire_type != ::protobuf::wire_format::WireTypeVarint {
-                        return ::std::result::Result::Err(::protobuf::ProtobufError::WireError("unexpected wire type".to_string()));
+                        return ::std::result::Result::Err(::protobuf::ProtobufError::WireError("unexpected wire type".to_owned()));
                     };
                     let tmp = try!(is.read_int64());
                     self.negative_int_value = ::std::option::Option::Some(tmp);
                 },
                 6 => {
                     if wire_type != ::protobuf::wire_format::WireTypeFixed64 {
-                        return ::std::result::Result::Err(::protobuf::ProtobufError::WireError("unexpected wire type".to_string()));
+                        return ::std::result::Result::Err(::protobuf::ProtobufError::WireError("unexpected wire type".to_owned()));
                     };
                     let tmp = try!(is.read_double());
                     self.double_value = ::std::option::Option::Some(tmp);
                 },
                 7 => {
                     if wire_type != ::protobuf::wire_format::WireTypeLengthDelimited {
-                        return ::std::result::Result::Err(::protobuf::ProtobufError::WireError("unexpected wire type".to_string()));
+                        return ::std::result::Result::Err(::protobuf::ProtobufError::WireError("unexpected wire type".to_owned()));
                     };
                     let tmp = self.string_value.set_default();
                     try!(is.read_bytes_into(tmp))
                 },
                 8 => {
                     if wire_type != ::protobuf::wire_format::WireTypeLengthDelimited {
-                        return ::std::result::Result::Err(::protobuf::ProtobufError::WireError("unexpected wire type".to_string()));
+                        return ::std::result::Result::Err(::protobuf::ProtobufError::WireError("unexpected wire type".to_owned()));
                     };
                     let tmp = self.aggregate_value.set_default();
                     try!(is.read_string_into(tmp))
@@ -6603,14 +6603,14 @@ impl ::protobuf::Message for UninterpretedOption_NamePart {
             match field_number {
                 1 => {
                     if wire_type != ::protobuf::wire_format::WireTypeLengthDelimited {
-                        return ::std::result::Result::Err(::protobuf::ProtobufError::WireError("unexpected wire type".to_string()));
+                        return ::std::result::Result::Err(::protobuf::ProtobufError::WireError("unexpected wire type".to_owned()));
                     };
                     let tmp = self.name_part.set_default();
                     try!(is.read_string_into(tmp))
                 },
                 2 => {
                     if wire_type != ::protobuf::wire_format::WireTypeVarint {
-                        return ::std::result::Result::Err(::protobuf::ProtobufError::WireError("unexpected wire type".to_string()));
+                        return ::std::result::Result::Err(::protobuf::ProtobufError::WireError("unexpected wire type".to_owned()));
                     };
                     let tmp = try!(is.read_bool());
                     self.is_extension = ::std::option::Option::Some(tmp);
@@ -7078,14 +7078,14 @@ impl ::protobuf::Message for SourceCodeInfo_Location {
                 },
                 3 => {
                     if wire_type != ::protobuf::wire_format::WireTypeLengthDelimited {
-                        return ::std::result::Result::Err(::protobuf::ProtobufError::WireError("unexpected wire type".to_string()));
+                        return ::std::result::Result::Err(::protobuf::ProtobufError::WireError("unexpected wire type".to_owned()));
                     };
                     let tmp = self.leading_comments.set_default();
                     try!(is.read_string_into(tmp))
                 },
                 4 => {
                     if wire_type != ::protobuf::wire_format::WireTypeLengthDelimited {
-                        return ::std::result::Result::Err(::protobuf::ProtobufError::WireError("unexpected wire type".to_string()));
+                        return ::std::result::Result::Err(::protobuf::ProtobufError::WireError("unexpected wire type".to_owned()));
                     };
                     let tmp = self.trailing_comments.set_default();
                     try!(is.read_string_into(tmp))

--- a/src/lib/descriptorx.rs
+++ b/src/lib/descriptorx.rs
@@ -168,7 +168,7 @@ impl<'a> Scope<'a> {
 
     pub fn prefix(&self) -> String {
         if self.path.is_empty() {
-            "".to_string()
+            String::new()
         } else {
             let v: Vec<&'a str> = self.path.iter().map(|m| m.get_name()).collect();
             let mut r = v.connect(".");

--- a/src/lib/hex.rs
+++ b/src/lib/hex.rs
@@ -64,9 +64,9 @@ mod test {
 
     #[test]
     fn test_encode_hex() {
-        assert_eq!("".to_string(), encode_hex(&[]));
-        assert_eq!("00".to_string(), encode_hex(&[0x00]));
-        assert_eq!("ab".to_string(), encode_hex(&[0xab]));
-        assert_eq!("01 a2 1a fe".to_string(), encode_hex(&[0x01, 0xa2, 0x1a, 0xfe]));
+        assert_eq!("".to_owned(), encode_hex(&[]));
+        assert_eq!("00".to_owned(), encode_hex(&[0x00]));
+        assert_eq!("ab".to_owned(), encode_hex(&[0xab]));
+        assert_eq!("01 a2 1a fe".to_owned(), encode_hex(&[0x01, 0xa2, 0x1a, 0xfe]));
     }
 }

--- a/src/lib/plugin.rs
+++ b/src/lib/plugin.rs
@@ -163,7 +163,7 @@ impl ::protobuf::Message for CodeGeneratorRequest {
                 },
                 2 => {
                     if wire_type != ::protobuf::wire_format::WireTypeLengthDelimited {
-                        return ::std::result::Result::Err(::protobuf::ProtobufError::WireError("unexpected wire type".to_string()));
+                        return ::std::result::Result::Err(::protobuf::ProtobufError::WireError("unexpected wire type".to_owned()));
                     };
                     let tmp = self.parameter.set_default();
                     try!(is.read_string_into(tmp))
@@ -405,7 +405,7 @@ impl ::protobuf::Message for CodeGeneratorResponse {
             match field_number {
                 1 => {
                     if wire_type != ::protobuf::wire_format::WireTypeLengthDelimited {
-                        return ::std::result::Result::Err(::protobuf::ProtobufError::WireError("unexpected wire type".to_string()));
+                        return ::std::result::Result::Err(::protobuf::ProtobufError::WireError("unexpected wire type".to_owned()));
                     };
                     let tmp = self.error.set_default();
                     try!(is.read_string_into(tmp))
@@ -684,21 +684,21 @@ impl ::protobuf::Message for CodeGeneratorResponse_File {
             match field_number {
                 1 => {
                     if wire_type != ::protobuf::wire_format::WireTypeLengthDelimited {
-                        return ::std::result::Result::Err(::protobuf::ProtobufError::WireError("unexpected wire type".to_string()));
+                        return ::std::result::Result::Err(::protobuf::ProtobufError::WireError("unexpected wire type".to_owned()));
                     };
                     let tmp = self.name.set_default();
                     try!(is.read_string_into(tmp))
                 },
                 2 => {
                     if wire_type != ::protobuf::wire_format::WireTypeLengthDelimited {
-                        return ::std::result::Result::Err(::protobuf::ProtobufError::WireError("unexpected wire type".to_string()));
+                        return ::std::result::Result::Err(::protobuf::ProtobufError::WireError("unexpected wire type".to_owned()));
                     };
                     let tmp = self.insertion_point.set_default();
                     try!(is.read_string_into(tmp))
                 },
                 15 => {
                     if wire_type != ::protobuf::wire_format::WireTypeLengthDelimited {
-                        return ::std::result::Result::Err(::protobuf::ProtobufError::WireError("unexpected wire type".to_string()));
+                        return ::std::result::Result::Err(::protobuf::ProtobufError::WireError("unexpected wire type".to_owned()));
                     };
                     let tmp = self.content.set_default();
                     try!(is.read_string_into(tmp))

--- a/src/lib/repeated.rs
+++ b/src/lib/repeated.rs
@@ -350,9 +350,9 @@ mod test {
     #[test]
     fn push_default() {
         let mut v = RepeatedField::new();
-        v.push("aa".to_string());
-        v.push("bb".to_string());
+        v.push("aa".to_owned());
+        v.push("bb".to_owned());
         v.clear();
-        assert_eq!("".to_string(), *v.push_default());
+        assert_eq!("".to_owned(), *v.push_default());
     }
 }

--- a/src/lib/rt.rs
+++ b/src/lib/rt.rs
@@ -208,7 +208,7 @@ pub fn read_repeated_int32_into(wire_type: WireType, is: &mut CodedInputStream, 
     match wire_type {
         WireTypeLengthDelimited => is.read_repeated_packed_int32_into(target),
         WireTypeVarint => { target.push(try!(is.read_int32())); Ok(()) },
-        _ => Err(ProtobufError::WireError("unexpected wire type".to_string())),
+        _ => Err(ProtobufError::WireError("unexpected wire type".to_owned())),
     }
 }
 
@@ -218,7 +218,7 @@ pub fn read_repeated_int64_into(wire_type: WireType, is: &mut CodedInputStream, 
     match wire_type {
         WireTypeLengthDelimited => is.read_repeated_packed_int64_into(target),
         WireTypeVarint => { target.push(try!(is.read_int64())); Ok(()) },
-        _ => Err(ProtobufError::WireError("unexpected wire type".to_string())),
+        _ => Err(ProtobufError::WireError("unexpected wire type".to_owned())),
     }
 }
 
@@ -228,7 +228,7 @@ pub fn read_repeated_uint32_into(wire_type: WireType, is: &mut CodedInputStream,
     match wire_type {
         WireTypeLengthDelimited => is.read_repeated_packed_uint32_into(target),
         WireTypeVarint => { target.push(try!(is.read_uint32())); Ok(()) },
-        _ => Err(ProtobufError::WireError("unexpected wire type".to_string())),
+        _ => Err(ProtobufError::WireError("unexpected wire type".to_owned())),
     }
 }
 
@@ -238,7 +238,7 @@ pub fn read_repeated_uint64_into(wire_type: WireType, is: &mut CodedInputStream,
     match wire_type {
         WireTypeLengthDelimited => is.read_repeated_packed_uint64_into(target),
         WireTypeVarint => { target.push(try!(is.read_uint64())); Ok(()) },
-        _ => Err(ProtobufError::WireError("unexpected wire type".to_string())),
+        _ => Err(ProtobufError::WireError("unexpected wire type".to_owned())),
     }
 }
 
@@ -248,7 +248,7 @@ pub fn read_repeated_sint32_into(wire_type: WireType, is: &mut CodedInputStream,
     match wire_type {
         WireTypeLengthDelimited => is.read_repeated_packed_sint32_into(target),
         WireTypeVarint => { target.push(try!(is.read_sint32())); Ok(()) },
-        _ => Err(ProtobufError::WireError("unexpected wire type".to_string())),
+        _ => Err(ProtobufError::WireError("unexpected wire type".to_owned())),
     }
 }
 
@@ -258,7 +258,7 @@ pub fn read_repeated_sint64_into(wire_type: WireType, is: &mut CodedInputStream,
     match wire_type {
         WireTypeLengthDelimited => is.read_repeated_packed_sint64_into(target),
         WireTypeVarint => { target.push(try!(is.read_sint64())); Ok(()) },
-        _ => Err(ProtobufError::WireError("unexpected wire type".to_string())),
+        _ => Err(ProtobufError::WireError("unexpected wire type".to_owned())),
     }
 }
 
@@ -268,7 +268,7 @@ pub fn read_repeated_fixed32_into(wire_type: WireType, is: &mut CodedInputStream
     match wire_type {
         WireTypeLengthDelimited => is.read_repeated_packed_fixed32_into(target),
         WireTypeFixed32 => { target.push(try!(is.read_fixed32())); Ok(()) },
-        _ => Err(ProtobufError::WireError("unexpected wire type".to_string())),
+        _ => Err(ProtobufError::WireError("unexpected wire type".to_owned())),
     }
 }
 
@@ -278,7 +278,7 @@ pub fn read_repeated_fixed64_into(wire_type: WireType, is: &mut CodedInputStream
     match wire_type {
         WireTypeLengthDelimited => is.read_repeated_packed_fixed64_into(target),
         WireTypeFixed64 => { target.push(try!(is.read_fixed64())); Ok(()) },
-        _ => Err(ProtobufError::WireError("unexpected wire type".to_string())),
+        _ => Err(ProtobufError::WireError("unexpected wire type".to_owned())),
     }
 }
 
@@ -288,7 +288,7 @@ pub fn read_repeated_sfixed32_into(wire_type: WireType, is: &mut CodedInputStrea
     match wire_type {
         WireTypeLengthDelimited => is.read_repeated_packed_sfixed32_into(target),
         WireTypeFixed32 => { target.push(try!(is.read_sfixed32())); Ok(()) },
-        _ => Err(ProtobufError::WireError("unexpected wire type".to_string())),
+        _ => Err(ProtobufError::WireError("unexpected wire type".to_owned())),
     }
 }
 
@@ -298,7 +298,7 @@ pub fn read_repeated_sfixed64_into(wire_type: WireType, is: &mut CodedInputStrea
     match wire_type {
         WireTypeLengthDelimited => is.read_repeated_packed_sfixed64_into(target),
         WireTypeFixed64 => { target.push(try!(is.read_sfixed64())); Ok(()) },
-        _ => Err(ProtobufError::WireError("unexpected wire type".to_string())),
+        _ => Err(ProtobufError::WireError("unexpected wire type".to_owned())),
     }
 }
 
@@ -308,7 +308,7 @@ pub fn read_repeated_double_into(wire_type: WireType, is: &mut CodedInputStream,
     match wire_type {
         WireTypeLengthDelimited => is.read_repeated_packed_double_into(target),
         WireTypeFixed64 => { target.push(try!(is.read_double())); Ok(()) },
-        _ => Err(ProtobufError::WireError("unexpected wire type".to_string())),
+        _ => Err(ProtobufError::WireError("unexpected wire type".to_owned())),
     }
 }
 
@@ -318,7 +318,7 @@ pub fn read_repeated_float_into(wire_type: WireType, is: &mut CodedInputStream, 
     match wire_type {
         WireTypeLengthDelimited => is.read_repeated_packed_float_into(target),
         WireTypeFixed32 => { target.push(try!(is.read_float())); Ok(()) },
-        _ => Err(ProtobufError::WireError("unexpected wire type".to_string())),
+        _ => Err(ProtobufError::WireError("unexpected wire type".to_owned())),
     }
 }
 
@@ -328,7 +328,7 @@ pub fn read_repeated_bool_into(wire_type: WireType, is: &mut CodedInputStream, t
     match wire_type {
         WireTypeLengthDelimited => is.read_repeated_packed_bool_into(target),
         WireTypeVarint => { target.push(try!(is.read_bool())); Ok(()) },
-        _ => Err(ProtobufError::WireError("unexpected wire type".to_string())),
+        _ => Err(ProtobufError::WireError("unexpected wire type".to_owned())),
     }
 }
 
@@ -339,7 +339,7 @@ pub fn read_repeated_enum_into<E : ProtobufEnum>(
     match wire_type {
         WireTypeLengthDelimited => is.read_repeated_packed_enum_into(target),
         WireTypeVarint => { target.push(try!(is.read_enum())); Ok(()) },
-        _ => Err(ProtobufError::WireError("unexpected wire type".to_string())),
+        _ => Err(ProtobufError::WireError("unexpected wire type".to_owned())),
     }
 }
 
@@ -352,7 +352,7 @@ pub fn read_repeated_string_into(
             let tmp = target.push_default();
             is.read_string_into(tmp)
         },
-        _ => Err(ProtobufError::WireError("unexpected wire type".to_string())),
+        _ => Err(ProtobufError::WireError("unexpected wire type".to_owned())),
     }
 }
 
@@ -365,7 +365,7 @@ pub fn read_repeated_bytes_into(
             let tmp = target.push_default();
             is.read_bytes_into(tmp)
         },
-        _ => Err(ProtobufError::WireError("unexpected wire type".to_string())),
+        _ => Err(ProtobufError::WireError("unexpected wire type".to_owned())),
     }
 }
 
@@ -378,7 +378,7 @@ pub fn read_repeated_message_into<M : Message + Default>(
             let tmp = target.push_default();
             is.merge_message(tmp)
         },
-        _ => Err(ProtobufError::WireError("unexpected wire type".to_string())),
+        _ => Err(ProtobufError::WireError("unexpected wire type".to_owned())),
     }
 }
 

--- a/src/lib/stream.rs
+++ b/src/lib/stream.rs
@@ -203,7 +203,7 @@ impl<'a> CodedInputStream<'a> {
         assert!(buf.len() < NO_LIMIT as usize);
         let new_pos = match self.pos.checked_add(buf.len() as u32) {
             None | Some(NO_LIMIT) =>
-                return Err(ProtobufError::WireError(format!("u32 overflow"))),
+                return Err(ProtobufError::WireError("u32 overflow".to_owned())),
             Some(new_pos) => new_pos,
         };
         try!(self.source.read(buf));
@@ -224,11 +224,11 @@ impl<'a> CodedInputStream<'a> {
     pub fn push_limit(&mut self, limit: u32) -> ProtobufResult<u32> {
         let old_limit = self.current_limit;
         let new_limit = match self.pos.checked_add(limit) {
-            None | Some(NO_LIMIT) => return Err(ProtobufError::WireError(format!("corrupted stream"))),
+            None | Some(NO_LIMIT) => return Err(ProtobufError::WireError("corrupted stream".to_owned())),
             Some(new_limit) => new_limit,
         };
         if old_limit != NO_LIMIT && new_limit > old_limit {
-            return Err(ProtobufError::WireError(format!("truncated message")));
+            return Err(ProtobufError::WireError("truncated message".to_owned()));
         }
         self.current_limit = new_limit;
         Ok(old_limit)
@@ -250,7 +250,7 @@ impl<'a> CodedInputStream<'a> {
     pub fn check_eof(&mut self) -> ProtobufResult<()> {
         let eof = try!(self.eof());
         if !eof {
-            return Err(ProtobufError::WireError(format!("expecting EOF")));
+            return Err(ProtobufError::WireError("expecting EOF".to_owned()));
         }
         Ok(())
     }
@@ -604,7 +604,7 @@ impl<'a> CodedInputStream<'a> {
 
         let s = match String::from_utf8(vec) {
             Ok(t) => t,
-            Err(_) => return Err(ProtobufError::WireError(format!("invalid UTF-8 string on wire"))),
+            Err(_) => return Err(ProtobufError::WireError("invalid UTF-8 string on wire".to_owned())),
         };
         mem::replace(target, s);
         Ok(())

--- a/src/perftest/perftest_data.rs
+++ b/src/perftest/perftest_data.rs
@@ -71,7 +71,7 @@ impl ::protobuf::Message for Test1 {
             match field_number {
                 1 => {
                     if wire_type != ::protobuf::wire_format::WireTypeVarint {
-                        return ::std::result::Result::Err(::protobuf::ProtobufError::WireError("unexpected wire type".to_string()));
+                        return ::std::result::Result::Err(::protobuf::ProtobufError::WireError("unexpected wire type".to_owned()));
                     };
                     let tmp = try!(is.read_int32());
                     self.value = ::std::option::Option::Some(tmp);
@@ -926,21 +926,21 @@ impl ::protobuf::Message for TestOptionalMessages {
             match field_number {
                 1 => {
                     if wire_type != ::protobuf::wire_format::WireTypeLengthDelimited {
-                        return ::std::result::Result::Err(::protobuf::ProtobufError::WireError("unexpected wire type".to_string()));
+                        return ::std::result::Result::Err(::protobuf::ProtobufError::WireError("unexpected wire type".to_owned()));
                     };
                     let tmp = self.message1.set_default();
                     try!(is.merge_message(tmp))
                 },
                 2 => {
                     if wire_type != ::protobuf::wire_format::WireTypeLengthDelimited {
-                        return ::std::result::Result::Err(::protobuf::ProtobufError::WireError("unexpected wire type".to_string()));
+                        return ::std::result::Result::Err(::protobuf::ProtobufError::WireError("unexpected wire type".to_owned()));
                     };
                     let tmp = self.message2.set_default();
                     try!(is.merge_message(tmp))
                 },
                 3 => {
                     if wire_type != ::protobuf::wire_format::WireTypeLengthDelimited {
-                        return ::std::result::Result::Err(::protobuf::ProtobufError::WireError("unexpected wire type".to_string()));
+                        return ::std::result::Result::Err(::protobuf::ProtobufError::WireError("unexpected wire type".to_owned()));
                     };
                     let tmp = self.message3.set_default();
                     try!(is.merge_message(tmp))
@@ -1236,21 +1236,21 @@ impl ::protobuf::Message for TestStrings {
             match field_number {
                 1 => {
                     if wire_type != ::protobuf::wire_format::WireTypeLengthDelimited {
-                        return ::std::result::Result::Err(::protobuf::ProtobufError::WireError("unexpected wire type".to_string()));
+                        return ::std::result::Result::Err(::protobuf::ProtobufError::WireError("unexpected wire type".to_owned()));
                     };
                     let tmp = self.s1.set_default();
                     try!(is.read_string_into(tmp))
                 },
                 2 => {
                     if wire_type != ::protobuf::wire_format::WireTypeLengthDelimited {
-                        return ::std::result::Result::Err(::protobuf::ProtobufError::WireError("unexpected wire type".to_string()));
+                        return ::std::result::Result::Err(::protobuf::ProtobufError::WireError("unexpected wire type".to_owned()));
                     };
                     let tmp = self.s2.set_default();
                     try!(is.read_string_into(tmp))
                 },
                 3 => {
                     if wire_type != ::protobuf::wire_format::WireTypeLengthDelimited {
-                        return ::std::result::Result::Err(::protobuf::ProtobufError::WireError("unexpected wire type".to_string()));
+                        return ::std::result::Result::Err(::protobuf::ProtobufError::WireError("unexpected wire type".to_owned()));
                     };
                     let tmp = self.s3.set_default();
                     try!(is.read_string_into(tmp))
@@ -1461,7 +1461,7 @@ impl ::protobuf::Message for TestBytes {
             match field_number {
                 1 => {
                     if wire_type != ::protobuf::wire_format::WireTypeLengthDelimited {
-                        return ::std::result::Result::Err(::protobuf::ProtobufError::WireError("unexpected wire type".to_string()));
+                        return ::std::result::Result::Err(::protobuf::ProtobufError::WireError("unexpected wire type".to_owned()));
                     };
                     let tmp = self.b1.set_default();
                     try!(is.read_bytes_into(tmp))

--- a/src/test/test.rs
+++ b/src/test/test.rs
@@ -48,7 +48,7 @@ fn test1() {
 #[test]
 fn test2() {
     let mut test2 = Test2::new();
-    test2.set_b("testing".to_string());
+    test2.set_b("testing".to_owned());
     test_serialize_deserialize("12 07 74 65 73 74 69 6e 67", &test2);
 }
 
@@ -140,7 +140,7 @@ fn test_types_singular() {
     message.set_sfixed32_field(-29);
     message.set_sfixed64_field(30);
     message.set_bool_field(true);
-    message.set_string_field("thirty two".to_string());
+    message.set_string_field("thirty two".to_owned());
     message.set_bytes_field([33u8, 34].to_vec());
     message.set_enum_field(TestEnumDescriptor::BLUE);
     test_serialize_deserialize_no_hex(&message);
@@ -162,7 +162,7 @@ fn test_types_repeated() {
     message.set_sfixed32_field([29i32, -30].to_vec());
     message.set_sfixed64_field([30i64].to_vec());
     message.set_bool_field([true, true].to_vec());
-    message.set_string_field(RepeatedField::from_slice(&["thirty two".to_string(), "thirty three".to_string()]));
+    message.set_string_field(RepeatedField::from_slice(&["thirty two".to_owned(), "thirty three".to_owned()]));
     message.set_bytes_field(RepeatedField::from_slice(&[[33u8, 34].to_vec(), [35u8].to_vec()]));
     message.set_enum_field([TestEnumDescriptor::BLUE, TestEnumDescriptor::GREEN].to_vec());
     test_serialize_deserialize_no_hex(&message);
@@ -184,7 +184,7 @@ fn test_types_repeated_packed() {
     message.set_sfixed32_field([29i32, -30].to_vec());
     message.set_sfixed64_field([30i64].to_vec());
     message.set_bool_field([true, true].to_vec());
-    message.set_string_field(RepeatedField::from_slice(&["thirty two".to_string(), "thirty three".to_string()]));
+    message.set_string_field(RepeatedField::from_slice(&["thirty two".to_owned(), "thirty three".to_owned()]));
     message.set_bytes_field(RepeatedField::from_slice(&[[33u8, 34].to_vec(), [35u8].to_vec()]));
     message.set_enum_field([TestEnumDescriptor::BLUE, TestEnumDescriptor::GREEN].to_vec());
     test_serialize_deserialize_no_hex(&message);

--- a/src/test/test_oneof.rs
+++ b/src/test/test_oneof.rs
@@ -57,7 +57,7 @@ fn test_types() {
     t(|o| o.set_sfixed32_field(20));
     t(|o| o.set_sfixed64_field(21));
     t(|o| o.set_bool_field(true));
-    t(|o| o.set_string_field("asas".to_string()));
+    t(|o| o.set_string_field("asas".to_owned()));
     t(|o| o.set_bytes_field(vec![99, 100]));
     t(|o| o.set_enum_field(EnumForOneof::A));
     t(|o| o.mut_message_field().set_f(22));

--- a/src/test/text_format_test.rs
+++ b/src/test/text_format_test.rs
@@ -26,7 +26,7 @@ fn test_singular() {
     t("sfixed32_singular: 99",    |m| m.set_sfixed32_singular(99));
     t("sfixed64_singular: 99",    |m| m.set_sfixed64_singular(99));
     t("bool_singular: false",     |m| m.set_bool_singular(false));
-    t("string_singular: \"abc\"", |m| m.set_string_singular("abc".to_string()));
+    t("string_singular: \"abc\"", |m| m.set_string_singular("abc".to_owned()));
     t("bytes_singular: \"def\"",  |m| m.set_bytes_singular(b"def".to_vec()));
     t("test_enum_singular: DARK", |m| m.set_test_enum_singular(TestEnum::DARK));
     t("test_message_singular {}", |m| { m.mut_test_message_singular(); });
@@ -48,7 +48,7 @@ fn test_repeated_one() {
     t("sfixed32_repeated: 99",    |m| m.mut_sfixed32_repeated().push(99));
     t("sfixed64_repeated: 99",    |m| m.mut_sfixed64_repeated().push(99));
     t("bool_repeated: false",     |m| m.mut_bool_repeated().push(false));
-    t("string_repeated: \"abc\"", |m| m.mut_string_repeated().push("abc".to_string()));
+    t("string_repeated: \"abc\"", |m| m.mut_string_repeated().push("abc".to_owned()));
     t("bytes_repeated: \"def\"",  |m| m.mut_bytes_repeated().push(b"def".to_vec()));
     t("test_enum_repeated: DARK", |m| m.mut_test_enum_repeated().push(TestEnum::DARK));
     t("test_message_repeated {}", |m| { m.mut_test_message_repeated().push(Default::default()); });


### PR DESCRIPTION
The formatting framework is really slow. Both `format!(...)` and
`x.to_string()` call this framework.