### PR TITLE
Support for messages in maps

### DIFF
--- a/src/lib/types.rs
+++ b/src/lib/types.rs
@@ -24,6 +24,11 @@ pub trait ProtobufType {
         Self::compute_size(value)
     }
 
+    #[inline]
+    fn get_map_prefix_size(_: u32, _: &Self::Value) -> u32 {
+        1
+    }
+
     fn write_with_cached_size(field_number: u32, value: &Self::Value, os: &mut CodedOutputStream) -> ProtobufResult<()>;
 }
 
@@ -382,6 +387,11 @@ impl<M : Message + MessageStatic + ProtobufValue> ProtobufType for ProtobufTypeM
 
     fn get_cached_size(value: &M) -> u32 {
         value.get_cached_size()
+    }
+
+    fn get_map_prefix_size(field_number: u32, value: &M) -> u32 {
+        rt::tag_size(field_number) +
+            rt::compute_raw_varint32_size(value.compute_size())
     }
 
     fn write_with_cached_size(field_number: u32, value: &Self::Value, os: &mut CodedOutputStream) -> ProtobufResult<()> {

--- a/src/test/v3/test_map.rs
+++ b/src/test/v3/test_map.rs
@@ -7,6 +7,8 @@ use test::*;
 #[test]
 fn test_map() {
     let mut map = TestMap::new();
+    let mut entry = TestMapEntry::new();
+    entry.set_v(10);
 
     test_serialize_deserialize("", &map);
 
@@ -14,6 +16,8 @@ fn test_map() {
     test_serialize_deserialize("0a 07 0a 03 74 77 6f 10 02", &map);
 
     map.mut_m().insert("sixty six".to_owned(), 66);
+    // Insert map entry sub message
+    map.mut_mm().insert("map".to_owned(), entry);
     // cannot (easily) test hex, because order is not specified
     test_serialize_deserialize_no_hex(&map);
 }

--- a/src/test/v3/test_map_pb.proto
+++ b/src/test/v3/test_map_pb.proto
@@ -2,4 +2,9 @@ syntax = "proto3";
 
 message TestMap {
     map<string, uint32> m = 1;
+    map<string, TestMapEntry> mm = 2;
+}
+
+message TestMapEntry {
+  int64 v = 1;
 }


### PR DESCRIPTION
When parsing back a message that includes a map that includes a message parsing fails with `WireError("truncated message")`. 

I've reproduced this in this failing test and am browsing to the code to see where this is handled exactly. Any thoughts on how to add support for this?