### PR TITLE
Fix compilation of Lazy#get() on nightly

### DIFF
--- a/src/lib/lazy.rs
+++ b/src/lib/lazy.rs
@@ -10,7 +10,13 @@ impl<T> Lazy<T> {
     pub fn get<F>(&'static mut self, init: F) -> &'static T
         where F : FnOnce() -> T
     {
-        self.lock.call_once(|| {
+        // ~ decouple the lifetimes of 'self' and 'self.lock' such we
+        // can initialize self.ptr in the call_once closure (note: we
+        // do have to initialize self.ptr in the closure to guarantee
+        // the ptr is valid for all calling threads at any point in
+        // time)
+        let lock: &sync::Once = unsafe { mem::transmute(&self.lock) };
+        lock.call_once(|| {
             unsafe {
                 self.ptr = mem::transmute(Box::new(init()));
             }


### PR DESCRIPTION
It seems the borrow checker got a bit stricter. This compiles (and still seems to work correctly) on stable, beta, nightly (`rustc 1.4.0-nightly (fd230ff12 2015-09-13)`).