### PR TITLE
Add `#[allow(…)]` directives for allow-by-default lints

### DIFF
--- a/src/lib/codegen.rs
+++ b/src/lib/codegen.rs
@@ -2040,11 +2040,15 @@ fn gen_file(
         w.write_line("");
         w.write_line("#![cfg_attr(rustfmt, rustfmt_skip)]");
         w.write_line("");
+        w.write_line("#![allow(box_pointers)]");
         w.write_line("#![allow(dead_code)]");
         w.write_line("#![allow(non_camel_case_types)]");
         w.write_line("#![allow(non_snake_case)]");
         w.write_line("#![allow(non_upper_case_globals)]");
+        w.write_line("#![allow(trivial_casts)]");
+        w.write_line("#![allow(unsafe_code)]");
         w.write_line("#![allow(unused_imports)]");
+        w.write_line("#![allow(unused_results)]");
 
         w.write_line("");
         w.write_line("use protobuf::Message as Message_imported_for_functions;");


### PR DESCRIPTION
This makes it possible to `#[warn(…)]` or `#[deny(…)]` on these lints at crate level without drowning in warnings/errors.

Library for extremely well by the way, thx! :bow: 