### PR TITLE
Implement From<io::Error> for ProtobufError and use try! more

### DIFF
--- a/src/lib/error.rs
+++ b/src/lib/error.rs
@@ -43,3 +43,9 @@ impl Error for ProtobufError {
         }
     }
 }
+
+impl From<io::Error> for ProtobufError {
+    fn from(err: io::Error) -> Self {
+        ProtobufError::IoError(err)
+    }
+}


### PR DESCRIPTION
Implement `From<io::Error>` for `ProtobufError`, which allows `try!` to automatically convert them.