### PR TITLE
Escape backslashes and 0x7f in bytes text format

### DIFF
--- a/src/lib/text_format.rs
+++ b/src/lib/text_format.rs
@@ -12,6 +12,8 @@ fn print_bytes_to(bytes: &[u8], buf: &mut String) {
             buf.push((b'0' + (b & 7)) as char);
         } else if b == b'"' {
             buf.push_str("\\\"");
+        } else if b == b'\\' {
+            buf.push_str("\\\\");
         } else {
             buf.push(b as char);
         }

--- a/src/lib/text_format.rs
+++ b/src/lib/text_format.rs
@@ -5,7 +5,7 @@ use descriptor::*;
 fn print_bytes_to(bytes: &[u8], buf: &mut String) {
     buf.push('"');
     for &b in bytes.iter() {
-        if b < 0x20 || b >= 0x80 {
+        if b < 0x20 || b >= 0x7f {
             buf.push('\\');
             buf.push((b'0' + ((b >> 6) & 3)) as char);
             buf.push((b'0' + ((b >> 3) & 7)) as char);

--- a/src/test/text_format_test.rs
+++ b/src/test/text_format_test.rs
@@ -78,6 +78,6 @@ fn test_show() {
 #[test]
 fn test_string_escaped() {
     let mut m = TestTypes::new();
-    m.set_string_singular("quote\"newline\n".to_string());
-    assert_eq!("string_singular: \"quote\\\"newline\\012\"", &*format!("{:?}", m));
+    m.set_string_singular("quote\"newline\nbackslash\\".to_string());
+    assert_eq!("string_singular: \"quote\\\"newline\\012backslash\\\\\"", &*format!("{:?}", m));
 }

--- a/src/test/text_format_test.rs
+++ b/src/test/text_format_test.rs
@@ -78,6 +78,6 @@ fn test_show() {
 #[test]
 fn test_string_escaped() {
     let mut m = TestTypes::new();
-    m.set_string_singular("quote\"newline\nbackslash\\".to_string());
-    assert_eq!("string_singular: \"quote\\\"newline\\012backslash\\\\\"", &*format!("{:?}", m));
+    m.set_string_singular("quote\"newline\nbackslash\\del\x7f".to_string());
+    assert_eq!("string_singular: \"quote\\\"newline\\012backslash\\\\del\\177\"", &*format!("{:?}", m));
 }


### PR DESCRIPTION
Following on from #139. Escaping backslashes allows `protoc --encode` to correctly parse the output produced by rust-protobuf. 0x7f is not strictly necessary, but it matches the output from `protoc --decode` and reads better on the terminal.

I have updated but haven't run the test - it doesn't appear to be hooked up properly?