### PR TITLE
Implemented conversion From<ProtobufError> for io::Error.

### DIFF
--- a/src/lib/error.rs
+++ b/src/lib/error.rs
@@ -49,3 +49,13 @@ impl From<io::Error> for ProtobufError {
         ProtobufError::IoError(err)
     }
 }
+
+impl From<ProtobufError> for io::Error {
+    fn from(err: ProtobufError) -> Self {
+        match err {
+            ProtobufError::IoError(e) => e,
+            ProtobufError::WireError(e) => io::Error::new(io::ErrorKind::InvalidData, ProtobufError::WireError(e)),
+            ProtobufError::MessageNotInitialized { message: msg } => io::Error::new(io::ErrorKind::InvalidInput, ProtobufError::MessageNotInitialized { message: msg }),
+        }
+    }
+}


### PR DESCRIPTION
This enables user of library to use `try!()` macro in function which should return `io::Error`.
~~I should probably bump the version to 1.1.0, right? If yes, let me know and I'll update it right away.~~

~~BTW, I think the doc is outdated, because the converse impl is already there but not in the doc. Could you re-generate it, please?~~

Seems like old version is released. When will be 1.1.0 released?
