### PR TITLE
Add config attr: `rustfmt` should not try to format generated code.

### DIFF
--- a/src/lib/codegen.rs
+++ b/src/lib/codegen.rs
@@ -2035,6 +2035,8 @@ fn gen_file(
         w.write_line("#![allow(unknown_lints)]");
         w.write_line("#![allow(clippy)]");
         w.write_line("");
+        w.write_line("#![cfg_attr(rustfmt, rustfmt_skip)]");
+        w.write_line("");
         w.write_line("#![allow(dead_code)]");
         w.write_line("#![allow(non_camel_case_types)]");
         w.write_line("#![allow(non_snake_case)]");


### PR DESCRIPTION
`rustfmt` tries to reformat generated code from `protoc-gen-rust`, and this is relevant when, for example, generated code is checked into version control and placed in the ordinary `src/` tree rather than generated during build.

This PR adds an attribute to the generated file that prevents rustfmt from processing the code.