### PR TITLE
Flush CodedOutputStream buffer on drop.

### DIFF
--- a/src/lib/stream.rs
+++ b/src/lib/stream.rs
@@ -1016,6 +1016,12 @@ impl<'a> CodedOutputStream<'a> {
     }
 }
 
+impl<'a> Drop for CodedOutputStream<'a> {
+    fn drop(&mut self) {
+        self.flush().unwrap();
+    }
+}
+
 
 #[cfg(test)]
 mod test {
@@ -1262,5 +1268,15 @@ mod test {
         test_write("f1 e2 d3 c4 b5 a6 07 f8", |os| {
             os.write_raw_little_endian64(0xf807a6b5c4d3e2f1)
         });
+    }
+
+    #[test]
+    fn test_drop_output_stream_flushes() {
+        let mut v = Vec::new();
+        {
+            let mut os = CodedOutputStream::new(&mut v as &mut Write);
+            os.write_int32_no_tag(1).unwrap();
+        }
+        assert!(v.len() == 1);
     }
 }


### PR DESCRIPTION
The current behavior -- that some leftover bytes may be silently forgotten in a `CodedOutputStream`'s output buffer on drop -- caught me by surprise.

I'm not sure if the current behavior is intentional. Perhaps you wanted to be able to explicitly return a `Result` on `flush()`, whereas `drop()` cannot do that? But in that case the user who wants to catch the error can now explicitly `flush()` first to avoid any panic on drop, and they should be doing that anyway to avoid silently forgetting bytes. In any case, the new semantics seem less error-prone to me.

Thanks!

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/stepancheg/rust-protobuf/147)

<!-- Reviewable:end -->
