### PR TITLE
print: keep interoperability with other language implementation

### DIFF
--- a/src/lib/text_format.rs
+++ b/src/lib/text_format.rs
@@ -7,18 +7,21 @@ use descriptor::*;
 
 fn print_bytes_to(bytes: &[u8], buf: &mut String) {
     buf.push('"');
-    for &b in bytes.iter() {
-        if b < 0x20 || b >= 0x7f {
-            buf.push('\\');
-            buf.push((b'0' + ((b >> 6) & 3)) as char);
-            buf.push((b'0' + ((b >> 3) & 7)) as char);
-            buf.push((b'0' + (b & 7)) as char);
-        } else if b == b'"' {
-            buf.push_str("\\\"");
-        } else if b == b'\\' {
-            buf.push_str("\\\\");
-        } else {
-            buf.push(b as char);
+    for &c in bytes {
+        match c {
+            b'\n' => buf.push_str(r"\n"),
+            b'\r' => buf.push_str(r"\r"),
+            b'\t' => buf.push_str(r"\t"),
+            b'"' => buf.push_str("\\\""),
+            b'\'' => buf.push_str(r"\'"),
+            b'\\' => buf.push_str(r"\\"),
+            b'\x20'...b'\x7e' => buf.push(c as char),
+            _ => {
+                buf.push('\\');
+                buf.push((b'0' + (c >> 6)) as char);
+                buf.push((b'0' + ((c >> 3) & 7)) as char);
+                buf.push((b'0' + (c & 7)) as char);
+            }
         }
     }
     buf.push('"');
@@ -245,4 +248,22 @@ pub fn print_to_string(m: &Message) -> String {
 pub fn fmt(m: &Message, f: &mut fmt::Formatter) -> fmt::Result {
     let pretty = f.alternate();
     f.write_str(&print_to_string_internal(m, pretty))
+}
+
+#[cfg(test)]
+mod test {
+    
+    fn escape(data: &[u8]) -> String {
+        let mut s = String::with_capacity(data.len() * 4);
+        super::print_bytes_to(data, &mut s);
+        s
+    }
+    
+    #[test]
+    fn test_print_to_bytes() {
+        assert_eq!("\"ab\"", escape(b"ab"));
+        assert_eq!("\"a\\\\023\"", escape(b"a\\023"));
+        assert_eq!("\"a\\r\\n\\t \\'\\\"\\\\\"", escape(b"a\r\n\t '\"\\"));
+        assert_eq!("\"\\342\\235\\244\\360\\237\\220\\267\"", escape("❤🐷".as_bytes()));
+    }
 }

--- a/src/lib/text_format.rs
+++ b/src/lib/text_format.rs
@@ -13,7 +13,6 @@ fn print_bytes_to(bytes: &[u8], buf: &mut String) {
             b'\r' => buf.push_str(r"\r"),
             b'\t' => buf.push_str(r"\t"),
             b'"' => buf.push_str("\\\""),
-            b'\'' => buf.push_str(r"\'"),
             b'\\' => buf.push_str(r"\\"),
             b'\x20'...b'\x7e' => buf.push(c as char),
             _ => {
@@ -263,7 +262,7 @@ mod test {
     fn test_print_to_bytes() {
         assert_eq!("\"ab\"", escape(b"ab"));
         assert_eq!("\"a\\\\023\"", escape(b"a\\023"));
-        assert_eq!("\"a\\r\\n\\t \\'\\\"\\\\\"", escape(b"a\r\n\t '\"\\"));
+        assert_eq!("\"a\\r\\n\\t '\\\"\\\\\"", escape(b"a\r\n\t '\"\\"));
         assert_eq!("\"\\342\\235\\244\\360\\237\\220\\267\"", escape("❤🐷".as_bytes()));
     }
 }

--- a/src/test/text_format_test.rs
+++ b/src/test/text_format_test.rs
@@ -79,7 +79,7 @@ fn test_show() {
 fn test_string_escaped() {
     let mut m = TestTypes::new();
     m.set_string_singular("quote\"newline\nbackslash\\del\x7f".to_string());
-    assert_eq!("string_singular: \"quote\\\"newline\\012backslash\\\\del\\177\"", &*format!("{:?}", m));
+    assert_eq!("string_singular: \"quote\\\"newline\\nbackslash\\\\del\\177\"", &*format!("{:?}", m));
 }
 
 #[test]


### PR DESCRIPTION
Currently when print byte array, only `"` and `\` is escaped, but in the [official C++ implementation](https://github.com/google/protobuf/blob/master/src/google/protobuf/stubs/strutil.cc#L482) there are some other chars are escaped too. So I add those cases to keep interoperability with other language implementation.