### PR TITLE
some enhancement of check_initialized

### DIFF
--- a/src/lib/codegen.rs
+++ b/src/lib/codegen.rs
@@ -2044,7 +2044,7 @@ fn gen_file(
         w.write_line("");
         w.write_line("use protobuf::Message as Message_imported_for_functions;");
         w.write_line("use protobuf::ProtobufEnum as ProtobufEnum_imported_for_functions;");
-        w.write_line("use protobuf::error::{ProtobufResult, ProtobufError};");
+        w.write_line("use protobuf::{ProtobufResult, ProtobufError};");
 
         let scope = FileScope { file_descriptor: file } .to_scope();
 

--- a/src/lib/codegen.rs
+++ b/src/lib/codegen.rs
@@ -1628,13 +1628,13 @@ impl<'a> MessageGen<'a> {
 
     fn write_impl_message(&self, w: &mut CodeWriter) {
         w.impl_for_block("::protobuf::Message", &self.type_name, |w| {
-            w.def_fn(format!("is_initialized(&self) -> bool"), |w| {
+            w.def_fn(format!("is_initialized(&self) -> ProtobufResult<()>"), |w| {
                 for f in self.required_fields() {
                     f.write_if_self_field_is_none(w, |w| {
-                        w.write_line("return false;");
+                        w.write_line(format!("return Err(ProtobufError::FieldError(\"{}_{}_field_error\".to_owned()))", self.type_name, &f.self_field()[5..]));
                     });
                 }
-                w.write_line("true");
+                w.write_line("Ok(())");
             });
             w.write_line("");
             self.write_merge_from(w);
@@ -2044,6 +2044,7 @@ fn gen_file(
         w.write_line("");
         w.write_line("use protobuf::Message as Message_imported_for_functions;");
         w.write_line("use protobuf::ProtobufEnum as ProtobufEnum_imported_for_functions;");
+        w.write_line("use protobuf::error::{ProtobufResult, ProtobufError};");
 
         let scope = FileScope { file_descriptor: file } .to_scope();
 

--- a/src/lib/descriptor.rs
+++ b/src/lib/descriptor.rs
@@ -13,7 +13,7 @@
 
 use protobuf::Message as Message_imported_for_functions;
 use protobuf::ProtobufEnum as ProtobufEnum_imported_for_functions;
-use error::{ProtobufResult, ProtobufError};
+use protobuf::{ProtobufResult, ProtobufError};
 
 #[derive(Clone,Default)]
 pub struct FileDescriptorSet {
@@ -6568,10 +6568,10 @@ impl UninterpretedOption_NamePart {
 impl ::protobuf::Message for UninterpretedOption_NamePart {
     fn is_initialized(&self) -> ProtobufResult<()> {
         if self.name_part.is_none() {
-            return Err(ProtobufError::FieldError("name_part_error".to_owned()));
+            return Err(ProtobufError::FieldError("UninterpretedOption_NamePart_name_part_field_error".to_owned()))
         };
         if self.is_extension.is_none() {
-            return Err(ProtobufError::FieldError("is_extension_error".to_owned()));
+            return Err(ProtobufError::FieldError("UninterpretedOption_NamePart_is_extension_field_error".to_owned()))
         };
         Ok(())
     }

--- a/src/lib/descriptor.rs
+++ b/src/lib/descriptor.rs
@@ -13,6 +13,7 @@
 
 use protobuf::Message as Message_imported_for_functions;
 use protobuf::ProtobufEnum as ProtobufEnum_imported_for_functions;
+use error::{ProtobufResult, ProtobufError};
 
 #[derive(Clone,Default)]
 pub struct FileDescriptorSet {
@@ -74,8 +75,8 @@ impl FileDescriptorSet {
 }
 
 impl ::protobuf::Message for FileDescriptorSet {
-    fn is_initialized(&self) -> bool {
-        true
+    fn is_initialized(&self) -> ProtobufResult<()> {
+        Ok(())
     }
 
     fn merge_from(&mut self, is: &mut ::protobuf::CodedInputStream) -> ::protobuf::ProtobufResult<()> {
@@ -556,8 +557,8 @@ impl FileDescriptorProto {
 }
 
 impl ::protobuf::Message for FileDescriptorProto {
-    fn is_initialized(&self) -> bool {
-        true
+    fn is_initialized(&self) -> ProtobufResult<()> {
+        Ok(())
     }
 
     fn merge_from(&mut self, is: &mut ::protobuf::CodedInputStream) -> ::protobuf::ProtobufResult<()> {
@@ -1107,8 +1108,8 @@ impl DescriptorProto {
 }
 
 impl ::protobuf::Message for DescriptorProto {
-    fn is_initialized(&self) -> bool {
-        true
+    fn is_initialized(&self) -> ProtobufResult<()> {
+        Ok(())
     }
 
     fn merge_from(&mut self, is: &mut ::protobuf::CodedInputStream) -> ::protobuf::ProtobufResult<()> {
@@ -1421,8 +1422,8 @@ impl DescriptorProto_ExtensionRange {
 }
 
 impl ::protobuf::Message for DescriptorProto_ExtensionRange {
-    fn is_initialized(&self) -> bool {
-        true
+    fn is_initialized(&self) -> ProtobufResult<()> {
+        Ok(())
     }
 
     fn merge_from(&mut self, is: &mut ::protobuf::CodedInputStream) -> ::protobuf::ProtobufResult<()> {
@@ -1861,8 +1862,8 @@ impl FieldDescriptorProto {
 }
 
 impl ::protobuf::Message for FieldDescriptorProto {
-    fn is_initialized(&self) -> bool {
-        true
+    fn is_initialized(&self) -> ProtobufResult<()> {
+        Ok(())
     }
 
     fn merge_from(&mut self, is: &mut ::protobuf::CodedInputStream) -> ::protobuf::ProtobufResult<()> {
@@ -2328,8 +2329,8 @@ impl OneofDescriptorProto {
 }
 
 impl ::protobuf::Message for OneofDescriptorProto {
-    fn is_initialized(&self) -> bool {
-        true
+    fn is_initialized(&self) -> ProtobufResult<()> {
+        Ok(())
     }
 
     fn merge_from(&mut self, is: &mut ::protobuf::CodedInputStream) -> ::protobuf::ProtobufResult<()> {
@@ -2573,8 +2574,8 @@ impl EnumDescriptorProto {
 }
 
 impl ::protobuf::Message for EnumDescriptorProto {
-    fn is_initialized(&self) -> bool {
-        true
+    fn is_initialized(&self) -> ProtobufResult<()> {
+        Ok(())
     }
 
     fn merge_from(&mut self, is: &mut ::protobuf::CodedInputStream) -> ::protobuf::ProtobufResult<()> {
@@ -2849,8 +2850,8 @@ impl EnumValueDescriptorProto {
 }
 
 impl ::protobuf::Message for EnumValueDescriptorProto {
-    fn is_initialized(&self) -> bool {
-        true
+    fn is_initialized(&self) -> ProtobufResult<()> {
+        Ok(())
     }
 
     fn merge_from(&mut self, is: &mut ::protobuf::CodedInputStream) -> ::protobuf::ProtobufResult<()> {
@@ -3133,8 +3134,8 @@ impl ServiceDescriptorProto {
 }
 
 impl ::protobuf::Message for ServiceDescriptorProto {
-    fn is_initialized(&self) -> bool {
-        true
+    fn is_initialized(&self) -> ProtobufResult<()> {
+        Ok(())
     }
 
     fn merge_from(&mut self, is: &mut ::protobuf::CodedInputStream) -> ::protobuf::ProtobufResult<()> {
@@ -3464,8 +3465,8 @@ impl MethodDescriptorProto {
 }
 
 impl ::protobuf::Message for MethodDescriptorProto {
-    fn is_initialized(&self) -> bool {
-        true
+    fn is_initialized(&self) -> ProtobufResult<()> {
+        Ok(())
     }
 
     fn merge_from(&mut self, is: &mut ::protobuf::CodedInputStream) -> ::protobuf::ProtobufResult<()> {
@@ -3969,8 +3970,8 @@ impl FileOptions {
 }
 
 impl ::protobuf::Message for FileOptions {
-    fn is_initialized(&self) -> bool {
-        true
+    fn is_initialized(&self) -> ProtobufResult<()> {
+        Ok(())
     }
 
     fn merge_from(&mut self, is: &mut ::protobuf::CodedInputStream) -> ::protobuf::ProtobufResult<()> {
@@ -4460,8 +4461,8 @@ impl MessageOptions {
 }
 
 impl ::protobuf::Message for MessageOptions {
-    fn is_initialized(&self) -> bool {
-        true
+    fn is_initialized(&self) -> ProtobufResult<()> {
+        Ok(())
     }
 
     fn merge_from(&mut self, is: &mut ::protobuf::CodedInputStream) -> ::protobuf::ProtobufResult<()> {
@@ -4837,8 +4838,8 @@ impl FieldOptions {
 }
 
 impl ::protobuf::Message for FieldOptions {
-    fn is_initialized(&self) -> bool {
-        true
+    fn is_initialized(&self) -> ProtobufResult<()> {
+        Ok(())
     }
 
     fn merge_from(&mut self, is: &mut ::protobuf::CodedInputStream) -> ::protobuf::ProtobufResult<()> {
@@ -5215,8 +5216,8 @@ impl EnumOptions {
 }
 
 impl ::protobuf::Message for EnumOptions {
-    fn is_initialized(&self) -> bool {
-        true
+    fn is_initialized(&self) -> ProtobufResult<()> {
+        Ok(())
     }
 
     fn merge_from(&mut self, is: &mut ::protobuf::CodedInputStream) -> ::protobuf::ProtobufResult<()> {
@@ -5450,8 +5451,8 @@ impl EnumValueOptions {
 }
 
 impl ::protobuf::Message for EnumValueOptions {
-    fn is_initialized(&self) -> bool {
-        true
+    fn is_initialized(&self) -> ProtobufResult<()> {
+        Ok(())
     }
 
     fn merge_from(&mut self, is: &mut ::protobuf::CodedInputStream) -> ::protobuf::ProtobufResult<()> {
@@ -5665,8 +5666,8 @@ impl ServiceOptions {
 }
 
 impl ::protobuf::Message for ServiceOptions {
-    fn is_initialized(&self) -> bool {
-        true
+    fn is_initialized(&self) -> ProtobufResult<()> {
+        Ok(())
     }
 
     fn merge_from(&mut self, is: &mut ::protobuf::CodedInputStream) -> ::protobuf::ProtobufResult<()> {
@@ -5880,8 +5881,8 @@ impl MethodOptions {
 }
 
 impl ::protobuf::Message for MethodOptions {
-    fn is_initialized(&self) -> bool {
-        true
+    fn is_initialized(&self) -> ProtobufResult<()> {
+        Ok(())
     }
 
     fn merge_from(&mut self, is: &mut ::protobuf::CodedInputStream) -> ::protobuf::ProtobufResult<()> {
@@ -6251,8 +6252,8 @@ impl UninterpretedOption {
 }
 
 impl ::protobuf::Message for UninterpretedOption {
-    fn is_initialized(&self) -> bool {
-        true
+    fn is_initialized(&self) -> ProtobufResult<()> {
+        Ok(())
     }
 
     fn merge_from(&mut self, is: &mut ::protobuf::CodedInputStream) -> ::protobuf::ProtobufResult<()> {
@@ -6565,14 +6566,14 @@ impl UninterpretedOption_NamePart {
 }
 
 impl ::protobuf::Message for UninterpretedOption_NamePart {
-    fn is_initialized(&self) -> bool {
+    fn is_initialized(&self) -> ProtobufResult<()> {
         if self.name_part.is_none() {
-            return false;
+            return Err(ProtobufError::FieldError("name_part_error".to_owned()));
         };
         if self.is_extension.is_none() {
-            return false;
+            return Err(ProtobufError::FieldError("is_extension_error".to_owned()));
         };
-        true
+        Ok(())
     }
 
     fn merge_from(&mut self, is: &mut ::protobuf::CodedInputStream) -> ::protobuf::ProtobufResult<()> {
@@ -6763,8 +6764,8 @@ impl SourceCodeInfo {
 }
 
 impl ::protobuf::Message for SourceCodeInfo {
-    fn is_initialized(&self) -> bool {
-        true
+    fn is_initialized(&self) -> ProtobufResult<()> {
+        Ok(())
     }
 
     fn merge_from(&mut self, is: &mut ::protobuf::CodedInputStream) -> ::protobuf::ProtobufResult<()> {
@@ -7040,8 +7041,8 @@ impl SourceCodeInfo_Location {
 }
 
 impl ::protobuf::Message for SourceCodeInfo_Location {
-    fn is_initialized(&self) -> bool {
-        true
+    fn is_initialized(&self) -> ProtobufResult<()> {
+        Ok(())
     }
 
     fn merge_from(&mut self, is: &mut ::protobuf::CodedInputStream) -> ::protobuf::ProtobufResult<()> {

--- a/src/lib/error.rs
+++ b/src/lib/error.rs
@@ -8,6 +8,7 @@ pub type ProtobufResult<T> = Result<T, ProtobufError>;
 pub enum ProtobufError {
     IoError(io::Error),
     WireError(String),
+    FieldError(String),
 }
 
 impl fmt::Display for ProtobufError {
@@ -22,6 +23,7 @@ impl Error for ProtobufError {
             // not sure that cause should be included in message
             &ProtobufError::IoError(ref e) => e.description(),
             &ProtobufError::WireError(ref e) => &e,
+            &ProtobufError::FieldError(ref e) => &e,
         }
     }
 
@@ -29,6 +31,7 @@ impl Error for ProtobufError {
         match self {
             &ProtobufError::IoError(ref e) => Some(e),
             &ProtobufError::WireError(..) => None,
+	    &ProtobufError::FieldError(..) => None,
         }
     }
 }

--- a/src/lib/plugin.rs
+++ b/src/lib/plugin.rs
@@ -13,6 +13,7 @@
 
 use protobuf::Message as Message_imported_for_functions;
 use protobuf::ProtobufEnum as ProtobufEnum_imported_for_functions;
+use error::ProtobufResult;
 
 #[derive(Clone,Default)]
 pub struct CodeGeneratorRequest {
@@ -139,8 +140,8 @@ impl CodeGeneratorRequest {
 }
 
 impl ::protobuf::Message for CodeGeneratorRequest {
-    fn is_initialized(&self) -> bool {
-        true
+    fn is_initialized(&self) -> ProtobufResult<()> {
+        Ok(())
     }
 
     fn merge_from(&mut self, is: &mut ::protobuf::CodedInputStream) -> ::protobuf::ProtobufResult<()> {
@@ -382,8 +383,8 @@ impl CodeGeneratorResponse {
 }
 
 impl ::protobuf::Message for CodeGeneratorResponse {
-    fn is_initialized(&self) -> bool {
-        true
+    fn is_initialized(&self) -> ProtobufResult<()> {
+        Ok(())
     }
 
     fn merge_from(&mut self, is: &mut ::protobuf::CodedInputStream) -> ::protobuf::ProtobufResult<()> {
@@ -659,8 +660,8 @@ impl CodeGeneratorResponse_File {
 }
 
 impl ::protobuf::Message for CodeGeneratorResponse_File {
-    fn is_initialized(&self) -> bool {
-        true
+    fn is_initialized(&self) -> ProtobufResult<()> {
+        Ok(())
     }
 
     fn merge_from(&mut self, is: &mut ::protobuf::CodedInputStream) -> ::protobuf::ProtobufResult<()> {

--- a/src/lib/plugin.rs
+++ b/src/lib/plugin.rs
@@ -13,7 +13,7 @@
 
 use protobuf::Message as Message_imported_for_functions;
 use protobuf::ProtobufEnum as ProtobufEnum_imported_for_functions;
-use error::ProtobufResult;
+use protobuf::{ProtobufResult, ProtobufError};
 
 #[derive(Clone,Default)]
 pub struct CodeGeneratorRequest {

--- a/src/lib/stream.rs
+++ b/src/lib/stream.rs
@@ -622,7 +622,7 @@ impl<'a> CodedInputStream<'a> {
     pub fn read_message<M : Message + MessageStatic>(&mut self) -> ProtobufResult<M> {
         let mut r: M = MessageStatic::new();
         try!(self.merge_message(&mut r));
-        r.check_initialized();
+        try!(r.check_initialized());
         Ok(r)
     }
 }

--- a/src/perftest/perftest_data.rs
+++ b/src/perftest/perftest_data.rs
@@ -68,8 +68,8 @@ impl Test1 {
 }
 
 impl ::protobuf::Message for Test1 {
-    fn is_initialized(&self) -> bool {
-        true
+    fn is_initialized(&self) -> ProtobufResult<()>> {
+        Ok(())
     }
 
     fn merge_from(&mut self, is: &mut ::protobuf::CodedInputStream) -> ::protobuf::ProtobufResult<()> {
@@ -244,8 +244,8 @@ impl TestRepeatedBool {
 }
 
 impl ::protobuf::Message for TestRepeatedBool {
-    fn is_initialized(&self) -> bool {
-        true
+    fn is_initialized(&self) -> ProtobufResult<()>> {
+        Ok(())
     }
 
     fn merge_from(&mut self, is: &mut ::protobuf::CodedInputStream) -> ::protobuf::ProtobufResult<()> {
@@ -413,8 +413,8 @@ impl TestRepeatedPackedInt32 {
 }
 
 impl ::protobuf::Message for TestRepeatedPackedInt32 {
-    fn is_initialized(&self) -> bool {
-        true
+    fn is_initialized(&self) -> ProtobufResult<()>> {
+        Ok(())
     }
 
     fn merge_from(&mut self, is: &mut ::protobuf::CodedInputStream) -> ::protobuf::ProtobufResult<()> {
@@ -643,8 +643,8 @@ impl TestRepeatedMessages {
 }
 
 impl ::protobuf::Message for TestRepeatedMessages {
-    fn is_initialized(&self) -> bool {
-        true
+    fn is_initialized(&self) -> ProtobufResult<()>> {
+        Ok(())
     }
 
     fn merge_from(&mut self, is: &mut ::protobuf::CodedInputStream) -> ::protobuf::ProtobufResult<()> {
@@ -931,8 +931,8 @@ impl TestOptionalMessages {
 }
 
 impl ::protobuf::Message for TestOptionalMessages {
-    fn is_initialized(&self) -> bool {
-        true
+    fn is_initialized(&self) -> ProtobufResult<()>> {
+        Ok(())
     }
 
     fn merge_from(&mut self, is: &mut ::protobuf::CodedInputStream) -> ::protobuf::ProtobufResult<()> {
@@ -1231,8 +1231,8 @@ impl TestStrings {
 }
 
 impl ::protobuf::Message for TestStrings {
-    fn is_initialized(&self) -> bool {
-        true
+    fn is_initialized(&self) -> ProtobufResult<()>> {
+        Ok(())
     }
 
     fn merge_from(&mut self, is: &mut ::protobuf::CodedInputStream) -> ::protobuf::ProtobufResult<()> {
@@ -1446,8 +1446,8 @@ impl TestBytes {
 }
 
 impl ::protobuf::Message for TestBytes {
-    fn is_initialized(&self) -> bool {
-        true
+    fn is_initialized(&self) -> ProtobufResult<()>> {
+        Ok(())
     }
 
     fn merge_from(&mut self, is: &mut ::protobuf::CodedInputStream) -> ::protobuf::ProtobufResult<()> {
@@ -1807,8 +1807,8 @@ impl PerftestData {
 }
 
 impl ::protobuf::Message for PerftestData {
-    fn is_initialized(&self) -> bool {
-        true
+    fn is_initialized(&self) -> ProtobufResult<()>> {
+        Ok(())
     }
 
     fn merge_from(&mut self, is: &mut ::protobuf::CodedInputStream) -> ::protobuf::ProtobufResult<()> {

--- a/src/perftest/perftest_data.rs
+++ b/src/perftest/perftest_data.rs
@@ -13,6 +13,7 @@
 
 use protobuf::Message as Message_imported_for_functions;
 use protobuf::ProtobufEnum as ProtobufEnum_imported_for_functions;
+use protobuf::{ProtobufResult, ProtobufError};
 
 #[derive(Clone,Default)]
 pub struct Test1 {
@@ -68,7 +69,7 @@ impl Test1 {
 }
 
 impl ::protobuf::Message for Test1 {
-    fn is_initialized(&self) -> ProtobufResult<()>> {
+    fn is_initialized(&self) -> ProtobufResult<()> {
         Ok(())
     }
 
@@ -244,7 +245,7 @@ impl TestRepeatedBool {
 }
 
 impl ::protobuf::Message for TestRepeatedBool {
-    fn is_initialized(&self) -> ProtobufResult<()>> {
+    fn is_initialized(&self) -> ProtobufResult<()> {
         Ok(())
     }
 
@@ -413,7 +414,7 @@ impl TestRepeatedPackedInt32 {
 }
 
 impl ::protobuf::Message for TestRepeatedPackedInt32 {
-    fn is_initialized(&self) -> ProtobufResult<()>> {
+    fn is_initialized(&self) -> ProtobufResult<()> {
         Ok(())
     }
 
@@ -643,7 +644,7 @@ impl TestRepeatedMessages {
 }
 
 impl ::protobuf::Message for TestRepeatedMessages {
-    fn is_initialized(&self) -> ProtobufResult<()>> {
+    fn is_initialized(&self) -> ProtobufResult<()> {
         Ok(())
     }
 
@@ -931,7 +932,7 @@ impl TestOptionalMessages {
 }
 
 impl ::protobuf::Message for TestOptionalMessages {
-    fn is_initialized(&self) -> ProtobufResult<()>> {
+    fn is_initialized(&self) -> ProtobufResult<()> {
         Ok(())
     }
 
@@ -1231,7 +1232,7 @@ impl TestStrings {
 }
 
 impl ::protobuf::Message for TestStrings {
-    fn is_initialized(&self) -> ProtobufResult<()>> {
+    fn is_initialized(&self) -> ProtobufResult<()> {
         Ok(())
     }
 
@@ -1446,7 +1447,7 @@ impl TestBytes {
 }
 
 impl ::protobuf::Message for TestBytes {
-    fn is_initialized(&self) -> ProtobufResult<()>> {
+    fn is_initialized(&self) -> ProtobufResult<()> {
         Ok(())
     }
 
@@ -1807,7 +1808,7 @@ impl PerftestData {
 }
 
 impl ::protobuf::Message for PerftestData {
-    fn is_initialized(&self) -> ProtobufResult<()>> {
+    fn is_initialized(&self) -> ProtobufResult<()> {
         Ok(())
     }
 

--- a/src/test/test_sync.rs
+++ b/src/test/test_sync.rs
@@ -23,7 +23,7 @@ fn test_sync() {
             let mut read = TestTypesSingular::new();
             // API is not very convenient here
             read.merge_from(&mut is).unwrap();
-            read.check_initialized();
+            read.check_initialized().unwrap();
             read.get_int32_field()
         })
     }).collect();


### PR DESCRIPTION
1. report not initialized fields in the result error message.
2. return a FieldError when missing fields, instead of just panic.