### PR TITLE
Add pretty-printed text format output with #? format

### DIFF
--- a/src/lib/text_format.rs
+++ b/src/lib/text_format.rs
@@ -26,21 +26,34 @@ fn print_str_to(s: &str, buf: &mut String) {
     print_bytes_to(s.as_bytes(), buf);
 }
 
-pub fn print_to(m: &Message, buf: &mut String) {
+fn do_indent(buf: &mut String, pretty: bool, indent: usize) {
+    if pretty && indent > 0 {
+        for _ in 0..indent {
+            buf.push_str("  ");
+        }
+    }
+}
+
+fn print_to_internal(m: &Message, buf: &mut String, pretty: bool, indent: usize) {
     let d = m.descriptor();
     let mut first = true;
     for f in d.fields().iter() {
         if f.is_repeated() {
             for i in 0..f.len_field(m) {
-                if !first {
+                if !first && !pretty {
                     buf.push_str(" ");
                 }
+                do_indent(buf, pretty, indent);
                 first = false;
                 buf.push_str(f.name());
                 match f.proto().get_field_type() {
                     FieldDescriptorProto_Type::TYPE_MESSAGE => {
                         buf.push_str(" {");
-                        print_to(f.get_rep_message_item(m, i), buf);
+                        if pretty {
+                            buf.push_str("\n");
+                        }
+                        print_to_internal(f.get_rep_message_item(m, i), buf, pretty, indent+1);
+                        do_indent(buf, pretty, indent);
                         buf.push_str("}");
                     },
                     FieldDescriptorProto_Type::TYPE_ENUM => {
@@ -93,18 +106,26 @@ pub fn print_to(m: &Message, buf: &mut String) {
                         buf.push_str(": <TYPE_GROUP>");
                     }
                 }
+                if pretty {
+                    buf.push_str("\n");
+                }
             }
         } else {
             if f.has_field(m) {
-                if !first {
+                if !first && !pretty {
                     buf.push_str(" ");
                 }
+                do_indent(buf, pretty, indent);
                 first = false;
                 buf.push_str(f.name());
                 match f.proto().get_field_type() {
                     FieldDescriptorProto_Type::TYPE_MESSAGE => {
                         buf.push_str(" {");
-                        print_to(f.get_message(m), buf);
+                        if pretty {
+                            buf.push_str("\n");
+                        }
+                        print_to_internal(f.get_message(m), buf, pretty, indent+1);
+                        do_indent(buf, pretty, indent);
                         buf.push_str("}");
                     },
                     FieldDescriptorProto_Type::TYPE_ENUM => {
@@ -157,6 +178,9 @@ pub fn print_to(m: &Message, buf: &mut String) {
                         buf.push_str(": <TYPE_GROUP>");
                     }
                 }
+                if pretty {
+                    buf.push_str("\n");
+                }
             }
         }
     }
@@ -164,12 +188,21 @@ pub fn print_to(m: &Message, buf: &mut String) {
     // TODO: unknown fields
 }
 
-pub fn print_to_string(m: &Message) -> String {
+pub fn print_to(m: &Message, buf: &mut String) {
+    print_to_internal(m, buf, false, 0)
+}
+
+fn print_to_string_internal(m: &Message, pretty: bool) -> String {
     let mut r = String::new();
-    print_to(m, &mut r);
+    print_to_internal(m, &mut r, pretty, 0);
     r.to_string()
 }
 
+pub fn print_to_string(m: &Message) -> String {
+    print_to_string_internal(m, false)
+}
+
 pub fn fmt(m: &Message, f: &mut fmt::Formatter) -> fmt::Result {
-    f.write_str(&print_to_string(m))
+    let pretty = f.flags() & 4 != 0; // private: fmt::FlagV1::Alternate
+    f.write_str(&print_to_string_internal(m, pretty))
 }

--- a/src/test/text_format_test.rs
+++ b/src/test/text_format_test.rs
@@ -81,3 +81,15 @@ fn test_string_escaped() {
     m.set_string_singular("quote\"newline\nbackslash\\del\x7f".to_string());
     assert_eq!("string_singular: \"quote\\\"newline\\012backslash\\\\del\\177\"", &*format!("{:?}", m));
 }
+
+#[test]
+fn test_pretty() {
+    let mut tm = TestMessage::new();
+    tm.set_value(23);
+    let mut m = TestTypes::new();
+    m.set_test_message_singular(tm);
+    m.set_string_singular("abc".to_string());
+    m.mut_string_repeated().push("def".to_string());
+    m.mut_string_repeated().push("ghi".to_string());
+    assert_eq!("string_singular: \"abc\"\ntest_message_singular {\n  value: 23\n}\nstring_repeated: \"def\"\nstring_repeated: \"ghi\"\n", &*format!("{:#?}", m));
+}


### PR DESCRIPTION
As it says. In my (limited) test cases on real data it matches the output from `protoc --decode` (apart from minor differences in `bytes` encoding, which isn't related to this change anyway).

I've taken care to preserve the public signatures for `print_to` and `print_to_string`. They're not used inside rust-protobuf itself though.

I'm not sure how supported the format flag is. `Formatter::flags` is certainly public, but the bit values inside it are not. This works and is fundamentally the same method used in the Rust core to detect the `#?` format.