### PR TITLE
Simplify generated code by using a new SpecialFields

### DIFF
--- a/src/lib/descriptor.rs
+++ b/src/lib/descriptor.rs
@@ -20,13 +20,12 @@
 use protobuf::Message as Message_imported_for_functions;
 use protobuf::ProtobufEnum as ProtobufEnum_imported_for_functions;
 
-#[derive(Clone,Default)]
+#[derive(Clone, Default, PartialEq)]
 pub struct FileDescriptorSet {
     // message fields
     file: ::protobuf::RepeatedField<FileDescriptorProto>,
     // special fields
-    unknown_fields: ::protobuf::UnknownFields,
-    cached_size: ::std::cell::Cell<u32>,
+    special_fields: ::protobuf::SpecialFields,
 }
 
 // see codegen.rs for the explanation why impl Sync explicitly
@@ -109,9 +108,7 @@ impl ::protobuf::Message for FileDescriptorSet {
             let len = value.compute_size();
             my_size += 1 + ::protobuf::rt::compute_raw_varint32_size(len) + len;
         };
-        my_size += ::protobuf::rt::unknown_fields_size(self.get_unknown_fields());
-        self.cached_size.set(my_size);
-        my_size
+        self.set_cached_size(my_size)
     }
 
     fn write_to_with_cached_sizes(&self, os: &mut ::protobuf::CodedOutputStream) -> ::protobuf::ProtobufResult<()> {
@@ -124,22 +121,14 @@ impl ::protobuf::Message for FileDescriptorSet {
         ::std::result::Result::Ok(())
     }
 
-    fn get_cached_size(&self) -> u32 {
-        self.cached_size.get()
+    fn get_special_fields(&self) -> &::protobuf::SpecialFields {
+        &self.special_fields
     }
 
-    fn get_unknown_fields(&self) -> &::protobuf::UnknownFields {
-        &self.unknown_fields
+    fn mut_special_fields(&mut self) -> &mut ::protobuf::SpecialFields {
+        &mut self.special_fields
     }
-
-    fn mut_unknown_fields(&mut self) -> &mut ::protobuf::UnknownFields {
-        &mut self.unknown_fields
-    }
-
-    fn type_id(&self) -> ::std::any::TypeId {
-        ::std::any::TypeId::of::<FileDescriptorSet>()
-    }
-
+    
     fn as_any(&self) -> &::std::any::Any {
         self as &::std::any::Any
     }
@@ -180,14 +169,7 @@ impl ::protobuf::MessageStatic for FileDescriptorSet {
 impl ::protobuf::Clear for FileDescriptorSet {
     fn clear(&mut self) {
         self.clear_file();
-        self.unknown_fields.clear();
-    }
-}
-
-impl ::std::cmp::PartialEq for FileDescriptorSet {
-    fn eq(&self, other: &FileDescriptorSet) -> bool {
-        self.file == other.file &&
-        self.unknown_fields == other.unknown_fields
+        self.mut_unknown_fields().clear();
     }
 }
 
@@ -203,7 +185,7 @@ impl ::protobuf::reflect::ProtobufValue for FileDescriptorSet {
     }
 }
 
-#[derive(Clone,Default)]
+#[derive(Clone,Default,PartialEq)]
 pub struct FileDescriptorProto {
     // message fields
     name: ::protobuf::SingularField<::std::string::String>,
@@ -219,8 +201,7 @@ pub struct FileDescriptorProto {
     source_code_info: ::protobuf::SingularPtrField<SourceCodeInfo>,
     syntax: ::protobuf::SingularField<::std::string::String>,
     // special fields
-    unknown_fields: ::protobuf::UnknownFields,
-    cached_size: ::std::cell::Cell<u32>,
+    special_fields: ::protobuf::SpecialFields,
 }
 
 // see codegen.rs for the explanation why impl Sync explicitly
@@ -786,9 +767,7 @@ impl ::protobuf::Message for FileDescriptorProto {
         if let Some(v) = self.syntax.as_ref() {
             my_size += ::protobuf::rt::string_size(12, &v);
         };
-        my_size += ::protobuf::rt::unknown_fields_size(self.get_unknown_fields());
-        self.cached_size.set(my_size);
-        my_size
+        self.set_cached_size(my_size)
     }
 
     fn write_to_with_cached_sizes(&self, os: &mut ::protobuf::CodedOutputStream) -> ::protobuf::ProtobufResult<()> {
@@ -844,20 +823,12 @@ impl ::protobuf::Message for FileDescriptorProto {
         ::std::result::Result::Ok(())
     }
 
-    fn get_cached_size(&self) -> u32 {
-        self.cached_size.get()
+    fn get_special_fields(&self) -> &::protobuf::SpecialFields {
+        &self.special_fields
     }
 
-    fn get_unknown_fields(&self) -> &::protobuf::UnknownFields {
-        &self.unknown_fields
-    }
-
-    fn mut_unknown_fields(&mut self) -> &mut ::protobuf::UnknownFields {
-        &mut self.unknown_fields
-    }
-
-    fn type_id(&self) -> ::std::any::TypeId {
-        ::std::any::TypeId::of::<FileDescriptorProto>()
+    fn mut_special_fields(&mut self) -> &mut ::protobuf::SpecialFields {
+        &mut self.special_fields
     }
 
     fn as_any(&self) -> &::std::any::Any {
@@ -966,25 +937,7 @@ impl ::protobuf::Clear for FileDescriptorProto {
         self.clear_options();
         self.clear_source_code_info();
         self.clear_syntax();
-        self.unknown_fields.clear();
-    }
-}
-
-impl ::std::cmp::PartialEq for FileDescriptorProto {
-    fn eq(&self, other: &FileDescriptorProto) -> bool {
-        self.name == other.name &&
-        self.package == other.package &&
-        self.dependency == other.dependency &&
-        self.public_dependency == other.public_dependency &&
-        self.weak_dependency == other.weak_dependency &&
-        self.message_type == other.message_type &&
-        self.enum_type == other.enum_type &&
-        self.service == other.service &&
-        self.extension == other.extension &&
-        self.options == other.options &&
-        self.source_code_info == other.source_code_info &&
-        self.syntax == other.syntax &&
-        self.unknown_fields == other.unknown_fields
+        self.mut_unknown_fields().clear();
     }
 }
 
@@ -1000,7 +953,7 @@ impl ::protobuf::reflect::ProtobufValue for FileDescriptorProto {
     }
 }
 
-#[derive(Clone,Default)]
+#[derive(Clone,Default,PartialEq)]
 pub struct DescriptorProto {
     // message fields
     name: ::protobuf::SingularField<::std::string::String>,
@@ -1014,8 +967,7 @@ pub struct DescriptorProto {
     reserved_range: ::protobuf::RepeatedField<DescriptorProto_ReservedRange>,
     reserved_name: ::protobuf::RepeatedField<::std::string::String>,
     // special fields
-    unknown_fields: ::protobuf::UnknownFields,
-    cached_size: ::std::cell::Cell<u32>,
+    special_fields: ::protobuf::SpecialFields,
 }
 
 // see codegen.rs for the explanation why impl Sync explicitly
@@ -1475,9 +1427,7 @@ impl ::protobuf::Message for DescriptorProto {
         for value in &self.reserved_name {
             my_size += ::protobuf::rt::string_size(10, &value);
         };
-        my_size += ::protobuf::rt::unknown_fields_size(self.get_unknown_fields());
-        self.cached_size.set(my_size);
-        my_size
+        self.set_cached_size(my_size)
     }
 
     fn write_to_with_cached_sizes(&self, os: &mut ::protobuf::CodedOutputStream) -> ::protobuf::ProtobufResult<()> {
@@ -1531,20 +1481,12 @@ impl ::protobuf::Message for DescriptorProto {
         ::std::result::Result::Ok(())
     }
 
-    fn get_cached_size(&self) -> u32 {
-        self.cached_size.get()
+    fn get_special_fields(&self) -> &::protobuf::SpecialFields {
+        &self.special_fields
     }
 
-    fn get_unknown_fields(&self) -> &::protobuf::UnknownFields {
-        &self.unknown_fields
-    }
-
-    fn mut_unknown_fields(&mut self) -> &mut ::protobuf::UnknownFields {
-        &mut self.unknown_fields
-    }
-
-    fn type_id(&self) -> ::std::any::TypeId {
-        ::std::any::TypeId::of::<DescriptorProto>()
+    fn mut_special_fields(&mut self) -> &mut ::protobuf::SpecialFields {
+        &mut self.special_fields
     }
 
     fn as_any(&self) -> &::std::any::Any {
@@ -1641,23 +1583,7 @@ impl ::protobuf::Clear for DescriptorProto {
         self.clear_options();
         self.clear_reserved_range();
         self.clear_reserved_name();
-        self.unknown_fields.clear();
-    }
-}
-
-impl ::std::cmp::PartialEq for DescriptorProto {
-    fn eq(&self, other: &DescriptorProto) -> bool {
-        self.name == other.name &&
-        self.field == other.field &&
-        self.extension == other.extension &&
-        self.nested_type == other.nested_type &&
-        self.enum_type == other.enum_type &&
-        self.extension_range == other.extension_range &&
-        self.oneof_decl == other.oneof_decl &&
-        self.options == other.options &&
-        self.reserved_range == other.reserved_range &&
-        self.reserved_name == other.reserved_name &&
-        self.unknown_fields == other.unknown_fields
+        self.mut_unknown_fields().clear();
     }
 }
 
@@ -1673,14 +1599,13 @@ impl ::protobuf::reflect::ProtobufValue for DescriptorProto {
     }
 }
 
-#[derive(Clone,Default)]
+#[derive(Clone,Default,PartialEq)]
 pub struct DescriptorProto_ExtensionRange {
     // message fields
     start: ::std::option::Option<i32>,
     end: ::std::option::Option<i32>,
     // special fields
-    unknown_fields: ::protobuf::UnknownFields,
-    cached_size: ::std::cell::Cell<u32>,
+    special_fields: ::protobuf::SpecialFields,
 }
 
 // see codegen.rs for the explanation why impl Sync explicitly
@@ -1797,9 +1722,7 @@ impl ::protobuf::Message for DescriptorProto_ExtensionRange {
         if let Some(v) = self.end {
             my_size += ::protobuf::rt::value_size(2, v, ::protobuf::wire_format::WireTypeVarint);
         };
-        my_size += ::protobuf::rt::unknown_fields_size(self.get_unknown_fields());
-        self.cached_size.set(my_size);
-        my_size
+        self.set_cached_size(my_size)
     }
 
     fn write_to_with_cached_sizes(&self, os: &mut ::protobuf::CodedOutputStream) -> ::protobuf::ProtobufResult<()> {
@@ -1813,20 +1736,12 @@ impl ::protobuf::Message for DescriptorProto_ExtensionRange {
         ::std::result::Result::Ok(())
     }
 
-    fn get_cached_size(&self) -> u32 {
-        self.cached_size.get()
+    fn get_special_fields(&self) -> &::protobuf::SpecialFields {
+        &self.special_fields
     }
 
-    fn get_unknown_fields(&self) -> &::protobuf::UnknownFields {
-        &self.unknown_fields
-    }
-
-    fn mut_unknown_fields(&mut self) -> &mut ::protobuf::UnknownFields {
-        &mut self.unknown_fields
-    }
-
-    fn type_id(&self) -> ::std::any::TypeId {
-        ::std::any::TypeId::of::<DescriptorProto_ExtensionRange>()
+    fn mut_special_fields(&mut self) -> &mut ::protobuf::SpecialFields {
+        &mut self.special_fields
     }
 
     fn as_any(&self) -> &::std::any::Any {
@@ -1875,15 +1790,7 @@ impl ::protobuf::Clear for DescriptorProto_ExtensionRange {
     fn clear(&mut self) {
         self.clear_start();
         self.clear_end();
-        self.unknown_fields.clear();
-    }
-}
-
-impl ::std::cmp::PartialEq for DescriptorProto_ExtensionRange {
-    fn eq(&self, other: &DescriptorProto_ExtensionRange) -> bool {
-        self.start == other.start &&
-        self.end == other.end &&
-        self.unknown_fields == other.unknown_fields
+        self.mut_unknown_fields().clear();
     }
 }
 
@@ -1899,14 +1806,13 @@ impl ::protobuf::reflect::ProtobufValue for DescriptorProto_ExtensionRange {
     }
 }
 
-#[derive(Clone,Default)]
+#[derive(Clone,Default,PartialEq)]
 pub struct DescriptorProto_ReservedRange {
     // message fields
     start: ::std::option::Option<i32>,
     end: ::std::option::Option<i32>,
     // special fields
-    unknown_fields: ::protobuf::UnknownFields,
-    cached_size: ::std::cell::Cell<u32>,
+    special_fields: ::protobuf::SpecialFields,
 }
 
 // see codegen.rs for the explanation why impl Sync explicitly
@@ -2023,9 +1929,7 @@ impl ::protobuf::Message for DescriptorProto_ReservedRange {
         if let Some(v) = self.end {
             my_size += ::protobuf::rt::value_size(2, v, ::protobuf::wire_format::WireTypeVarint);
         };
-        my_size += ::protobuf::rt::unknown_fields_size(self.get_unknown_fields());
-        self.cached_size.set(my_size);
-        my_size
+        self.set_cached_size(my_size)
     }
 
     fn write_to_with_cached_sizes(&self, os: &mut ::protobuf::CodedOutputStream) -> ::protobuf::ProtobufResult<()> {
@@ -2039,20 +1943,12 @@ impl ::protobuf::Message for DescriptorProto_ReservedRange {
         ::std::result::Result::Ok(())
     }
 
-    fn get_cached_size(&self) -> u32 {
-        self.cached_size.get()
+    fn get_special_fields(&self) -> &::protobuf::SpecialFields {
+        &self.special_fields
     }
 
-    fn get_unknown_fields(&self) -> &::protobuf::UnknownFields {
-        &self.unknown_fields
-    }
-
-    fn mut_unknown_fields(&mut self) -> &mut ::protobuf::UnknownFields {
-        &mut self.unknown_fields
-    }
-
-    fn type_id(&self) -> ::std::any::TypeId {
-        ::std::any::TypeId::of::<DescriptorProto_ReservedRange>()
+    fn mut_special_fields(&mut self) -> &mut ::protobuf::SpecialFields {
+        &mut self.special_fields
     }
 
     fn as_any(&self) -> &::std::any::Any {
@@ -2101,15 +1997,7 @@ impl ::protobuf::Clear for DescriptorProto_ReservedRange {
     fn clear(&mut self) {
         self.clear_start();
         self.clear_end();
-        self.unknown_fields.clear();
-    }
-}
-
-impl ::std::cmp::PartialEq for DescriptorProto_ReservedRange {
-    fn eq(&self, other: &DescriptorProto_ReservedRange) -> bool {
-        self.start == other.start &&
-        self.end == other.end &&
-        self.unknown_fields == other.unknown_fields
+        self.mut_unknown_fields().clear();
     }
 }
 
@@ -2125,7 +2013,7 @@ impl ::protobuf::reflect::ProtobufValue for DescriptorProto_ReservedRange {
     }
 }
 
-#[derive(Clone,Default)]
+#[derive(Clone,Default,PartialEq)]
 pub struct FieldDescriptorProto {
     // message fields
     name: ::protobuf::SingularField<::std::string::String>,
@@ -2139,8 +2027,7 @@ pub struct FieldDescriptorProto {
     json_name: ::protobuf::SingularField<::std::string::String>,
     options: ::protobuf::SingularPtrField<FieldOptions>,
     // special fields
-    unknown_fields: ::protobuf::UnknownFields,
-    cached_size: ::std::cell::Cell<u32>,
+    special_fields: ::protobuf::SpecialFields,
 }
 
 // see codegen.rs for the explanation why impl Sync explicitly
@@ -2629,9 +2516,7 @@ impl ::protobuf::Message for FieldDescriptorProto {
             let len = v.compute_size();
             my_size += 1 + ::protobuf::rt::compute_raw_varint32_size(len) + len;
         };
-        my_size += ::protobuf::rt::unknown_fields_size(self.get_unknown_fields());
-        self.cached_size.set(my_size);
-        my_size
+        self.set_cached_size(my_size)
     }
 
     fn write_to_with_cached_sizes(&self, os: &mut ::protobuf::CodedOutputStream) -> ::protobuf::ProtobufResult<()> {
@@ -2671,20 +2556,12 @@ impl ::protobuf::Message for FieldDescriptorProto {
         ::std::result::Result::Ok(())
     }
 
-    fn get_cached_size(&self) -> u32 {
-        self.cached_size.get()
+    fn get_special_fields(&self) -> &::protobuf::SpecialFields {
+        &self.special_fields
     }
 
-    fn get_unknown_fields(&self) -> &::protobuf::UnknownFields {
-        &self.unknown_fields
-    }
-
-    fn mut_unknown_fields(&mut self) -> &mut ::protobuf::UnknownFields {
-        &mut self.unknown_fields
-    }
-
-    fn type_id(&self) -> ::std::any::TypeId {
-        ::std::any::TypeId::of::<FieldDescriptorProto>()
+    fn mut_special_fields(&mut self) -> &mut ::protobuf::SpecialFields {
+        &mut self.special_fields
     }
 
     fn as_any(&self) -> &::std::any::Any {
@@ -2781,23 +2658,7 @@ impl ::protobuf::Clear for FieldDescriptorProto {
         self.clear_oneof_index();
         self.clear_json_name();
         self.clear_options();
-        self.unknown_fields.clear();
-    }
-}
-
-impl ::std::cmp::PartialEq for FieldDescriptorProto {
-    fn eq(&self, other: &FieldDescriptorProto) -> bool {
-        self.name == other.name &&
-        self.number == other.number &&
-        self.label == other.label &&
-        self.field_type == other.field_type &&
-        self.type_name == other.type_name &&
-        self.extendee == other.extendee &&
-        self.default_value == other.default_value &&
-        self.oneof_index == other.oneof_index &&
-        self.json_name == other.json_name &&
-        self.options == other.options &&
-        self.unknown_fields == other.unknown_fields
+        self.mut_unknown_fields().clear();
     }
 }
 
@@ -2962,14 +2823,13 @@ impl ::protobuf::reflect::ProtobufValue for FieldDescriptorProto_Label {
     }
 }
 
-#[derive(Clone,Default)]
+#[derive(Clone,Default,PartialEq)]
 pub struct OneofDescriptorProto {
     // message fields
     name: ::protobuf::SingularField<::std::string::String>,
     options: ::protobuf::SingularPtrField<OneofOptions>,
     // special fields
-    unknown_fields: ::protobuf::UnknownFields,
-    cached_size: ::std::cell::Cell<u32>,
+    special_fields: ::protobuf::SpecialFields,
 }
 
 // see codegen.rs for the explanation why impl Sync explicitly
@@ -3110,9 +2970,7 @@ impl ::protobuf::Message for OneofDescriptorProto {
             let len = v.compute_size();
             my_size += 1 + ::protobuf::rt::compute_raw_varint32_size(len) + len;
         };
-        my_size += ::protobuf::rt::unknown_fields_size(self.get_unknown_fields());
-        self.cached_size.set(my_size);
-        my_size
+        self.set_cached_size(my_size)
     }
 
     fn write_to_with_cached_sizes(&self, os: &mut ::protobuf::CodedOutputStream) -> ::protobuf::ProtobufResult<()> {
@@ -3128,20 +2986,12 @@ impl ::protobuf::Message for OneofDescriptorProto {
         ::std::result::Result::Ok(())
     }
 
-    fn get_cached_size(&self) -> u32 {
-        self.cached_size.get()
+    fn get_special_fields(&self) -> &::protobuf::SpecialFields {
+        &self.special_fields
     }
 
-    fn get_unknown_fields(&self) -> &::protobuf::UnknownFields {
-        &self.unknown_fields
-    }
-
-    fn mut_unknown_fields(&mut self) -> &mut ::protobuf::UnknownFields {
-        &mut self.unknown_fields
-    }
-
-    fn type_id(&self) -> ::std::any::TypeId {
-        ::std::any::TypeId::of::<OneofDescriptorProto>()
+    fn mut_special_fields(&mut self) -> &mut ::protobuf::SpecialFields {
+        &mut self.special_fields
     }
 
     fn as_any(&self) -> &::std::any::Any {
@@ -3190,15 +3040,7 @@ impl ::protobuf::Clear for OneofDescriptorProto {
     fn clear(&mut self) {
         self.clear_name();
         self.clear_options();
-        self.unknown_fields.clear();
-    }
-}
-
-impl ::std::cmp::PartialEq for OneofDescriptorProto {
-    fn eq(&self, other: &OneofDescriptorProto) -> bool {
-        self.name == other.name &&
-        self.options == other.options &&
-        self.unknown_fields == other.unknown_fields
+        self.mut_unknown_fields().clear();
     }
 }
 
@@ -3214,15 +3056,14 @@ impl ::protobuf::reflect::ProtobufValue for OneofDescriptorProto {
     }
 }
 
-#[derive(Clone,Default)]
+#[derive(Clone,Default,PartialEq)]
 pub struct EnumDescriptorProto {
     // message fields
     name: ::protobuf::SingularField<::std::string::String>,
     value: ::protobuf::RepeatedField<EnumValueDescriptorProto>,
     options: ::protobuf::SingularPtrField<EnumOptions>,
     // special fields
-    unknown_fields: ::protobuf::UnknownFields,
-    cached_size: ::std::cell::Cell<u32>,
+    special_fields: ::protobuf::SpecialFields,
 }
 
 // see codegen.rs for the explanation why impl Sync explicitly
@@ -3403,9 +3244,7 @@ impl ::protobuf::Message for EnumDescriptorProto {
             let len = v.compute_size();
             my_size += 1 + ::protobuf::rt::compute_raw_varint32_size(len) + len;
         };
-        my_size += ::protobuf::rt::unknown_fields_size(self.get_unknown_fields());
-        self.cached_size.set(my_size);
-        my_size
+        self.set_cached_size(my_size)
     }
 
     fn write_to_with_cached_sizes(&self, os: &mut ::protobuf::CodedOutputStream) -> ::protobuf::ProtobufResult<()> {
@@ -3426,20 +3265,12 @@ impl ::protobuf::Message for EnumDescriptorProto {
         ::std::result::Result::Ok(())
     }
 
-    fn get_cached_size(&self) -> u32 {
-        self.cached_size.get()
+    fn get_special_fields(&self) -> &::protobuf::SpecialFields {
+        &self.special_fields
     }
 
-    fn get_unknown_fields(&self) -> &::protobuf::UnknownFields {
-        &self.unknown_fields
-    }
-
-    fn mut_unknown_fields(&mut self) -> &mut ::protobuf::UnknownFields {
-        &mut self.unknown_fields
-    }
-
-    fn type_id(&self) -> ::std::any::TypeId {
-        ::std::any::TypeId::of::<EnumDescriptorProto>()
+    fn mut_special_fields(&mut self) -> &mut ::protobuf::SpecialFields {
+        &mut self.special_fields
     }
 
     fn as_any(&self) -> &::std::any::Any {
@@ -3494,16 +3325,7 @@ impl ::protobuf::Clear for EnumDescriptorProto {
         self.clear_name();
         self.clear_value();
         self.clear_options();
-        self.unknown_fields.clear();
-    }
-}
-
-impl ::std::cmp::PartialEq for EnumDescriptorProto {
-    fn eq(&self, other: &EnumDescriptorProto) -> bool {
-        self.name == other.name &&
-        self.value == other.value &&
-        self.options == other.options &&
-        self.unknown_fields == other.unknown_fields
+        self.mut_unknown_fields().clear();
     }
 }
 
@@ -3519,15 +3341,14 @@ impl ::protobuf::reflect::ProtobufValue for EnumDescriptorProto {
     }
 }
 
-#[derive(Clone,Default)]
+#[derive(Clone,Default,PartialEq)]
 pub struct EnumValueDescriptorProto {
     // message fields
     name: ::protobuf::SingularField<::std::string::String>,
     number: ::std::option::Option<i32>,
     options: ::protobuf::SingularPtrField<EnumValueOptions>,
     // special fields
-    unknown_fields: ::protobuf::UnknownFields,
-    cached_size: ::std::cell::Cell<u32>,
+    special_fields: ::protobuf::SpecialFields,
 }
 
 // see codegen.rs for the explanation why impl Sync explicitly
@@ -3705,9 +3526,7 @@ impl ::protobuf::Message for EnumValueDescriptorProto {
             let len = v.compute_size();
             my_size += 1 + ::protobuf::rt::compute_raw_varint32_size(len) + len;
         };
-        my_size += ::protobuf::rt::unknown_fields_size(self.get_unknown_fields());
-        self.cached_size.set(my_size);
-        my_size
+        self.set_cached_size(my_size)
     }
 
     fn write_to_with_cached_sizes(&self, os: &mut ::protobuf::CodedOutputStream) -> ::protobuf::ProtobufResult<()> {
@@ -3726,20 +3545,12 @@ impl ::protobuf::Message for EnumValueDescriptorProto {
         ::std::result::Result::Ok(())
     }
 
-    fn get_cached_size(&self) -> u32 {
-        self.cached_size.get()
+    fn get_special_fields(&self) -> &::protobuf::SpecialFields {
+        &self.special_fields
     }
 
-    fn get_unknown_fields(&self) -> &::protobuf::UnknownFields {
-        &self.unknown_fields
-    }
-
-    fn mut_unknown_fields(&mut self) -> &mut ::protobuf::UnknownFields {
-        &mut self.unknown_fields
-    }
-
-    fn type_id(&self) -> ::std::any::TypeId {
-        ::std::any::TypeId::of::<EnumValueDescriptorProto>()
+    fn mut_special_fields(&mut self) -> &mut ::protobuf::SpecialFields {
+        &mut self.special_fields
     }
 
     fn as_any(&self) -> &::std::any::Any {
@@ -3794,16 +3605,7 @@ impl ::protobuf::Clear for EnumValueDescriptorProto {
         self.clear_name();
         self.clear_number();
         self.clear_options();
-        self.unknown_fields.clear();
-    }
-}
-
-impl ::std::cmp::PartialEq for EnumValueDescriptorProto {
-    fn eq(&self, other: &EnumValueDescriptorProto) -> bool {
-        self.name == other.name &&
-        self.number == other.number &&
-        self.options == other.options &&
-        self.unknown_fields == other.unknown_fields
+        self.mut_unknown_fields().clear();
     }
 }
 
@@ -3819,15 +3621,14 @@ impl ::protobuf::reflect::ProtobufValue for EnumValueDescriptorProto {
     }
 }
 
-#[derive(Clone,Default)]
+#[derive(Clone,Default,PartialEq)]
 pub struct ServiceDescriptorProto {
     // message fields
     name: ::protobuf::SingularField<::std::string::String>,
     method: ::protobuf::RepeatedField<MethodDescriptorProto>,
     options: ::protobuf::SingularPtrField<ServiceOptions>,
     // special fields
-    unknown_fields: ::protobuf::UnknownFields,
-    cached_size: ::std::cell::Cell<u32>,
+    special_fields: ::protobuf::SpecialFields,
 }
 
 // see codegen.rs for the explanation why impl Sync explicitly
@@ -4008,9 +3809,7 @@ impl ::protobuf::Message for ServiceDescriptorProto {
             let len = v.compute_size();
             my_size += 1 + ::protobuf::rt::compute_raw_varint32_size(len) + len;
         };
-        my_size += ::protobuf::rt::unknown_fields_size(self.get_unknown_fields());
-        self.cached_size.set(my_size);
-        my_size
+        self.set_cached_size(my_size)
     }
 
     fn write_to_with_cached_sizes(&self, os: &mut ::protobuf::CodedOutputStream) -> ::protobuf::ProtobufResult<()> {
@@ -4031,20 +3830,12 @@ impl ::protobuf::Message for ServiceDescriptorProto {
         ::std::result::Result::Ok(())
     }
 
-    fn get_cached_size(&self) -> u32 {
-        self.cached_size.get()
+    fn get_special_fields(&self) -> &::protobuf::SpecialFields {
+        &self.special_fields
     }
 
-    fn get_unknown_fields(&self) -> &::protobuf::UnknownFields {
-        &self.unknown_fields
-    }
-
-    fn mut_unknown_fields(&mut self) -> &mut ::protobuf::UnknownFields {
-        &mut self.unknown_fields
-    }
-
-    fn type_id(&self) -> ::std::any::TypeId {
-        ::std::any::TypeId::of::<ServiceDescriptorProto>()
+    fn mut_special_fields(&mut self) -> &mut ::protobuf::SpecialFields {
+        &mut self.special_fields
     }
 
     fn as_any(&self) -> &::std::any::Any {
@@ -4099,16 +3890,7 @@ impl ::protobuf::Clear for ServiceDescriptorProto {
         self.clear_name();
         self.clear_method();
         self.clear_options();
-        self.unknown_fields.clear();
-    }
-}
-
-impl ::std::cmp::PartialEq for ServiceDescriptorProto {
-    fn eq(&self, other: &ServiceDescriptorProto) -> bool {
-        self.name == other.name &&
-        self.method == other.method &&
-        self.options == other.options &&
-        self.unknown_fields == other.unknown_fields
+        self.mut_unknown_fields().clear();
     }
 }
 
@@ -4124,7 +3906,7 @@ impl ::protobuf::reflect::ProtobufValue for ServiceDescriptorProto {
     }
 }
 
-#[derive(Clone,Default)]
+#[derive(Clone,Default,PartialEq)]
 pub struct MethodDescriptorProto {
     // message fields
     name: ::protobuf::SingularField<::std::string::String>,
@@ -4134,8 +3916,7 @@ pub struct MethodDescriptorProto {
     client_streaming: ::std::option::Option<bool>,
     server_streaming: ::std::option::Option<bool>,
     // special fields
-    unknown_fields: ::protobuf::UnknownFields,
-    cached_size: ::std::cell::Cell<u32>,
+    special_fields: ::protobuf::SpecialFields,
 }
 
 // see codegen.rs for the explanation why impl Sync explicitly
@@ -4450,9 +4231,7 @@ impl ::protobuf::Message for MethodDescriptorProto {
         if let Some(v) = self.server_streaming {
             my_size += 2;
         };
-        my_size += ::protobuf::rt::unknown_fields_size(self.get_unknown_fields());
-        self.cached_size.set(my_size);
-        my_size
+        self.set_cached_size(my_size)
     }
 
     fn write_to_with_cached_sizes(&self, os: &mut ::protobuf::CodedOutputStream) -> ::protobuf::ProtobufResult<()> {
@@ -4480,20 +4259,12 @@ impl ::protobuf::Message for MethodDescriptorProto {
         ::std::result::Result::Ok(())
     }
 
-    fn get_cached_size(&self) -> u32 {
-        self.cached_size.get()
+    fn get_special_fields(&self) -> &::protobuf::SpecialFields {
+        &self.special_fields
     }
 
-    fn get_unknown_fields(&self) -> &::protobuf::UnknownFields {
-        &self.unknown_fields
-    }
-
-    fn mut_unknown_fields(&mut self) -> &mut ::protobuf::UnknownFields {
-        &mut self.unknown_fields
-    }
-
-    fn type_id(&self) -> ::std::any::TypeId {
-        ::std::any::TypeId::of::<MethodDescriptorProto>()
+    fn mut_special_fields(&mut self) -> &mut ::protobuf::SpecialFields {
+        &mut self.special_fields
     }
 
     fn as_any(&self) -> &::std::any::Any {
@@ -4566,19 +4337,7 @@ impl ::protobuf::Clear for MethodDescriptorProto {
         self.clear_options();
         self.clear_client_streaming();
         self.clear_server_streaming();
-        self.unknown_fields.clear();
-    }
-}
-
-impl ::std::cmp::PartialEq for MethodDescriptorProto {
-    fn eq(&self, other: &MethodDescriptorProto) -> bool {
-        self.name == other.name &&
-        self.input_type == other.input_type &&
-        self.output_type == other.output_type &&
-        self.options == other.options &&
-        self.client_streaming == other.client_streaming &&
-        self.server_streaming == other.server_streaming &&
-        self.unknown_fields == other.unknown_fields
+        self.mut_unknown_fields().clear();
     }
 }
 
@@ -4594,7 +4353,7 @@ impl ::protobuf::reflect::ProtobufValue for MethodDescriptorProto {
     }
 }
 
-#[derive(Clone,Default)]
+#[derive(Clone,Default,PartialEq)]
 pub struct FileOptions {
     // message fields
     java_package: ::protobuf::SingularField<::std::string::String>,
@@ -4613,8 +4372,7 @@ pub struct FileOptions {
     csharp_namespace: ::protobuf::SingularField<::std::string::String>,
     uninterpreted_option: ::protobuf::RepeatedField<UninterpretedOption>,
     // special fields
-    unknown_fields: ::protobuf::UnknownFields,
-    cached_size: ::std::cell::Cell<u32>,
+    special_fields: ::protobuf::SpecialFields,
 }
 
 // see codegen.rs for the explanation why impl Sync explicitly
@@ -5280,9 +5038,7 @@ impl ::protobuf::Message for FileOptions {
             let len = value.compute_size();
             my_size += 2 + ::protobuf::rt::compute_raw_varint32_size(len) + len;
         };
-        my_size += ::protobuf::rt::unknown_fields_size(self.get_unknown_fields());
-        self.cached_size.set(my_size);
-        my_size
+        self.set_cached_size(my_size)
     }
 
     fn write_to_with_cached_sizes(&self, os: &mut ::protobuf::CodedOutputStream) -> ::protobuf::ProtobufResult<()> {
@@ -5337,20 +5093,12 @@ impl ::protobuf::Message for FileOptions {
         ::std::result::Result::Ok(())
     }
 
-    fn get_cached_size(&self) -> u32 {
-        self.cached_size.get()
+    fn get_special_fields(&self) -> &::protobuf::SpecialFields {
+        &self.special_fields
     }
 
-    fn get_unknown_fields(&self) -> &::protobuf::UnknownFields {
-        &self.unknown_fields
-    }
-
-    fn mut_unknown_fields(&mut self) -> &mut ::protobuf::UnknownFields {
-        &mut self.unknown_fields
-    }
-
-    fn type_id(&self) -> ::std::any::TypeId {
-        ::std::any::TypeId::of::<FileOptions>()
+    fn mut_special_fields(&mut self) -> &mut ::protobuf::SpecialFields {
+        &mut self.special_fields
     }
 
     fn as_any(&self) -> &::std::any::Any {
@@ -5477,28 +5225,7 @@ impl ::protobuf::Clear for FileOptions {
         self.clear_objc_class_prefix();
         self.clear_csharp_namespace();
         self.clear_uninterpreted_option();
-        self.unknown_fields.clear();
-    }
-}
-
-impl ::std::cmp::PartialEq for FileOptions {
-    fn eq(&self, other: &FileOptions) -> bool {
-        self.java_package == other.java_package &&
-        self.java_outer_classname == other.java_outer_classname &&
-        self.java_multiple_files == other.java_multiple_files &&
-        self.java_generate_equals_and_hash == other.java_generate_equals_and_hash &&
-        self.java_string_check_utf8 == other.java_string_check_utf8 &&
-        self.optimize_for == other.optimize_for &&
-        self.go_package == other.go_package &&
-        self.cc_generic_services == other.cc_generic_services &&
-        self.java_generic_services == other.java_generic_services &&
-        self.py_generic_services == other.py_generic_services &&
-        self.deprecated == other.deprecated &&
-        self.cc_enable_arenas == other.cc_enable_arenas &&
-        self.objc_class_prefix == other.objc_class_prefix &&
-        self.csharp_namespace == other.csharp_namespace &&
-        self.uninterpreted_option == other.uninterpreted_option &&
-        self.unknown_fields == other.unknown_fields
+        self.mut_unknown_fields().clear();
     }
 }
 
@@ -5566,7 +5293,7 @@ impl ::protobuf::reflect::ProtobufValue for FileOptions_OptimizeMode {
     }
 }
 
-#[derive(Clone,Default)]
+#[derive(Clone,Default,PartialEq)]
 pub struct MessageOptions {
     // message fields
     message_set_wire_format: ::std::option::Option<bool>,
@@ -5575,8 +5302,7 @@ pub struct MessageOptions {
     map_entry: ::std::option::Option<bool>,
     uninterpreted_option: ::protobuf::RepeatedField<UninterpretedOption>,
     // special fields
-    unknown_fields: ::protobuf::UnknownFields,
-    cached_size: ::std::cell::Cell<u32>,
+    special_fields: ::protobuf::SpecialFields,
 }
 
 // see codegen.rs for the explanation why impl Sync explicitly
@@ -5807,9 +5533,7 @@ impl ::protobuf::Message for MessageOptions {
             let len = value.compute_size();
             my_size += 2 + ::protobuf::rt::compute_raw_varint32_size(len) + len;
         };
-        my_size += ::protobuf::rt::unknown_fields_size(self.get_unknown_fields());
-        self.cached_size.set(my_size);
-        my_size
+        self.set_cached_size(my_size)
     }
 
     fn write_to_with_cached_sizes(&self, os: &mut ::protobuf::CodedOutputStream) -> ::protobuf::ProtobufResult<()> {
@@ -5834,20 +5558,12 @@ impl ::protobuf::Message for MessageOptions {
         ::std::result::Result::Ok(())
     }
 
-    fn get_cached_size(&self) -> u32 {
-        self.cached_size.get()
+    fn get_special_fields(&self) -> &::protobuf::SpecialFields {
+        &self.special_fields
     }
 
-    fn get_unknown_fields(&self) -> &::protobuf::UnknownFields {
-        &self.unknown_fields
-    }
-
-    fn mut_unknown_fields(&mut self) -> &mut ::protobuf::UnknownFields {
-        &mut self.unknown_fields
-    }
-
-    fn type_id(&self) -> ::std::any::TypeId {
-        ::std::any::TypeId::of::<MessageOptions>()
+    fn mut_special_fields(&mut self) -> &mut ::protobuf::SpecialFields {
+        &mut self.special_fields
     }
 
     fn as_any(&self) -> &::std::any::Any {
@@ -5914,18 +5630,7 @@ impl ::protobuf::Clear for MessageOptions {
         self.clear_deprecated();
         self.clear_map_entry();
         self.clear_uninterpreted_option();
-        self.unknown_fields.clear();
-    }
-}
-
-impl ::std::cmp::PartialEq for MessageOptions {
-    fn eq(&self, other: &MessageOptions) -> bool {
-        self.message_set_wire_format == other.message_set_wire_format &&
-        self.no_standard_descriptor_accessor == other.no_standard_descriptor_accessor &&
-        self.deprecated == other.deprecated &&
-        self.map_entry == other.map_entry &&
-        self.uninterpreted_option == other.uninterpreted_option &&
-        self.unknown_fields == other.unknown_fields
+        self.mut_unknown_fields().clear();
     }
 }
 
@@ -5941,7 +5646,7 @@ impl ::protobuf::reflect::ProtobufValue for MessageOptions {
     }
 }
 
-#[derive(Clone,Default)]
+#[derive(Clone,Default,PartialEq)]
 pub struct FieldOptions {
     // message fields
     ctype: ::std::option::Option<FieldOptions_CType>,
@@ -5952,8 +5657,7 @@ pub struct FieldOptions {
     weak: ::std::option::Option<bool>,
     uninterpreted_option: ::protobuf::RepeatedField<UninterpretedOption>,
     // special fields
-    unknown_fields: ::protobuf::UnknownFields,
-    cached_size: ::std::cell::Cell<u32>,
+    special_fields: ::protobuf::SpecialFields,
 }
 
 // see codegen.rs for the explanation why impl Sync explicitly
@@ -6258,9 +5962,7 @@ impl ::protobuf::Message for FieldOptions {
             let len = value.compute_size();
             my_size += 2 + ::protobuf::rt::compute_raw_varint32_size(len) + len;
         };
-        my_size += ::protobuf::rt::unknown_fields_size(self.get_unknown_fields());
-        self.cached_size.set(my_size);
-        my_size
+        self.set_cached_size(my_size)
     }
 
     fn write_to_with_cached_sizes(&self, os: &mut ::protobuf::CodedOutputStream) -> ::protobuf::ProtobufResult<()> {
@@ -6291,20 +5993,12 @@ impl ::protobuf::Message for FieldOptions {
         ::std::result::Result::Ok(())
     }
 
-    fn get_cached_size(&self) -> u32 {
-        self.cached_size.get()
+    fn get_special_fields(&self) -> &::protobuf::SpecialFields {
+        &self.special_fields
     }
 
-    fn get_unknown_fields(&self) -> &::protobuf::UnknownFields {
-        &self.unknown_fields
-    }
-
-    fn mut_unknown_fields(&mut self) -> &mut ::protobuf::UnknownFields {
-        &mut self.unknown_fields
-    }
-
-    fn type_id(&self) -> ::std::any::TypeId {
-        ::std::any::TypeId::of::<FieldOptions>()
+    fn mut_special_fields(&mut self) -> &mut ::protobuf::SpecialFields {
+        &mut self.special_fields
     }
 
     fn as_any(&self) -> &::std::any::Any {
@@ -6383,20 +6077,7 @@ impl ::protobuf::Clear for FieldOptions {
         self.clear_deprecated();
         self.clear_weak();
         self.clear_uninterpreted_option();
-        self.unknown_fields.clear();
-    }
-}
-
-impl ::std::cmp::PartialEq for FieldOptions {
-    fn eq(&self, other: &FieldOptions) -> bool {
-        self.ctype == other.ctype &&
-        self.packed == other.packed &&
-        self.jstype == other.jstype &&
-        self.lazy == other.lazy &&
-        self.deprecated == other.deprecated &&
-        self.weak == other.weak &&
-        self.uninterpreted_option == other.uninterpreted_option &&
-        self.unknown_fields == other.unknown_fields
+        self.mut_unknown_fields().clear();
     }
 }
 
@@ -6516,13 +6197,12 @@ impl ::protobuf::reflect::ProtobufValue for FieldOptions_JSType {
     }
 }
 
-#[derive(Clone,Default)]
+#[derive(Clone,Default,PartialEq)]
 pub struct OneofOptions {
     // message fields
     uninterpreted_option: ::protobuf::RepeatedField<UninterpretedOption>,
     // special fields
-    unknown_fields: ::protobuf::UnknownFields,
-    cached_size: ::std::cell::Cell<u32>,
+    special_fields: ::protobuf::SpecialFields,
 }
 
 // see codegen.rs for the explanation why impl Sync explicitly
@@ -6605,9 +6285,7 @@ impl ::protobuf::Message for OneofOptions {
             let len = value.compute_size();
             my_size += 2 + ::protobuf::rt::compute_raw_varint32_size(len) + len;
         };
-        my_size += ::protobuf::rt::unknown_fields_size(self.get_unknown_fields());
-        self.cached_size.set(my_size);
-        my_size
+        self.set_cached_size(my_size)
     }
 
     fn write_to_with_cached_sizes(&self, os: &mut ::protobuf::CodedOutputStream) -> ::protobuf::ProtobufResult<()> {
@@ -6620,20 +6298,12 @@ impl ::protobuf::Message for OneofOptions {
         ::std::result::Result::Ok(())
     }
 
-    fn get_cached_size(&self) -> u32 {
-        self.cached_size.get()
+    fn get_special_fields(&self) -> &::protobuf::SpecialFields {
+        &self.special_fields
     }
 
-    fn get_unknown_fields(&self) -> &::protobuf::UnknownFields {
-        &self.unknown_fields
-    }
-
-    fn mut_unknown_fields(&mut self) -> &mut ::protobuf::UnknownFields {
-        &mut self.unknown_fields
-    }
-
-    fn type_id(&self) -> ::std::any::TypeId {
-        ::std::any::TypeId::of::<OneofOptions>()
+    fn mut_special_fields(&mut self) -> &mut ::protobuf::SpecialFields {
+        &mut self.special_fields
     }
 
     fn as_any(&self) -> &::std::any::Any {
@@ -6676,14 +6346,7 @@ impl ::protobuf::MessageStatic for OneofOptions {
 impl ::protobuf::Clear for OneofOptions {
     fn clear(&mut self) {
         self.clear_uninterpreted_option();
-        self.unknown_fields.clear();
-    }
-}
-
-impl ::std::cmp::PartialEq for OneofOptions {
-    fn eq(&self, other: &OneofOptions) -> bool {
-        self.uninterpreted_option == other.uninterpreted_option &&
-        self.unknown_fields == other.unknown_fields
+        self.mut_unknown_fields().clear();
     }
 }
 
@@ -6699,15 +6362,14 @@ impl ::protobuf::reflect::ProtobufValue for OneofOptions {
     }
 }
 
-#[derive(Clone,Default)]
+#[derive(Clone,Default,PartialEq)]
 pub struct EnumOptions {
     // message fields
     allow_alias: ::std::option::Option<bool>,
     deprecated: ::std::option::Option<bool>,
     uninterpreted_option: ::protobuf::RepeatedField<UninterpretedOption>,
     // special fields
-    unknown_fields: ::protobuf::UnknownFields,
-    cached_size: ::std::cell::Cell<u32>,
+    special_fields: ::protobuf::SpecialFields,
 }
 
 // see codegen.rs for the explanation why impl Sync explicitly
@@ -6864,9 +6526,7 @@ impl ::protobuf::Message for EnumOptions {
             let len = value.compute_size();
             my_size += 2 + ::protobuf::rt::compute_raw_varint32_size(len) + len;
         };
-        my_size += ::protobuf::rt::unknown_fields_size(self.get_unknown_fields());
-        self.cached_size.set(my_size);
-        my_size
+        self.set_cached_size(my_size)
     }
 
     fn write_to_with_cached_sizes(&self, os: &mut ::protobuf::CodedOutputStream) -> ::protobuf::ProtobufResult<()> {
@@ -6885,20 +6545,12 @@ impl ::protobuf::Message for EnumOptions {
         ::std::result::Result::Ok(())
     }
 
-    fn get_cached_size(&self) -> u32 {
-        self.cached_size.get()
+    fn get_special_fields(&self) -> &::protobuf::SpecialFields {
+        &self.special_fields
     }
 
-    fn get_unknown_fields(&self) -> &::protobuf::UnknownFields {
-        &self.unknown_fields
-    }
-
-    fn mut_unknown_fields(&mut self) -> &mut ::protobuf::UnknownFields {
-        &mut self.unknown_fields
-    }
-
-    fn type_id(&self) -> ::std::any::TypeId {
-        ::std::any::TypeId::of::<EnumOptions>()
+    fn mut_special_fields(&mut self) -> &mut ::protobuf::SpecialFields {
+        &mut self.special_fields
     }
 
     fn as_any(&self) -> &::std::any::Any {
@@ -6953,16 +6605,7 @@ impl ::protobuf::Clear for EnumOptions {
         self.clear_allow_alias();
         self.clear_deprecated();
         self.clear_uninterpreted_option();
-        self.unknown_fields.clear();
-    }
-}
-
-impl ::std::cmp::PartialEq for EnumOptions {
-    fn eq(&self, other: &EnumOptions) -> bool {
-        self.allow_alias == other.allow_alias &&
-        self.deprecated == other.deprecated &&
-        self.uninterpreted_option == other.uninterpreted_option &&
-        self.unknown_fields == other.unknown_fields
+        self.mut_unknown_fields().clear();
     }
 }
 
@@ -6978,14 +6621,13 @@ impl ::protobuf::reflect::ProtobufValue for EnumOptions {
     }
 }
 
-#[derive(Clone,Default)]
+#[derive(Clone,Default,PartialEq)]
 pub struct EnumValueOptions {
     // message fields
     deprecated: ::std::option::Option<bool>,
     uninterpreted_option: ::protobuf::RepeatedField<UninterpretedOption>,
     // special fields
-    unknown_fields: ::protobuf::UnknownFields,
-    cached_size: ::std::cell::Cell<u32>,
+    special_fields: ::protobuf::SpecialFields,
 }
 
 // see codegen.rs for the explanation why impl Sync explicitly
@@ -7105,9 +6747,7 @@ impl ::protobuf::Message for EnumValueOptions {
             let len = value.compute_size();
             my_size += 2 + ::protobuf::rt::compute_raw_varint32_size(len) + len;
         };
-        my_size += ::protobuf::rt::unknown_fields_size(self.get_unknown_fields());
-        self.cached_size.set(my_size);
-        my_size
+        self.set_cached_size(my_size)
     }
 
     fn write_to_with_cached_sizes(&self, os: &mut ::protobuf::CodedOutputStream) -> ::protobuf::ProtobufResult<()> {
@@ -7123,20 +6763,12 @@ impl ::protobuf::Message for EnumValueOptions {
         ::std::result::Result::Ok(())
     }
 
-    fn get_cached_size(&self) -> u32 {
-        self.cached_size.get()
+    fn get_special_fields(&self) -> &::protobuf::SpecialFields {
+        &self.special_fields
     }
 
-    fn get_unknown_fields(&self) -> &::protobuf::UnknownFields {
-        &self.unknown_fields
-    }
-
-    fn mut_unknown_fields(&mut self) -> &mut ::protobuf::UnknownFields {
-        &mut self.unknown_fields
-    }
-
-    fn type_id(&self) -> ::std::any::TypeId {
-        ::std::any::TypeId::of::<EnumValueOptions>()
+    fn mut_special_fields(&mut self) -> &mut ::protobuf::SpecialFields {
+        &mut self.special_fields
     }
 
     fn as_any(&self) -> &::std::any::Any {
@@ -7185,15 +6817,7 @@ impl ::protobuf::Clear for EnumValueOptions {
     fn clear(&mut self) {
         self.clear_deprecated();
         self.clear_uninterpreted_option();
-        self.unknown_fields.clear();
-    }
-}
-
-impl ::std::cmp::PartialEq for EnumValueOptions {
-    fn eq(&self, other: &EnumValueOptions) -> bool {
-        self.deprecated == other.deprecated &&
-        self.uninterpreted_option == other.uninterpreted_option &&
-        self.unknown_fields == other.unknown_fields
+        self.mut_unknown_fields().clear();
     }
 }
 
@@ -7209,14 +6833,13 @@ impl ::protobuf::reflect::ProtobufValue for EnumValueOptions {
     }
 }
 
-#[derive(Clone,Default)]
+#[derive(Clone,Default,PartialEq)]
 pub struct ServiceOptions {
     // message fields
     deprecated: ::std::option::Option<bool>,
     uninterpreted_option: ::protobuf::RepeatedField<UninterpretedOption>,
     // special fields
-    unknown_fields: ::protobuf::UnknownFields,
-    cached_size: ::std::cell::Cell<u32>,
+    special_fields: ::protobuf::SpecialFields,
 }
 
 // see codegen.rs for the explanation why impl Sync explicitly
@@ -7336,9 +6959,7 @@ impl ::protobuf::Message for ServiceOptions {
             let len = value.compute_size();
             my_size += 2 + ::protobuf::rt::compute_raw_varint32_size(len) + len;
         };
-        my_size += ::protobuf::rt::unknown_fields_size(self.get_unknown_fields());
-        self.cached_size.set(my_size);
-        my_size
+        self.set_cached_size(my_size)
     }
 
     fn write_to_with_cached_sizes(&self, os: &mut ::protobuf::CodedOutputStream) -> ::protobuf::ProtobufResult<()> {
@@ -7354,20 +6975,12 @@ impl ::protobuf::Message for ServiceOptions {
         ::std::result::Result::Ok(())
     }
 
-    fn get_cached_size(&self) -> u32 {
-        self.cached_size.get()
+    fn get_special_fields(&self) -> &::protobuf::SpecialFields {
+        &self.special_fields
     }
 
-    fn get_unknown_fields(&self) -> &::protobuf::UnknownFields {
-        &self.unknown_fields
-    }
-
-    fn mut_unknown_fields(&mut self) -> &mut ::protobuf::UnknownFields {
-        &mut self.unknown_fields
-    }
-
-    fn type_id(&self) -> ::std::any::TypeId {
-        ::std::any::TypeId::of::<ServiceOptions>()
+    fn mut_special_fields(&mut self) -> &mut ::protobuf::SpecialFields {
+        &mut self.special_fields
     }
 
     fn as_any(&self) -> &::std::any::Any {
@@ -7416,15 +7029,7 @@ impl ::protobuf::Clear for ServiceOptions {
     fn clear(&mut self) {
         self.clear_deprecated();
         self.clear_uninterpreted_option();
-        self.unknown_fields.clear();
-    }
-}
-
-impl ::std::cmp::PartialEq for ServiceOptions {
-    fn eq(&self, other: &ServiceOptions) -> bool {
-        self.deprecated == other.deprecated &&
-        self.uninterpreted_option == other.uninterpreted_option &&
-        self.unknown_fields == other.unknown_fields
+        self.mut_unknown_fields().clear();
     }
 }
 
@@ -7440,14 +7045,13 @@ impl ::protobuf::reflect::ProtobufValue for ServiceOptions {
     }
 }
 
-#[derive(Clone,Default)]
+#[derive(Clone,Default,PartialEq)]
 pub struct MethodOptions {
     // message fields
     deprecated: ::std::option::Option<bool>,
     uninterpreted_option: ::protobuf::RepeatedField<UninterpretedOption>,
     // special fields
-    unknown_fields: ::protobuf::UnknownFields,
-    cached_size: ::std::cell::Cell<u32>,
+    special_fields: ::protobuf::SpecialFields,
 }
 
 // see codegen.rs for the explanation why impl Sync explicitly
@@ -7567,9 +7171,7 @@ impl ::protobuf::Message for MethodOptions {
             let len = value.compute_size();
             my_size += 2 + ::protobuf::rt::compute_raw_varint32_size(len) + len;
         };
-        my_size += ::protobuf::rt::unknown_fields_size(self.get_unknown_fields());
-        self.cached_size.set(my_size);
-        my_size
+        self.set_cached_size(my_size)
     }
 
     fn write_to_with_cached_sizes(&self, os: &mut ::protobuf::CodedOutputStream) -> ::protobuf::ProtobufResult<()> {
@@ -7585,20 +7187,12 @@ impl ::protobuf::Message for MethodOptions {
         ::std::result::Result::Ok(())
     }
 
-    fn get_cached_size(&self) -> u32 {
-        self.cached_size.get()
+    fn get_special_fields(&self) -> &::protobuf::SpecialFields {
+        &self.special_fields
     }
 
-    fn get_unknown_fields(&self) -> &::protobuf::UnknownFields {
-        &self.unknown_fields
-    }
-
-    fn mut_unknown_fields(&mut self) -> &mut ::protobuf::UnknownFields {
-        &mut self.unknown_fields
-    }
-
-    fn type_id(&self) -> ::std::any::TypeId {
-        ::std::any::TypeId::of::<MethodOptions>()
+    fn mut_special_fields(&mut self) -> &mut ::protobuf::SpecialFields {
+        &mut self.special_fields
     }
 
     fn as_any(&self) -> &::std::any::Any {
@@ -7647,15 +7241,7 @@ impl ::protobuf::Clear for MethodOptions {
     fn clear(&mut self) {
         self.clear_deprecated();
         self.clear_uninterpreted_option();
-        self.unknown_fields.clear();
-    }
-}
-
-impl ::std::cmp::PartialEq for MethodOptions {
-    fn eq(&self, other: &MethodOptions) -> bool {
-        self.deprecated == other.deprecated &&
-        self.uninterpreted_option == other.uninterpreted_option &&
-        self.unknown_fields == other.unknown_fields
+        self.mut_unknown_fields().clear();
     }
 }
 
@@ -7671,7 +7257,7 @@ impl ::protobuf::reflect::ProtobufValue for MethodOptions {
     }
 }
 
-#[derive(Clone,Default)]
+#[derive(Clone,Default,PartialEq)]
 pub struct UninterpretedOption {
     // message fields
     name: ::protobuf::RepeatedField<UninterpretedOption_NamePart>,
@@ -7682,8 +7268,7 @@ pub struct UninterpretedOption {
     string_value: ::protobuf::SingularField<::std::vec::Vec<u8>>,
     aggregate_value: ::protobuf::SingularField<::std::string::String>,
     // special fields
-    unknown_fields: ::protobuf::UnknownFields,
-    cached_size: ::std::cell::Cell<u32>,
+    special_fields: ::protobuf::SpecialFields,
 }
 
 // see codegen.rs for the explanation why impl Sync explicitly
@@ -8027,9 +7612,7 @@ impl ::protobuf::Message for UninterpretedOption {
         if let Some(v) = self.aggregate_value.as_ref() {
             my_size += ::protobuf::rt::string_size(8, &v);
         };
-        my_size += ::protobuf::rt::unknown_fields_size(self.get_unknown_fields());
-        self.cached_size.set(my_size);
-        my_size
+        self.set_cached_size(my_size)
     }
 
     fn write_to_with_cached_sizes(&self, os: &mut ::protobuf::CodedOutputStream) -> ::protobuf::ProtobufResult<()> {
@@ -8060,20 +7643,12 @@ impl ::protobuf::Message for UninterpretedOption {
         ::std::result::Result::Ok(())
     }
 
-    fn get_cached_size(&self) -> u32 {
-        self.cached_size.get()
+    fn get_special_fields(&self) -> &::protobuf::SpecialFields {
+        &self.special_fields
     }
 
-    fn get_unknown_fields(&self) -> &::protobuf::UnknownFields {
-        &self.unknown_fields
-    }
-
-    fn mut_unknown_fields(&mut self) -> &mut ::protobuf::UnknownFields {
-        &mut self.unknown_fields
-    }
-
-    fn type_id(&self) -> ::std::any::TypeId {
-        ::std::any::TypeId::of::<UninterpretedOption>()
+    fn mut_special_fields(&mut self) -> &mut ::protobuf::SpecialFields {
+        &mut self.special_fields
     }
 
     fn as_any(&self) -> &::std::any::Any {
@@ -8152,20 +7727,7 @@ impl ::protobuf::Clear for UninterpretedOption {
         self.clear_double_value();
         self.clear_string_value();
         self.clear_aggregate_value();
-        self.unknown_fields.clear();
-    }
-}
-
-impl ::std::cmp::PartialEq for UninterpretedOption {
-    fn eq(&self, other: &UninterpretedOption) -> bool {
-        self.name == other.name &&
-        self.identifier_value == other.identifier_value &&
-        self.positive_int_value == other.positive_int_value &&
-        self.negative_int_value == other.negative_int_value &&
-        self.double_value == other.double_value &&
-        self.string_value == other.string_value &&
-        self.aggregate_value == other.aggregate_value &&
-        self.unknown_fields == other.unknown_fields
+        self.mut_unknown_fields().clear();
     }
 }
 
@@ -8181,14 +7743,13 @@ impl ::protobuf::reflect::ProtobufValue for UninterpretedOption {
     }
 }
 
-#[derive(Clone,Default)]
+#[derive(Clone,Default,PartialEq)]
 pub struct UninterpretedOption_NamePart {
     // message fields
     name_part: ::protobuf::SingularField<::std::string::String>,
     is_extension: ::std::option::Option<bool>,
     // special fields
-    unknown_fields: ::protobuf::UnknownFields,
-    cached_size: ::std::cell::Cell<u32>,
+    special_fields: ::protobuf::SpecialFields,
 }
 
 // see codegen.rs for the explanation why impl Sync explicitly
@@ -8324,9 +7885,7 @@ impl ::protobuf::Message for UninterpretedOption_NamePart {
         if let Some(v) = self.is_extension {
             my_size += 2;
         };
-        my_size += ::protobuf::rt::unknown_fields_size(self.get_unknown_fields());
-        self.cached_size.set(my_size);
-        my_size
+        self.set_cached_size(my_size)
     }
 
     fn write_to_with_cached_sizes(&self, os: &mut ::protobuf::CodedOutputStream) -> ::protobuf::ProtobufResult<()> {
@@ -8340,20 +7899,12 @@ impl ::protobuf::Message for UninterpretedOption_NamePart {
         ::std::result::Result::Ok(())
     }
 
-    fn get_cached_size(&self) -> u32 {
-        self.cached_size.get()
+    fn get_special_fields(&self) -> &::protobuf::SpecialFields {
+        &self.special_fields
     }
 
-    fn get_unknown_fields(&self) -> &::protobuf::UnknownFields {
-        &self.unknown_fields
-    }
-
-    fn mut_unknown_fields(&mut self) -> &mut ::protobuf::UnknownFields {
-        &mut self.unknown_fields
-    }
-
-    fn type_id(&self) -> ::std::any::TypeId {
-        ::std::any::TypeId::of::<UninterpretedOption_NamePart>()
+    fn mut_special_fields(&mut self) -> &mut ::protobuf::SpecialFields {
+        &mut self.special_fields
     }
 
     fn as_any(&self) -> &::std::any::Any {
@@ -8402,15 +7953,7 @@ impl ::protobuf::Clear for UninterpretedOption_NamePart {
     fn clear(&mut self) {
         self.clear_name_part();
         self.clear_is_extension();
-        self.unknown_fields.clear();
-    }
-}
-
-impl ::std::cmp::PartialEq for UninterpretedOption_NamePart {
-    fn eq(&self, other: &UninterpretedOption_NamePart) -> bool {
-        self.name_part == other.name_part &&
-        self.is_extension == other.is_extension &&
-        self.unknown_fields == other.unknown_fields
+        self.mut_unknown_fields().clear();
     }
 }
 
@@ -8426,13 +7969,12 @@ impl ::protobuf::reflect::ProtobufValue for UninterpretedOption_NamePart {
     }
 }
 
-#[derive(Clone,Default)]
+#[derive(Clone,Default,PartialEq)]
 pub struct SourceCodeInfo {
     // message fields
     location: ::protobuf::RepeatedField<SourceCodeInfo_Location>,
     // special fields
-    unknown_fields: ::protobuf::UnknownFields,
-    cached_size: ::std::cell::Cell<u32>,
+    special_fields: ::protobuf::SpecialFields,
 }
 
 // see codegen.rs for the explanation why impl Sync explicitly
@@ -8515,9 +8057,7 @@ impl ::protobuf::Message for SourceCodeInfo {
             let len = value.compute_size();
             my_size += 1 + ::protobuf::rt::compute_raw_varint32_size(len) + len;
         };
-        my_size += ::protobuf::rt::unknown_fields_size(self.get_unknown_fields());
-        self.cached_size.set(my_size);
-        my_size
+        self.set_cached_size(my_size)
     }
 
     fn write_to_with_cached_sizes(&self, os: &mut ::protobuf::CodedOutputStream) -> ::protobuf::ProtobufResult<()> {
@@ -8530,20 +8070,12 @@ impl ::protobuf::Message for SourceCodeInfo {
         ::std::result::Result::Ok(())
     }
 
-    fn get_cached_size(&self) -> u32 {
-        self.cached_size.get()
+    fn get_special_fields(&self) -> &::protobuf::SpecialFields {
+        &self.special_fields
     }
 
-    fn get_unknown_fields(&self) -> &::protobuf::UnknownFields {
-        &self.unknown_fields
-    }
-
-    fn mut_unknown_fields(&mut self) -> &mut ::protobuf::UnknownFields {
-        &mut self.unknown_fields
-    }
-
-    fn type_id(&self) -> ::std::any::TypeId {
-        ::std::any::TypeId::of::<SourceCodeInfo>()
+    fn mut_special_fields(&mut self) -> &mut ::protobuf::SpecialFields {
+        &mut self.special_fields
     }
 
     fn as_any(&self) -> &::std::any::Any {
@@ -8586,14 +8118,7 @@ impl ::protobuf::MessageStatic for SourceCodeInfo {
 impl ::protobuf::Clear for SourceCodeInfo {
     fn clear(&mut self) {
         self.clear_location();
-        self.unknown_fields.clear();
-    }
-}
-
-impl ::std::cmp::PartialEq for SourceCodeInfo {
-    fn eq(&self, other: &SourceCodeInfo) -> bool {
-        self.location == other.location &&
-        self.unknown_fields == other.unknown_fields
+        self.mut_unknown_fields().clear();
     }
 }
 
@@ -8609,7 +8134,7 @@ impl ::protobuf::reflect::ProtobufValue for SourceCodeInfo {
     }
 }
 
-#[derive(Clone,Default)]
+#[derive(Clone,Default,PartialEq)]
 pub struct SourceCodeInfo_Location {
     // message fields
     path: ::std::vec::Vec<i32>,
@@ -8618,8 +8143,7 @@ pub struct SourceCodeInfo_Location {
     trailing_comments: ::protobuf::SingularField<::std::string::String>,
     leading_detached_comments: ::protobuf::RepeatedField<::std::string::String>,
     // special fields
-    unknown_fields: ::protobuf::UnknownFields,
-    cached_size: ::std::cell::Cell<u32>,
+    special_fields: ::protobuf::SpecialFields,
 }
 
 // see codegen.rs for the explanation why impl Sync explicitly
@@ -8879,9 +8403,7 @@ impl ::protobuf::Message for SourceCodeInfo_Location {
         for value in &self.leading_detached_comments {
             my_size += ::protobuf::rt::string_size(6, &value);
         };
-        my_size += ::protobuf::rt::unknown_fields_size(self.get_unknown_fields());
-        self.cached_size.set(my_size);
-        my_size
+        self.set_cached_size(my_size)
     }
 
     fn write_to_with_cached_sizes(&self, os: &mut ::protobuf::CodedOutputStream) -> ::protobuf::ProtobufResult<()> {
@@ -8914,20 +8436,12 @@ impl ::protobuf::Message for SourceCodeInfo_Location {
         ::std::result::Result::Ok(())
     }
 
-    fn get_cached_size(&self) -> u32 {
-        self.cached_size.get()
+    fn get_special_fields(&self) -> &::protobuf::SpecialFields {
+        &self.special_fields
     }
 
-    fn get_unknown_fields(&self) -> &::protobuf::UnknownFields {
-        &self.unknown_fields
-    }
-
-    fn mut_unknown_fields(&mut self) -> &mut ::protobuf::UnknownFields {
-        &mut self.unknown_fields
-    }
-
-    fn type_id(&self) -> ::std::any::TypeId {
-        ::std::any::TypeId::of::<SourceCodeInfo_Location>()
+    fn mut_special_fields(&mut self) -> &mut ::protobuf::SpecialFields {
+        &mut self.special_fields
     }
 
     fn as_any(&self) -> &::std::any::Any {
@@ -8994,18 +8508,7 @@ impl ::protobuf::Clear for SourceCodeInfo_Location {
         self.clear_leading_comments();
         self.clear_trailing_comments();
         self.clear_leading_detached_comments();
-        self.unknown_fields.clear();
-    }
-}
-
-impl ::std::cmp::PartialEq for SourceCodeInfo_Location {
-    fn eq(&self, other: &SourceCodeInfo_Location) -> bool {
-        self.path == other.path &&
-        self.span == other.span &&
-        self.leading_comments == other.leading_comments &&
-        self.trailing_comments == other.trailing_comments &&
-        self.leading_detached_comments == other.leading_detached_comments &&
-        self.unknown_fields == other.unknown_fields
+        self.mut_unknown_fields().clear();
     }
 }
 
@@ -9021,13 +8524,12 @@ impl ::protobuf::reflect::ProtobufValue for SourceCodeInfo_Location {
     }
 }
 
-#[derive(Clone,Default)]
+#[derive(Clone,Default,PartialEq)]
 pub struct GeneratedCodeInfo {
     // message fields
     annotation: ::protobuf::RepeatedField<GeneratedCodeInfo_Annotation>,
     // special fields
-    unknown_fields: ::protobuf::UnknownFields,
-    cached_size: ::std::cell::Cell<u32>,
+    special_fields: ::protobuf::SpecialFields,
 }
 
 // see codegen.rs for the explanation why impl Sync explicitly
@@ -9110,9 +8612,7 @@ impl ::protobuf::Message for GeneratedCodeInfo {
             let len = value.compute_size();
             my_size += 1 + ::protobuf::rt::compute_raw_varint32_size(len) + len;
         };
-        my_size += ::protobuf::rt::unknown_fields_size(self.get_unknown_fields());
-        self.cached_size.set(my_size);
-        my_size
+        self.set_cached_size(my_size)
     }
 
     fn write_to_with_cached_sizes(&self, os: &mut ::protobuf::CodedOutputStream) -> ::protobuf::ProtobufResult<()> {
@@ -9125,20 +8625,12 @@ impl ::protobuf::Message for GeneratedCodeInfo {
         ::std::result::Result::Ok(())
     }
 
-    fn get_cached_size(&self) -> u32 {
-        self.cached_size.get()
+    fn get_special_fields(&self) -> &::protobuf::SpecialFields {
+        &self.special_fields
     }
 
-    fn get_unknown_fields(&self) -> &::protobuf::UnknownFields {
-        &self.unknown_fields
-    }
-
-    fn mut_unknown_fields(&mut self) -> &mut ::protobuf::UnknownFields {
-        &mut self.unknown_fields
-    }
-
-    fn type_id(&self) -> ::std::any::TypeId {
-        ::std::any::TypeId::of::<GeneratedCodeInfo>()
+    fn mut_special_fields(&mut self) -> &mut ::protobuf::SpecialFields {
+        &mut self.special_fields
     }
 
     fn as_any(&self) -> &::std::any::Any {
@@ -9181,14 +8673,7 @@ impl ::protobuf::MessageStatic for GeneratedCodeInfo {
 impl ::protobuf::Clear for GeneratedCodeInfo {
     fn clear(&mut self) {
         self.clear_annotation();
-        self.unknown_fields.clear();
-    }
-}
-
-impl ::std::cmp::PartialEq for GeneratedCodeInfo {
-    fn eq(&self, other: &GeneratedCodeInfo) -> bool {
-        self.annotation == other.annotation &&
-        self.unknown_fields == other.unknown_fields
+        self.mut_unknown_fields().clear();
     }
 }
 
@@ -9204,7 +8689,7 @@ impl ::protobuf::reflect::ProtobufValue for GeneratedCodeInfo {
     }
 }
 
-#[derive(Clone,Default)]
+#[derive(Clone,Default,PartialEq)]
 pub struct GeneratedCodeInfo_Annotation {
     // message fields
     path: ::std::vec::Vec<i32>,
@@ -9212,8 +8697,7 @@ pub struct GeneratedCodeInfo_Annotation {
     begin: ::std::option::Option<i32>,
     end: ::std::option::Option<i32>,
     // special fields
-    unknown_fields: ::protobuf::UnknownFields,
-    cached_size: ::std::cell::Cell<u32>,
+    special_fields: ::protobuf::SpecialFields,
 }
 
 // see codegen.rs for the explanation why impl Sync explicitly
@@ -9419,9 +8903,7 @@ impl ::protobuf::Message for GeneratedCodeInfo_Annotation {
         if let Some(v) = self.end {
             my_size += ::protobuf::rt::value_size(4, v, ::protobuf::wire_format::WireTypeVarint);
         };
-        my_size += ::protobuf::rt::unknown_fields_size(self.get_unknown_fields());
-        self.cached_size.set(my_size);
-        my_size
+        self.set_cached_size(my_size)
     }
 
     fn write_to_with_cached_sizes(&self, os: &mut ::protobuf::CodedOutputStream) -> ::protobuf::ProtobufResult<()> {
@@ -9446,20 +8928,12 @@ impl ::protobuf::Message for GeneratedCodeInfo_Annotation {
         ::std::result::Result::Ok(())
     }
 
-    fn get_cached_size(&self) -> u32 {
-        self.cached_size.get()
+    fn get_special_fields(&self) -> &::protobuf::SpecialFields {
+        &self.special_fields
     }
 
-    fn get_unknown_fields(&self) -> &::protobuf::UnknownFields {
-        &self.unknown_fields
-    }
-
-    fn mut_unknown_fields(&mut self) -> &mut ::protobuf::UnknownFields {
-        &mut self.unknown_fields
-    }
-
-    fn type_id(&self) -> ::std::any::TypeId {
-        ::std::any::TypeId::of::<GeneratedCodeInfo_Annotation>()
+    fn mut_special_fields(&mut self) -> &mut ::protobuf::SpecialFields {
+        &mut self.special_fields
     }
 
     fn as_any(&self) -> &::std::any::Any {
@@ -9520,17 +8994,7 @@ impl ::protobuf::Clear for GeneratedCodeInfo_Annotation {
         self.clear_source_file();
         self.clear_begin();
         self.clear_end();
-        self.unknown_fields.clear();
-    }
-}
-
-impl ::std::cmp::PartialEq for GeneratedCodeInfo_Annotation {
-    fn eq(&self, other: &GeneratedCodeInfo_Annotation) -> bool {
-        self.path == other.path &&
-        self.source_file == other.source_file &&
-        self.begin == other.begin &&
-        self.end == other.end &&
-        self.unknown_fields == other.unknown_fields
+        self.mut_unknown_fields().clear();
     }
 }
 

--- a/src/lib/plugin.rs
+++ b/src/lib/plugin.rs
@@ -20,15 +20,14 @@
 use protobuf::Message as Message_imported_for_functions;
 use protobuf::ProtobufEnum as ProtobufEnum_imported_for_functions;
 
-#[derive(Clone,Default)]
+#[derive(Clone,Default,PartialEq)]
 pub struct CodeGeneratorRequest {
     // message fields
     file_to_generate: ::protobuf::RepeatedField<::std::string::String>,
     parameter: ::protobuf::SingularField<::std::string::String>,
     proto_file: ::protobuf::RepeatedField<super::descriptor::FileDescriptorProto>,
     // special fields
-    unknown_fields: ::protobuf::UnknownFields,
-    cached_size: ::std::cell::Cell<u32>,
+    special_fields: ::protobuf::SpecialFields,
 }
 
 // see codegen.rs for the explanation why impl Sync explicitly
@@ -200,9 +199,7 @@ impl ::protobuf::Message for CodeGeneratorRequest {
             let len = value.compute_size();
             my_size += 1 + ::protobuf::rt::compute_raw_varint32_size(len) + len;
         };
-        my_size += ::protobuf::rt::unknown_fields_size(self.get_unknown_fields());
-        self.cached_size.set(my_size);
-        my_size
+        self.set_cached_size(my_size)
     }
 
     fn write_to_with_cached_sizes(&self, os: &mut ::protobuf::CodedOutputStream) -> ::protobuf::ProtobufResult<()> {
@@ -221,20 +218,12 @@ impl ::protobuf::Message for CodeGeneratorRequest {
         ::std::result::Result::Ok(())
     }
 
-    fn get_cached_size(&self) -> u32 {
-        self.cached_size.get()
+    fn get_special_fields(&self) -> &::protobuf::SpecialFields {
+        &self.special_fields
     }
 
-    fn get_unknown_fields(&self) -> &::protobuf::UnknownFields {
-        &self.unknown_fields
-    }
-
-    fn mut_unknown_fields(&mut self) -> &mut ::protobuf::UnknownFields {
-        &mut self.unknown_fields
-    }
-
-    fn type_id(&self) -> ::std::any::TypeId {
-        ::std::any::TypeId::of::<CodeGeneratorRequest>()
+    fn mut_special_fields(&mut self) -> &mut ::protobuf::SpecialFields {
+        &mut self.special_fields
     }
 
     fn as_any(&self) -> &::std::any::Any {
@@ -289,16 +278,7 @@ impl ::protobuf::Clear for CodeGeneratorRequest {
         self.clear_file_to_generate();
         self.clear_parameter();
         self.clear_proto_file();
-        self.unknown_fields.clear();
-    }
-}
-
-impl ::std::cmp::PartialEq for CodeGeneratorRequest {
-    fn eq(&self, other: &CodeGeneratorRequest) -> bool {
-        self.file_to_generate == other.file_to_generate &&
-        self.parameter == other.parameter &&
-        self.proto_file == other.proto_file &&
-        self.unknown_fields == other.unknown_fields
+        self.mut_unknown_fields().clear();
     }
 }
 
@@ -314,14 +294,13 @@ impl ::protobuf::reflect::ProtobufValue for CodeGeneratorRequest {
     }
 }
 
-#[derive(Clone,Default)]
+#[derive(Clone,Default,PartialEq)]
 pub struct CodeGeneratorResponse {
     // message fields
     error: ::protobuf::SingularField<::std::string::String>,
     file: ::protobuf::RepeatedField<CodeGeneratorResponse_File>,
     // special fields
-    unknown_fields: ::protobuf::UnknownFields,
-    cached_size: ::std::cell::Cell<u32>,
+    special_fields: ::protobuf::SpecialFields,
 }
 
 // see codegen.rs for the explanation why impl Sync explicitly
@@ -454,9 +433,7 @@ impl ::protobuf::Message for CodeGeneratorResponse {
             let len = value.compute_size();
             my_size += 1 + ::protobuf::rt::compute_raw_varint32_size(len) + len;
         };
-        my_size += ::protobuf::rt::unknown_fields_size(self.get_unknown_fields());
-        self.cached_size.set(my_size);
-        my_size
+        self.set_cached_size(my_size)
     }
 
     fn write_to_with_cached_sizes(&self, os: &mut ::protobuf::CodedOutputStream) -> ::protobuf::ProtobufResult<()> {
@@ -472,20 +449,12 @@ impl ::protobuf::Message for CodeGeneratorResponse {
         ::std::result::Result::Ok(())
     }
 
-    fn get_cached_size(&self) -> u32 {
-        self.cached_size.get()
+    fn get_special_fields(&self) -> &::protobuf::SpecialFields {
+        &self.special_fields
     }
 
-    fn get_unknown_fields(&self) -> &::protobuf::UnknownFields {
-        &self.unknown_fields
-    }
-
-    fn mut_unknown_fields(&mut self) -> &mut ::protobuf::UnknownFields {
-        &mut self.unknown_fields
-    }
-
-    fn type_id(&self) -> ::std::any::TypeId {
-        ::std::any::TypeId::of::<CodeGeneratorResponse>()
+    fn mut_special_fields(&mut self) -> &mut ::protobuf::SpecialFields {
+        &mut self.special_fields
     }
 
     fn as_any(&self) -> &::std::any::Any {
@@ -534,15 +503,7 @@ impl ::protobuf::Clear for CodeGeneratorResponse {
     fn clear(&mut self) {
         self.clear_error();
         self.clear_file();
-        self.unknown_fields.clear();
-    }
-}
-
-impl ::std::cmp::PartialEq for CodeGeneratorResponse {
-    fn eq(&self, other: &CodeGeneratorResponse) -> bool {
-        self.error == other.error &&
-        self.file == other.file &&
-        self.unknown_fields == other.unknown_fields
+        self.mut_unknown_fields().clear();
     }
 }
 
@@ -558,15 +519,14 @@ impl ::protobuf::reflect::ProtobufValue for CodeGeneratorResponse {
     }
 }
 
-#[derive(Clone,Default)]
+#[derive(Clone,Default,PartialEq)]
 pub struct CodeGeneratorResponse_File {
     // message fields
     name: ::protobuf::SingularField<::std::string::String>,
     insertion_point: ::protobuf::SingularField<::std::string::String>,
     content: ::protobuf::SingularField<::std::string::String>,
     // special fields
-    unknown_fields: ::protobuf::UnknownFields,
-    cached_size: ::std::cell::Cell<u32>,
+    special_fields: ::protobuf::SpecialFields,
 }
 
 // see codegen.rs for the explanation why impl Sync explicitly
@@ -759,9 +719,7 @@ impl ::protobuf::Message for CodeGeneratorResponse_File {
         if let Some(v) = self.content.as_ref() {
             my_size += ::protobuf::rt::string_size(15, &v);
         };
-        my_size += ::protobuf::rt::unknown_fields_size(self.get_unknown_fields());
-        self.cached_size.set(my_size);
-        my_size
+        self.set_cached_size(my_size)
     }
 
     fn write_to_with_cached_sizes(&self, os: &mut ::protobuf::CodedOutputStream) -> ::protobuf::ProtobufResult<()> {
@@ -778,20 +736,12 @@ impl ::protobuf::Message for CodeGeneratorResponse_File {
         ::std::result::Result::Ok(())
     }
 
-    fn get_cached_size(&self) -> u32 {
-        self.cached_size.get()
+    fn get_special_fields(&self) -> &::protobuf::SpecialFields {
+        &self.special_fields
     }
 
-    fn get_unknown_fields(&self) -> &::protobuf::UnknownFields {
-        &self.unknown_fields
-    }
-
-    fn mut_unknown_fields(&mut self) -> &mut ::protobuf::UnknownFields {
-        &mut self.unknown_fields
-    }
-
-    fn type_id(&self) -> ::std::any::TypeId {
-        ::std::any::TypeId::of::<CodeGeneratorResponse_File>()
+    fn mut_special_fields(&mut self) -> &mut ::protobuf::SpecialFields {
+        &mut self.special_fields
     }
 
     fn as_any(&self) -> &::std::any::Any {
@@ -846,16 +796,7 @@ impl ::protobuf::Clear for CodeGeneratorResponse_File {
         self.clear_name();
         self.clear_insertion_point();
         self.clear_content();
-        self.unknown_fields.clear();
-    }
-}
-
-impl ::std::cmp::PartialEq for CodeGeneratorResponse_File {
-    fn eq(&self, other: &CodeGeneratorResponse_File) -> bool {
-        self.name == other.name &&
-        self.insertion_point == other.insertion_point &&
-        self.content == other.content &&
-        self.unknown_fields == other.unknown_fields
+        self.mut_unknown_fields().clear();
     }
 }
 

--- a/src/lib/protobuf.rs
+++ b/src/lib/protobuf.rs
@@ -9,6 +9,7 @@ pub use unknown::UnknownValuesIter;
 pub use repeated::RepeatedField;
 pub use singular::SingularField;
 pub use singular::SingularPtrField;
+pub use special::SpecialFields;
 pub use clear::Clear;
 pub use core::Message;
 pub use core::MessageStatic;
@@ -51,6 +52,7 @@ pub mod descriptorx;
 mod zigzag;
 mod paginate;
 mod unknown;
+mod special;
 mod strx;
 mod rust;
 
@@ -76,5 +78,6 @@ mod protobuf {
     pub use repeated::RepeatedField;
     pub use singular::SingularField;
     pub use singular::SingularPtrField;
+    pub use special::SpecialFields;
     pub use clear::Clear;
 }

--- a/src/lib/special.rs
+++ b/src/lib/special.rs
@@ -1,0 +1,35 @@
+use unknown::UnknownFields;
+use std::cell::Cell;
+
+#[derive(Clone, Default)]
+pub struct SpecialFields {
+    unknown_fields: UnknownFields,
+    cached_size: Cell<u32>,
+}
+
+impl ::std::cmp::PartialEq for SpecialFields {
+    fn eq(&self, other: &SpecialFields) -> bool {
+        self.unknown_fields == other.unknown_fields
+    }
+}
+
+impl SpecialFields {
+
+    pub fn get_unknown_fields(&self) -> &UnknownFields {
+        &self.unknown_fields
+    }
+
+    pub fn mut_unknown_fields(&mut self) -> &mut UnknownFields {
+        &mut self.unknown_fields
+    }
+
+    pub fn get_cached_size(&self) -> u32 {
+        self.cached_size.get()
+    }
+
+    pub fn set_cached_size(&self, mut size: u32) -> u32 {
+        size += ::protobuf::rt::unknown_fields_size(&self.unknown_fields);
+        self.cached_size.set(size);
+        size
+    }
+}

--- a/src/lib/special.rs
+++ b/src/lib/special.rs
@@ -1,7 +1,7 @@
 use unknown::UnknownFields;
 use std::cell::Cell;
 
-#[derive(Clone, Default)]
+#[derive(Clone, Default, Debug)]
 pub struct SpecialFields {
     unknown_fields: UnknownFields,
     cached_size: Cell<u32>,

--- a/src/test/v2/test_basic_pb_1_0_24.rs
+++ b/src/test/v2/test_basic_pb_1_0_24.rs
@@ -20,13 +20,12 @@
 use protobuf::Message as Message_imported_for_functions;
 use protobuf::ProtobufEnum as ProtobufEnum_imported_for_functions;
 
-#[derive(Clone,Default)]
+#[derive(Clone,Default,PartialEq)]
 pub struct Test1 {
     // message fields
     a: ::std::option::Option<i32>,
     // special fields
-    unknown_fields: ::protobuf::UnknownFields,
-    cached_size: ::std::cell::Cell<u32>,
+    special_fields: ::protobuf::SpecialFields,
 }
 
 // see codegen.rs for the explanation why impl Sync explicitly
@@ -42,15 +41,7 @@ impl Test1 {
             lock: ::protobuf::lazy::ONCE_INIT,
             ptr: 0 as *const Test1,
         };
-        unsafe {
-            instance.get(|| {
-                Test1 {
-                    a: ::std::option::Option::None,
-                    unknown_fields: ::protobuf::UnknownFields::new(),
-                    cached_size: ::std::cell::Cell::new(0),
-                }
-            })
-        }
+        unsafe { instance.get(|| Test1::default()) }
     }
 
     // required int32 a = 1;
@@ -107,9 +98,7 @@ impl ::protobuf::Message for Test1 {
         for value in &self.a {
             my_size += ::protobuf::rt::value_size(1, *value, ::protobuf::wire_format::WireTypeVarint);
         };
-        my_size += ::protobuf::rt::unknown_fields_size(self.get_unknown_fields());
-        self.cached_size.set(my_size);
-        my_size
+        self.set_cached_size(my_size)
     }
 
     fn write_to_with_cached_sizes(&self, os: &mut ::protobuf::CodedOutputStream) -> ::protobuf::ProtobufResult<()> {
@@ -120,20 +109,12 @@ impl ::protobuf::Message for Test1 {
         ::std::result::Result::Ok(())
     }
 
-    fn get_cached_size(&self) -> u32 {
-        self.cached_size.get()
+    fn get_special_fields(&self) -> &::protobuf::SpecialFields {
+        &self.special_fields
     }
 
-    fn get_unknown_fields(&self) -> &::protobuf::UnknownFields {
-        &self.unknown_fields
-    }
-
-    fn mut_unknown_fields(&mut self) -> &mut ::protobuf::UnknownFields {
-        &mut self.unknown_fields
-    }
-
-    fn type_id(&self) -> ::std::any::TypeId {
-        ::std::any::TypeId::of::<Test1>()
+    fn mut_special_fields(&mut self) -> &mut ::protobuf::SpecialFields {
+        &mut self.special_fields
     }
 
     fn as_any(&self) -> &::std::any::Any {
@@ -176,14 +157,7 @@ impl ::protobuf::MessageStatic for Test1 {
 impl ::protobuf::Clear for Test1 {
     fn clear(&mut self) {
         self.clear_a();
-        self.unknown_fields.clear();
-    }
-}
-
-impl ::std::cmp::PartialEq for Test1 {
-    fn eq(&self, other: &Test1) -> bool {
-        self.a == other.a &&
-        self.unknown_fields == other.unknown_fields
+        self.mut_unknown_fields().clear();
     }
 }
 
@@ -193,13 +167,12 @@ impl ::std::fmt::Debug for Test1 {
     }
 }
 
-#[derive(Clone,Default)]
+#[derive(Clone,Default,PartialEq)]
 pub struct Test2 {
     // message fields
     b: ::protobuf::SingularField<::std::string::String>,
     // special fields
-    unknown_fields: ::protobuf::UnknownFields,
-    cached_size: ::std::cell::Cell<u32>,
+    special_fields: ::protobuf::SpecialFields,
 }
 
 // see codegen.rs for the explanation why impl Sync explicitly
@@ -215,15 +188,7 @@ impl Test2 {
             lock: ::protobuf::lazy::ONCE_INIT,
             ptr: 0 as *const Test2,
         };
-        unsafe {
-            instance.get(|| {
-                Test2 {
-                    b: ::protobuf::SingularField::none(),
-                    unknown_fields: ::protobuf::UnknownFields::new(),
-                    cached_size: ::std::cell::Cell::new(0),
-                }
-            })
-        }
+        unsafe { instance.get(|| Test2::default()) }
     }
 
     // required string b = 2;
@@ -293,9 +258,7 @@ impl ::protobuf::Message for Test2 {
         for value in &self.b {
             my_size += ::protobuf::rt::string_size(2, &value);
         };
-        my_size += ::protobuf::rt::unknown_fields_size(self.get_unknown_fields());
-        self.cached_size.set(my_size);
-        my_size
+        self.set_cached_size(my_size)
     }
 
     fn write_to_with_cached_sizes(&self, os: &mut ::protobuf::CodedOutputStream) -> ::protobuf::ProtobufResult<()> {
@@ -306,20 +269,12 @@ impl ::protobuf::Message for Test2 {
         ::std::result::Result::Ok(())
     }
 
-    fn get_cached_size(&self) -> u32 {
-        self.cached_size.get()
+    fn get_special_fields(&self) -> &::protobuf::SpecialFields {
+        &self.special_fields
     }
 
-    fn get_unknown_fields(&self) -> &::protobuf::UnknownFields {
-        &self.unknown_fields
-    }
-
-    fn mut_unknown_fields(&mut self) -> &mut ::protobuf::UnknownFields {
-        &mut self.unknown_fields
-    }
-
-    fn type_id(&self) -> ::std::any::TypeId {
-        ::std::any::TypeId::of::<Test2>()
+    fn mut_special_fields(&mut self) -> &mut ::protobuf::SpecialFields {
+        &mut self.special_fields
     }
 
     fn as_any(&self) -> &::std::any::Any {
@@ -362,14 +317,7 @@ impl ::protobuf::MessageStatic for Test2 {
 impl ::protobuf::Clear for Test2 {
     fn clear(&mut self) {
         self.clear_b();
-        self.unknown_fields.clear();
-    }
-}
-
-impl ::std::cmp::PartialEq for Test2 {
-    fn eq(&self, other: &Test2) -> bool {
-        self.b == other.b &&
-        self.unknown_fields == other.unknown_fields
+        self.mut_unknown_fields().clear();
     }
 }
 
@@ -379,13 +327,12 @@ impl ::std::fmt::Debug for Test2 {
     }
 }
 
-#[derive(Clone,Default)]
+#[derive(Clone,Default,PartialEq)]
 pub struct Test3 {
     // message fields
     c: ::protobuf::SingularPtrField<Test1>,
     // special fields
-    unknown_fields: ::protobuf::UnknownFields,
-    cached_size: ::std::cell::Cell<u32>,
+    special_fields: ::protobuf::SpecialFields,
 }
 
 // see codegen.rs for the explanation why impl Sync explicitly
@@ -401,15 +348,7 @@ impl Test3 {
             lock: ::protobuf::lazy::ONCE_INIT,
             ptr: 0 as *const Test3,
         };
-        unsafe {
-            instance.get(|| {
-                Test3 {
-                    c: ::protobuf::SingularPtrField::none(),
-                    unknown_fields: ::protobuf::UnknownFields::new(),
-                    cached_size: ::std::cell::Cell::new(0),
-                }
-            })
-        }
+        unsafe { instance.get(|| Test3::default()) }
     }
 
     // required .basic.Test1 c = 3;
@@ -477,9 +416,7 @@ impl ::protobuf::Message for Test3 {
             let len = value.compute_size();
             my_size += 1 + ::protobuf::rt::compute_raw_varint32_size(len) + len;
         };
-        my_size += ::protobuf::rt::unknown_fields_size(self.get_unknown_fields());
-        self.cached_size.set(my_size);
-        my_size
+        self.set_cached_size(my_size)
     }
 
     fn write_to_with_cached_sizes(&self, os: &mut ::protobuf::CodedOutputStream) -> ::protobuf::ProtobufResult<()> {
@@ -492,20 +429,12 @@ impl ::protobuf::Message for Test3 {
         ::std::result::Result::Ok(())
     }
 
-    fn get_cached_size(&self) -> u32 {
-        self.cached_size.get()
+    fn get_special_fields(&self) -> &::protobuf::SpecialFields {
+        &self.special_fields
     }
 
-    fn get_unknown_fields(&self) -> &::protobuf::UnknownFields {
-        &self.unknown_fields
-    }
-
-    fn mut_unknown_fields(&mut self) -> &mut ::protobuf::UnknownFields {
-        &mut self.unknown_fields
-    }
-
-    fn type_id(&self) -> ::std::any::TypeId {
-        ::std::any::TypeId::of::<Test3>()
+    fn mut_special_fields(&mut self) -> &mut ::protobuf::SpecialFields {
+        &mut self.special_fields
     }
 
     fn as_any(&self) -> &::std::any::Any {
@@ -548,14 +477,7 @@ impl ::protobuf::MessageStatic for Test3 {
 impl ::protobuf::Clear for Test3 {
     fn clear(&mut self) {
         self.clear_c();
-        self.unknown_fields.clear();
-    }
-}
-
-impl ::std::cmp::PartialEq for Test3 {
-    fn eq(&self, other: &Test3) -> bool {
-        self.c == other.c &&
-        self.unknown_fields == other.unknown_fields
+        self.mut_unknown_fields().clear();
     }
 }
 
@@ -565,13 +487,12 @@ impl ::std::fmt::Debug for Test3 {
     }
 }
 
-#[derive(Clone,Default)]
+#[derive(Clone,Default,PartialEq)]
 pub struct Test4 {
     // message fields
     d: ::std::vec::Vec<i32>,
     // special fields
-    unknown_fields: ::protobuf::UnknownFields,
-    cached_size: ::std::cell::Cell<u32>,
+    special_fields: ::protobuf::SpecialFields,
 }
 
 // see codegen.rs for the explanation why impl Sync explicitly
@@ -587,15 +508,7 @@ impl Test4 {
             lock: ::protobuf::lazy::ONCE_INIT,
             ptr: 0 as *const Test4,
         };
-        unsafe {
-            instance.get(|| {
-                Test4 {
-                    d: ::std::vec::Vec::new(),
-                    unknown_fields: ::protobuf::UnknownFields::new(),
-                    cached_size: ::std::cell::Cell::new(0),
-                }
-            })
-        }
+        unsafe { instance.get(|| Test4::default()) }
     }
 
     // repeated int32 d = 4;
@@ -651,9 +564,7 @@ impl ::protobuf::Message for Test4 {
         if !self.d.is_empty() {
             my_size += ::protobuf::rt::vec_packed_varint_size(4, &self.d);
         };
-        my_size += ::protobuf::rt::unknown_fields_size(self.get_unknown_fields());
-        self.cached_size.set(my_size);
-        my_size
+        self.set_cached_size(my_size)
     }
 
     fn write_to_with_cached_sizes(&self, os: &mut ::protobuf::CodedOutputStream) -> ::protobuf::ProtobufResult<()> {
@@ -669,20 +580,12 @@ impl ::protobuf::Message for Test4 {
         ::std::result::Result::Ok(())
     }
 
-    fn get_cached_size(&self) -> u32 {
-        self.cached_size.get()
+    fn get_special_fields(&self) -> &::protobuf::SpecialFields {
+        &self.special_fields
     }
 
-    fn get_unknown_fields(&self) -> &::protobuf::UnknownFields {
-        &self.unknown_fields
-    }
-
-    fn mut_unknown_fields(&mut self) -> &mut ::protobuf::UnknownFields {
-        &mut self.unknown_fields
-    }
-
-    fn type_id(&self) -> ::std::any::TypeId {
-        ::std::any::TypeId::of::<Test4>()
+    fn mut_special_fields(&mut self) -> &mut ::protobuf::SpecialFields {
+        &mut self.special_fields
     }
 
     fn as_any(&self) -> &::std::any::Any {
@@ -724,14 +627,7 @@ impl ::protobuf::MessageStatic for Test4 {
 impl ::protobuf::Clear for Test4 {
     fn clear(&mut self) {
         self.clear_d();
-        self.unknown_fields.clear();
-    }
-}
-
-impl ::std::cmp::PartialEq for Test4 {
-    fn eq(&self, other: &Test4) -> bool {
-        self.d == other.d &&
-        self.unknown_fields == other.unknown_fields
+        self.mut_unknown_fields().clear();
     }
 }
 
@@ -741,14 +637,13 @@ impl ::std::fmt::Debug for Test4 {
     }
 }
 
-#[derive(Clone,Default)]
+#[derive(Clone,Default,PartialEq)]
 pub struct TestPackedUnpacked {
     // message fields
     unpacked: ::std::vec::Vec<i32>,
     packed: ::std::vec::Vec<i32>,
     // special fields
-    unknown_fields: ::protobuf::UnknownFields,
-    cached_size: ::std::cell::Cell<u32>,
+    special_fields: ::protobuf::SpecialFields,
 }
 
 // see codegen.rs for the explanation why impl Sync explicitly
@@ -764,16 +659,7 @@ impl TestPackedUnpacked {
             lock: ::protobuf::lazy::ONCE_INIT,
             ptr: 0 as *const TestPackedUnpacked,
         };
-        unsafe {
-            instance.get(|| {
-                TestPackedUnpacked {
-                    unpacked: ::std::vec::Vec::new(),
-                    packed: ::std::vec::Vec::new(),
-                    unknown_fields: ::protobuf::UnknownFields::new(),
-                    cached_size: ::std::cell::Cell::new(0),
-                }
-            })
-        }
+        unsafe { instance.get(|| TestPackedUnpacked::default()) }
     }
 
     // repeated int32 unpacked = 4;
@@ -860,9 +746,7 @@ impl ::protobuf::Message for TestPackedUnpacked {
         if !self.packed.is_empty() {
             my_size += ::protobuf::rt::vec_packed_varint_size(5, &self.packed);
         };
-        my_size += ::protobuf::rt::unknown_fields_size(self.get_unknown_fields());
-        self.cached_size.set(my_size);
-        my_size
+        self.set_cached_size(my_size)
     }
 
     fn write_to_with_cached_sizes(&self, os: &mut ::protobuf::CodedOutputStream) -> ::protobuf::ProtobufResult<()> {
@@ -881,20 +765,12 @@ impl ::protobuf::Message for TestPackedUnpacked {
         ::std::result::Result::Ok(())
     }
 
-    fn get_cached_size(&self) -> u32 {
-        self.cached_size.get()
+    fn get_special_fields(&self) -> &::protobuf::SpecialFields {
+        &self.special_fields
     }
 
-    fn get_unknown_fields(&self) -> &::protobuf::UnknownFields {
-        &self.unknown_fields
-    }
-
-    fn mut_unknown_fields(&mut self) -> &mut ::protobuf::UnknownFields {
-        &mut self.unknown_fields
-    }
-
-    fn type_id(&self) -> ::std::any::TypeId {
-        ::std::any::TypeId::of::<TestPackedUnpacked>()
+    fn mut_special_fields(&mut self) -> &mut ::protobuf::SpecialFields {
+        &mut self.special_fields
     }
 
     fn as_any(&self) -> &::std::any::Any {
@@ -941,15 +817,7 @@ impl ::protobuf::Clear for TestPackedUnpacked {
     fn clear(&mut self) {
         self.clear_unpacked();
         self.clear_packed();
-        self.unknown_fields.clear();
-    }
-}
-
-impl ::std::cmp::PartialEq for TestPackedUnpacked {
-    fn eq(&self, other: &TestPackedUnpacked) -> bool {
-        self.unpacked == other.unpacked &&
-        self.packed == other.packed &&
-        self.unknown_fields == other.unknown_fields
+        self.mut_unknown_fields().clear();
     }
 }
 
@@ -959,13 +827,12 @@ impl ::std::fmt::Debug for TestPackedUnpacked {
     }
 }
 
-#[derive(Clone,Default)]
+#[derive(Clone,Default,PartialEq)]
 pub struct TestEmpty {
     // message fields
     foo: ::std::option::Option<i32>,
     // special fields
-    unknown_fields: ::protobuf::UnknownFields,
-    cached_size: ::std::cell::Cell<u32>,
+    special_fields: ::protobuf::SpecialFields,
 }
 
 // see codegen.rs for the explanation why impl Sync explicitly
@@ -981,15 +848,7 @@ impl TestEmpty {
             lock: ::protobuf::lazy::ONCE_INIT,
             ptr: 0 as *const TestEmpty,
         };
-        unsafe {
-            instance.get(|| {
-                TestEmpty {
-                    foo: ::std::option::Option::None,
-                    unknown_fields: ::protobuf::UnknownFields::new(),
-                    cached_size: ::std::cell::Cell::new(0),
-                }
-            })
-        }
+        unsafe { instance.get(|| TestEmpty::default()) }
     }
 
     // optional int32 foo = 10;
@@ -1043,9 +902,7 @@ impl ::protobuf::Message for TestEmpty {
         for value in &self.foo {
             my_size += ::protobuf::rt::value_size(10, *value, ::protobuf::wire_format::WireTypeVarint);
         };
-        my_size += ::protobuf::rt::unknown_fields_size(self.get_unknown_fields());
-        self.cached_size.set(my_size);
-        my_size
+        self.set_cached_size(my_size)
     }
 
     fn write_to_with_cached_sizes(&self, os: &mut ::protobuf::CodedOutputStream) -> ::protobuf::ProtobufResult<()> {
@@ -1056,20 +913,12 @@ impl ::protobuf::Message for TestEmpty {
         ::std::result::Result::Ok(())
     }
 
-    fn get_cached_size(&self) -> u32 {
-        self.cached_size.get()
+    fn get_special_fields(&self) -> &::protobuf::SpecialFields {
+        &self.special_fields
     }
 
-    fn get_unknown_fields(&self) -> &::protobuf::UnknownFields {
-        &self.unknown_fields
-    }
-
-    fn mut_unknown_fields(&mut self) -> &mut ::protobuf::UnknownFields {
-        &mut self.unknown_fields
-    }
-
-    fn type_id(&self) -> ::std::any::TypeId {
-        ::std::any::TypeId::of::<TestEmpty>()
+    fn mut_special_fields(&mut self) -> &mut ::protobuf::SpecialFields {
+        &mut self.special_fields
     }
 
     fn as_any(&self) -> &::std::any::Any {
@@ -1112,14 +961,7 @@ impl ::protobuf::MessageStatic for TestEmpty {
 impl ::protobuf::Clear for TestEmpty {
     fn clear(&mut self) {
         self.clear_foo();
-        self.unknown_fields.clear();
-    }
-}
-
-impl ::std::cmp::PartialEq for TestEmpty {
-    fn eq(&self, other: &TestEmpty) -> bool {
-        self.foo == other.foo &&
-        self.unknown_fields == other.unknown_fields
+        self.mut_unknown_fields().clear();
     }
 }
 
@@ -1129,13 +971,12 @@ impl ::std::fmt::Debug for TestEmpty {
     }
 }
 
-#[derive(Clone,Default)]
+#[derive(Clone,Default,PartialEq)]
 pub struct TestRequired {
     // message fields
     b: ::std::option::Option<bool>,
     // special fields
-    unknown_fields: ::protobuf::UnknownFields,
-    cached_size: ::std::cell::Cell<u32>,
+    special_fields: ::protobuf::SpecialFields,
 }
 
 // see codegen.rs for the explanation why impl Sync explicitly
@@ -1151,15 +992,7 @@ impl TestRequired {
             lock: ::protobuf::lazy::ONCE_INIT,
             ptr: 0 as *const TestRequired,
         };
-        unsafe {
-            instance.get(|| {
-                TestRequired {
-                    b: ::std::option::Option::None,
-                    unknown_fields: ::protobuf::UnknownFields::new(),
-                    cached_size: ::std::cell::Cell::new(0),
-                }
-            })
-        }
+        unsafe { instance.get(|| TestRequired::default()) }
     }
 
     // required bool b = 5;
@@ -1216,9 +1049,7 @@ impl ::protobuf::Message for TestRequired {
         if self.b.is_some() {
             my_size += 2;
         };
-        my_size += ::protobuf::rt::unknown_fields_size(self.get_unknown_fields());
-        self.cached_size.set(my_size);
-        my_size
+        self.set_cached_size(my_size)
     }
 
     fn write_to_with_cached_sizes(&self, os: &mut ::protobuf::CodedOutputStream) -> ::protobuf::ProtobufResult<()> {
@@ -1229,20 +1060,12 @@ impl ::protobuf::Message for TestRequired {
         ::std::result::Result::Ok(())
     }
 
-    fn get_cached_size(&self) -> u32 {
-        self.cached_size.get()
+    fn get_special_fields(&self) -> &::protobuf::SpecialFields {
+        &self.special_fields
     }
 
-    fn get_unknown_fields(&self) -> &::protobuf::UnknownFields {
-        &self.unknown_fields
-    }
-
-    fn mut_unknown_fields(&mut self) -> &mut ::protobuf::UnknownFields {
-        &mut self.unknown_fields
-    }
-
-    fn type_id(&self) -> ::std::any::TypeId {
-        ::std::any::TypeId::of::<TestRequired>()
+    fn mut_special_fields(&mut self) -> &mut ::protobuf::SpecialFields {
+        &mut self.special_fields
     }
 
     fn as_any(&self) -> &::std::any::Any {
@@ -1285,14 +1108,7 @@ impl ::protobuf::MessageStatic for TestRequired {
 impl ::protobuf::Clear for TestRequired {
     fn clear(&mut self) {
         self.clear_b();
-        self.unknown_fields.clear();
-    }
-}
-
-impl ::std::cmp::PartialEq for TestRequired {
-    fn eq(&self, other: &TestRequired) -> bool {
-        self.b == other.b &&
-        self.unknown_fields == other.unknown_fields
+        self.mut_unknown_fields().clear();
     }
 }
 
@@ -1302,13 +1118,12 @@ impl ::std::fmt::Debug for TestRequired {
     }
 }
 
-#[derive(Clone,Default)]
+#[derive(Clone,Default,PartialEq)]
 pub struct TestUnknownFields {
     // message fields
     a: ::std::option::Option<i32>,
     // special fields
-    unknown_fields: ::protobuf::UnknownFields,
-    cached_size: ::std::cell::Cell<u32>,
+    special_fields: ::protobuf::SpecialFields,
 }
 
 // see codegen.rs for the explanation why impl Sync explicitly
@@ -1324,15 +1139,7 @@ impl TestUnknownFields {
             lock: ::protobuf::lazy::ONCE_INIT,
             ptr: 0 as *const TestUnknownFields,
         };
-        unsafe {
-            instance.get(|| {
-                TestUnknownFields {
-                    a: ::std::option::Option::None,
-                    unknown_fields: ::protobuf::UnknownFields::new(),
-                    cached_size: ::std::cell::Cell::new(0),
-                }
-            })
-        }
+        unsafe { instance.get(|| TestUnknownFields::default()) }
     }
 
     // required int32 a = 1;
@@ -1389,9 +1196,7 @@ impl ::protobuf::Message for TestUnknownFields {
         for value in &self.a {
             my_size += ::protobuf::rt::value_size(1, *value, ::protobuf::wire_format::WireTypeVarint);
         };
-        my_size += ::protobuf::rt::unknown_fields_size(self.get_unknown_fields());
-        self.cached_size.set(my_size);
-        my_size
+        self.set_cached_size(my_size)
     }
 
     fn write_to_with_cached_sizes(&self, os: &mut ::protobuf::CodedOutputStream) -> ::protobuf::ProtobufResult<()> {
@@ -1402,20 +1207,12 @@ impl ::protobuf::Message for TestUnknownFields {
         ::std::result::Result::Ok(())
     }
 
-    fn get_cached_size(&self) -> u32 {
-        self.cached_size.get()
+    fn get_special_fields(&self) -> &::protobuf::SpecialFields {
+        &self.special_fields
     }
 
-    fn get_unknown_fields(&self) -> &::protobuf::UnknownFields {
-        &self.unknown_fields
-    }
-
-    fn mut_unknown_fields(&mut self) -> &mut ::protobuf::UnknownFields {
-        &mut self.unknown_fields
-    }
-
-    fn type_id(&self) -> ::std::any::TypeId {
-        ::std::any::TypeId::of::<TestUnknownFields>()
+    fn mut_special_fields(&mut self) -> &mut ::protobuf::SpecialFields {
+        &mut self.special_fields
     }
 
     fn as_any(&self) -> &::std::any::Any {
@@ -1458,14 +1255,7 @@ impl ::protobuf::MessageStatic for TestUnknownFields {
 impl ::protobuf::Clear for TestUnknownFields {
     fn clear(&mut self) {
         self.clear_a();
-        self.unknown_fields.clear();
-    }
-}
-
-impl ::std::cmp::PartialEq for TestUnknownFields {
-    fn eq(&self, other: &TestUnknownFields) -> bool {
-        self.a == other.a &&
-        self.unknown_fields == other.unknown_fields
+        self.mut_unknown_fields().clear();
     }
 }
 
@@ -1475,14 +1265,13 @@ impl ::std::fmt::Debug for TestUnknownFields {
     }
 }
 
-#[derive(Clone,Default)]
+#[derive(Clone,Default,PartialEq)]
 pub struct TestSelfReference {
     // message fields
     r1: ::protobuf::SingularPtrField<TestSelfReference>,
     r2: ::protobuf::SingularPtrField<TestSelfReference>,
     // special fields
-    unknown_fields: ::protobuf::UnknownFields,
-    cached_size: ::std::cell::Cell<u32>,
+    special_fields: ::protobuf::SpecialFields,
 }
 
 // see codegen.rs for the explanation why impl Sync explicitly
@@ -1498,16 +1287,7 @@ impl TestSelfReference {
             lock: ::protobuf::lazy::ONCE_INIT,
             ptr: 0 as *const TestSelfReference,
         };
-        unsafe {
-            instance.get(|| {
-                TestSelfReference {
-                    r1: ::protobuf::SingularPtrField::none(),
-                    r2: ::protobuf::SingularPtrField::none(),
-                    unknown_fields: ::protobuf::UnknownFields::new(),
-                    cached_size: ::std::cell::Cell::new(0),
-                }
-            })
-        }
+        unsafe { instance.get(|| TestSelfReference::default()) }
     }
 
     // required .basic.TestSelfReference r1 = 1;
@@ -1615,9 +1395,7 @@ impl ::protobuf::Message for TestSelfReference {
             let len = value.compute_size();
             my_size += 1 + ::protobuf::rt::compute_raw_varint32_size(len) + len;
         };
-        my_size += ::protobuf::rt::unknown_fields_size(self.get_unknown_fields());
-        self.cached_size.set(my_size);
-        my_size
+        self.set_cached_size(my_size)
     }
 
     fn write_to_with_cached_sizes(&self, os: &mut ::protobuf::CodedOutputStream) -> ::protobuf::ProtobufResult<()> {
@@ -1635,20 +1413,12 @@ impl ::protobuf::Message for TestSelfReference {
         ::std::result::Result::Ok(())
     }
 
-    fn get_cached_size(&self) -> u32 {
-        self.cached_size.get()
+    fn get_special_fields(&self) -> &::protobuf::SpecialFields {
+        &self.special_fields
     }
 
-    fn get_unknown_fields(&self) -> &::protobuf::UnknownFields {
-        &self.unknown_fields
-    }
-
-    fn mut_unknown_fields(&mut self) -> &mut ::protobuf::UnknownFields {
-        &mut self.unknown_fields
-    }
-
-    fn type_id(&self) -> ::std::any::TypeId {
-        ::std::any::TypeId::of::<TestSelfReference>()
+    fn mut_special_fields(&mut self) -> &mut ::protobuf::SpecialFields {
+        &mut self.special_fields
     }
 
     fn as_any(&self) -> &::std::any::Any {
@@ -1697,15 +1467,7 @@ impl ::protobuf::Clear for TestSelfReference {
     fn clear(&mut self) {
         self.clear_r1();
         self.clear_r2();
-        self.unknown_fields.clear();
-    }
-}
-
-impl ::std::cmp::PartialEq for TestSelfReference {
-    fn eq(&self, other: &TestSelfReference) -> bool {
-        self.r1 == other.r1 &&
-        self.r2 == other.r2 &&
-        self.unknown_fields == other.unknown_fields
+        self.mut_unknown_fields().clear();
     }
 }
 
@@ -1715,13 +1477,12 @@ impl ::std::fmt::Debug for TestSelfReference {
     }
 }
 
-#[derive(Clone,Default)]
+#[derive(Clone,Default,PartialEq)]
 pub struct TestDefaultInstanceField {
     // message fields
     s: ::protobuf::SingularField<::std::string::String>,
     // special fields
-    unknown_fields: ::protobuf::UnknownFields,
-    cached_size: ::std::cell::Cell<u32>,
+    special_fields: ::protobuf::SpecialFields,
 }
 
 // see codegen.rs for the explanation why impl Sync explicitly
@@ -1737,15 +1498,7 @@ impl TestDefaultInstanceField {
             lock: ::protobuf::lazy::ONCE_INIT,
             ptr: 0 as *const TestDefaultInstanceField,
         };
-        unsafe {
-            instance.get(|| {
-                TestDefaultInstanceField {
-                    s: ::protobuf::SingularField::none(),
-                    unknown_fields: ::protobuf::UnknownFields::new(),
-                    cached_size: ::std::cell::Cell::new(0),
-                }
-            })
-        }
+        unsafe { instance.get(|| TestDefaultInstanceField::default()) }
     }
 
     // optional string s = 1;
@@ -1812,9 +1565,7 @@ impl ::protobuf::Message for TestDefaultInstanceField {
         for value in &self.s {
             my_size += ::protobuf::rt::string_size(1, &value);
         };
-        my_size += ::protobuf::rt::unknown_fields_size(self.get_unknown_fields());
-        self.cached_size.set(my_size);
-        my_size
+        self.set_cached_size(my_size)
     }
 
     fn write_to_with_cached_sizes(&self, os: &mut ::protobuf::CodedOutputStream) -> ::protobuf::ProtobufResult<()> {
@@ -1825,20 +1576,12 @@ impl ::protobuf::Message for TestDefaultInstanceField {
         ::std::result::Result::Ok(())
     }
 
-    fn get_cached_size(&self) -> u32 {
-        self.cached_size.get()
+    fn get_special_fields(&self) -> &::protobuf::SpecialFields {
+        &self.special_fields
     }
 
-    fn get_unknown_fields(&self) -> &::protobuf::UnknownFields {
-        &self.unknown_fields
-    }
-
-    fn mut_unknown_fields(&mut self) -> &mut ::protobuf::UnknownFields {
-        &mut self.unknown_fields
-    }
-
-    fn type_id(&self) -> ::std::any::TypeId {
-        ::std::any::TypeId::of::<TestDefaultInstanceField>()
+    fn mut_special_fields(&mut self) -> &mut ::protobuf::SpecialFields {
+        &mut self.special_fields
     }
 
     fn as_any(&self) -> &::std::any::Any {
@@ -1881,14 +1624,7 @@ impl ::protobuf::MessageStatic for TestDefaultInstanceField {
 impl ::protobuf::Clear for TestDefaultInstanceField {
     fn clear(&mut self) {
         self.clear_s();
-        self.unknown_fields.clear();
-    }
-}
-
-impl ::std::cmp::PartialEq for TestDefaultInstanceField {
-    fn eq(&self, other: &TestDefaultInstanceField) -> bool {
-        self.s == other.s &&
-        self.unknown_fields == other.unknown_fields
+        self.mut_unknown_fields().clear();
     }
 }
 
@@ -1898,13 +1634,12 @@ impl ::std::fmt::Debug for TestDefaultInstanceField {
     }
 }
 
-#[derive(Clone,Default)]
+#[derive(Clone,Default,PartialEq)]
 pub struct TestDefaultInstance {
     // message fields
     field: ::protobuf::SingularPtrField<TestDefaultInstanceField>,
     // special fields
-    unknown_fields: ::protobuf::UnknownFields,
-    cached_size: ::std::cell::Cell<u32>,
+    special_fields: ::protobuf::SpecialFields,
 }
 
 // see codegen.rs for the explanation why impl Sync explicitly
@@ -1920,15 +1655,7 @@ impl TestDefaultInstance {
             lock: ::protobuf::lazy::ONCE_INIT,
             ptr: 0 as *const TestDefaultInstance,
         };
-        unsafe {
-            instance.get(|| {
-                TestDefaultInstance {
-                    field: ::protobuf::SingularPtrField::none(),
-                    unknown_fields: ::protobuf::UnknownFields::new(),
-                    cached_size: ::std::cell::Cell::new(0),
-                }
-            })
-        }
+        unsafe { instance.get(|| TestDefaultInstance::default()) }
     }
 
     // optional .basic.TestDefaultInstanceField field = 1;
@@ -1993,9 +1720,7 @@ impl ::protobuf::Message for TestDefaultInstance {
             let len = value.compute_size();
             my_size += 1 + ::protobuf::rt::compute_raw_varint32_size(len) + len;
         };
-        my_size += ::protobuf::rt::unknown_fields_size(self.get_unknown_fields());
-        self.cached_size.set(my_size);
-        my_size
+        self.set_cached_size(my_size)
     }
 
     fn write_to_with_cached_sizes(&self, os: &mut ::protobuf::CodedOutputStream) -> ::protobuf::ProtobufResult<()> {
@@ -2008,20 +1733,12 @@ impl ::protobuf::Message for TestDefaultInstance {
         ::std::result::Result::Ok(())
     }
 
-    fn get_cached_size(&self) -> u32 {
-        self.cached_size.get()
+    fn get_special_fields(&self) -> &::protobuf::SpecialFields {
+        &self.special_fields
     }
 
-    fn get_unknown_fields(&self) -> &::protobuf::UnknownFields {
-        &self.unknown_fields
-    }
-
-    fn mut_unknown_fields(&mut self) -> &mut ::protobuf::UnknownFields {
-        &mut self.unknown_fields
-    }
-
-    fn type_id(&self) -> ::std::any::TypeId {
-        ::std::any::TypeId::of::<TestDefaultInstance>()
+    fn mut_special_fields(&mut self) -> &mut ::protobuf::SpecialFields {
+        &mut self.special_fields
     }
 
     fn as_any(&self) -> &::std::any::Any {
@@ -2064,14 +1781,7 @@ impl ::protobuf::MessageStatic for TestDefaultInstance {
 impl ::protobuf::Clear for TestDefaultInstance {
     fn clear(&mut self) {
         self.clear_field();
-        self.unknown_fields.clear();
-    }
-}
-
-impl ::std::cmp::PartialEq for TestDefaultInstance {
-    fn eq(&self, other: &TestDefaultInstance) -> bool {
-        self.field == other.field &&
-        self.unknown_fields == other.unknown_fields
+        self.mut_unknown_fields().clear();
     }
 }
 
@@ -2081,13 +1791,12 @@ impl ::std::fmt::Debug for TestDefaultInstance {
     }
 }
 
-#[derive(Clone,Default)]
+#[derive(Clone,Default,PartialEq)]
 pub struct TestDescriptor {
     // message fields
     stuff: ::std::option::Option<i32>,
     // special fields
-    unknown_fields: ::protobuf::UnknownFields,
-    cached_size: ::std::cell::Cell<u32>,
+    special_fields: ::protobuf::SpecialFields,
 }
 
 // see codegen.rs for the explanation why impl Sync explicitly
@@ -2103,15 +1812,7 @@ impl TestDescriptor {
             lock: ::protobuf::lazy::ONCE_INIT,
             ptr: 0 as *const TestDescriptor,
         };
-        unsafe {
-            instance.get(|| {
-                TestDescriptor {
-                    stuff: ::std::option::Option::None,
-                    unknown_fields: ::protobuf::UnknownFields::new(),
-                    cached_size: ::std::cell::Cell::new(0),
-                }
-            })
-        }
+        unsafe { instance.get(|| TestDescriptor::default()) }
     }
 
     // optional int32 stuff = 10;
@@ -2165,9 +1866,7 @@ impl ::protobuf::Message for TestDescriptor {
         for value in &self.stuff {
             my_size += ::protobuf::rt::value_size(10, *value, ::protobuf::wire_format::WireTypeVarint);
         };
-        my_size += ::protobuf::rt::unknown_fields_size(self.get_unknown_fields());
-        self.cached_size.set(my_size);
-        my_size
+        self.set_cached_size(my_size)
     }
 
     fn write_to_with_cached_sizes(&self, os: &mut ::protobuf::CodedOutputStream) -> ::protobuf::ProtobufResult<()> {
@@ -2178,20 +1877,12 @@ impl ::protobuf::Message for TestDescriptor {
         ::std::result::Result::Ok(())
     }
 
-    fn get_cached_size(&self) -> u32 {
-        self.cached_size.get()
+    fn get_special_fields(&self) -> &::protobuf::SpecialFields {
+        &self.special_fields
     }
 
-    fn get_unknown_fields(&self) -> &::protobuf::UnknownFields {
-        &self.unknown_fields
-    }
-
-    fn mut_unknown_fields(&mut self) -> &mut ::protobuf::UnknownFields {
-        &mut self.unknown_fields
-    }
-
-    fn type_id(&self) -> ::std::any::TypeId {
-        ::std::any::TypeId::of::<TestDescriptor>()
+    fn mut_special_fields(&mut self) -> &mut ::protobuf::SpecialFields {
+        &mut self.special_fields
     }
 
     fn as_any(&self) -> &::std::any::Any {
@@ -2234,14 +1925,7 @@ impl ::protobuf::MessageStatic for TestDescriptor {
 impl ::protobuf::Clear for TestDescriptor {
     fn clear(&mut self) {
         self.clear_stuff();
-        self.unknown_fields.clear();
-    }
-}
-
-impl ::std::cmp::PartialEq for TestDescriptor {
-    fn eq(&self, other: &TestDescriptor) -> bool {
-        self.stuff == other.stuff &&
-        self.unknown_fields == other.unknown_fields
+        self.mut_unknown_fields().clear();
     }
 }
 
@@ -2251,7 +1935,7 @@ impl ::std::fmt::Debug for TestDescriptor {
     }
 }
 
-#[derive(Clone,Default)]
+#[derive(Clone,Default,PartialEq)]
 pub struct TestTypesSingular {
     // message fields
     double_field: ::std::option::Option<f64>,
@@ -2271,8 +1955,7 @@ pub struct TestTypesSingular {
     bytes_field: ::protobuf::SingularField<::std::vec::Vec<u8>>,
     enum_field: ::std::option::Option<TestEnumDescriptor>,
     // special fields
-    unknown_fields: ::protobuf::UnknownFields,
-    cached_size: ::std::cell::Cell<u32>,
+    special_fields: ::protobuf::SpecialFields,
 }
 
 // see codegen.rs for the explanation why impl Sync explicitly
@@ -2288,30 +1971,7 @@ impl TestTypesSingular {
             lock: ::protobuf::lazy::ONCE_INIT,
             ptr: 0 as *const TestTypesSingular,
         };
-        unsafe {
-            instance.get(|| {
-                TestTypesSingular {
-                    double_field: ::std::option::Option::None,
-                    float_field: ::std::option::Option::None,
-                    int32_field: ::std::option::Option::None,
-                    int64_field: ::std::option::Option::None,
-                    uint32_field: ::std::option::Option::None,
-                    uint64_field: ::std::option::Option::None,
-                    sint32_field: ::std::option::Option::None,
-                    sint64_field: ::std::option::Option::None,
-                    fixed32_field: ::std::option::Option::None,
-                    fixed64_field: ::std::option::Option::None,
-                    sfixed32_field: ::std::option::Option::None,
-                    sfixed64_field: ::std::option::Option::None,
-                    bool_field: ::std::option::Option::None,
-                    string_field: ::protobuf::SingularField::none(),
-                    bytes_field: ::protobuf::SingularField::none(),
-                    enum_field: ::std::option::Option::None,
-                    unknown_fields: ::protobuf::UnknownFields::new(),
-                    cached_size: ::std::cell::Cell::new(0),
-                }
-            })
-        }
+        unsafe { instance.get(|| TestTypesSingular::default()) }
     }
 
     // optional double double_field = 1;
@@ -2826,9 +2486,7 @@ impl ::protobuf::Message for TestTypesSingular {
         for value in &self.enum_field {
             my_size += ::protobuf::rt::enum_size(16, *value);
         };
-        my_size += ::protobuf::rt::unknown_fields_size(self.get_unknown_fields());
-        self.cached_size.set(my_size);
-        my_size
+        self.set_cached_size(my_size)
     }
 
     fn write_to_with_cached_sizes(&self, os: &mut ::protobuf::CodedOutputStream) -> ::protobuf::ProtobufResult<()> {
@@ -2884,20 +2542,12 @@ impl ::protobuf::Message for TestTypesSingular {
         ::std::result::Result::Ok(())
     }
 
-    fn get_cached_size(&self) -> u32 {
-        self.cached_size.get()
+    fn get_special_fields(&self) -> &::protobuf::SpecialFields {
+        &self.special_fields
     }
 
-    fn get_unknown_fields(&self) -> &::protobuf::UnknownFields {
-        &self.unknown_fields
-    }
-
-    fn mut_unknown_fields(&mut self) -> &mut ::protobuf::UnknownFields {
-        &mut self.unknown_fields
-    }
-
-    fn type_id(&self) -> ::std::any::TypeId {
-        ::std::any::TypeId::of::<TestTypesSingular>()
+    fn mut_special_fields(&mut self) -> &mut ::protobuf::SpecialFields {
+        &mut self.special_fields
     }
 
     fn as_any(&self) -> &::std::any::Any {
@@ -3030,29 +2680,7 @@ impl ::protobuf::Clear for TestTypesSingular {
         self.clear_string_field();
         self.clear_bytes_field();
         self.clear_enum_field();
-        self.unknown_fields.clear();
-    }
-}
-
-impl ::std::cmp::PartialEq for TestTypesSingular {
-    fn eq(&self, other: &TestTypesSingular) -> bool {
-        self.double_field == other.double_field &&
-        self.float_field == other.float_field &&
-        self.int32_field == other.int32_field &&
-        self.int64_field == other.int64_field &&
-        self.uint32_field == other.uint32_field &&
-        self.uint64_field == other.uint64_field &&
-        self.sint32_field == other.sint32_field &&
-        self.sint64_field == other.sint64_field &&
-        self.fixed32_field == other.fixed32_field &&
-        self.fixed64_field == other.fixed64_field &&
-        self.sfixed32_field == other.sfixed32_field &&
-        self.sfixed64_field == other.sfixed64_field &&
-        self.bool_field == other.bool_field &&
-        self.string_field == other.string_field &&
-        self.bytes_field == other.bytes_field &&
-        self.enum_field == other.enum_field &&
-        self.unknown_fields == other.unknown_fields
+        self.mut_unknown_fields().clear();
     }
 }
 
@@ -3062,7 +2690,7 @@ impl ::std::fmt::Debug for TestTypesSingular {
     }
 }
 
-#[derive(Clone,Default)]
+#[derive(Clone,Default,PartialEq)]
 pub struct TestTypesRepeated {
     // message fields
     double_field: ::std::vec::Vec<f64>,
@@ -3082,8 +2710,7 @@ pub struct TestTypesRepeated {
     bytes_field: ::protobuf::RepeatedField<::std::vec::Vec<u8>>,
     enum_field: ::std::vec::Vec<TestEnumDescriptor>,
     // special fields
-    unknown_fields: ::protobuf::UnknownFields,
-    cached_size: ::std::cell::Cell<u32>,
+    special_fields: ::protobuf::SpecialFields,
 }
 
 // see codegen.rs for the explanation why impl Sync explicitly
@@ -3099,30 +2726,7 @@ impl TestTypesRepeated {
             lock: ::protobuf::lazy::ONCE_INIT,
             ptr: 0 as *const TestTypesRepeated,
         };
-        unsafe {
-            instance.get(|| {
-                TestTypesRepeated {
-                    double_field: ::std::vec::Vec::new(),
-                    float_field: ::std::vec::Vec::new(),
-                    int32_field: ::std::vec::Vec::new(),
-                    int64_field: ::std::vec::Vec::new(),
-                    uint32_field: ::std::vec::Vec::new(),
-                    uint64_field: ::std::vec::Vec::new(),
-                    sint32_field: ::std::vec::Vec::new(),
-                    sint64_field: ::std::vec::Vec::new(),
-                    fixed32_field: ::std::vec::Vec::new(),
-                    fixed64_field: ::std::vec::Vec::new(),
-                    sfixed32_field: ::std::vec::Vec::new(),
-                    sfixed64_field: ::std::vec::Vec::new(),
-                    bool_field: ::std::vec::Vec::new(),
-                    string_field: ::protobuf::RepeatedField::new(),
-                    bytes_field: ::protobuf::RepeatedField::new(),
-                    enum_field: ::std::vec::Vec::new(),
-                    unknown_fields: ::protobuf::UnknownFields::new(),
-                    cached_size: ::std::cell::Cell::new(0),
-                }
-            })
-        }
+        unsafe { instance.get(|| TestTypesRepeated::default()) }
     }
 
     // repeated double double_field = 1;
@@ -3629,9 +3233,7 @@ impl ::protobuf::Message for TestTypesRepeated {
         for value in &self.enum_field {
             my_size += ::protobuf::rt::enum_size(16, *value);
         };
-        my_size += ::protobuf::rt::unknown_fields_size(self.get_unknown_fields());
-        self.cached_size.set(my_size);
-        my_size
+        self.set_cached_size(my_size)
     }
 
     fn write_to_with_cached_sizes(&self, os: &mut ::protobuf::CodedOutputStream) -> ::protobuf::ProtobufResult<()> {
@@ -3687,20 +3289,12 @@ impl ::protobuf::Message for TestTypesRepeated {
         ::std::result::Result::Ok(())
     }
 
-    fn get_cached_size(&self) -> u32 {
-        self.cached_size.get()
+    fn get_special_fields(&self) -> &::protobuf::SpecialFields {
+        &self.special_fields
     }
 
-    fn get_unknown_fields(&self) -> &::protobuf::UnknownFields {
-        &self.unknown_fields
-    }
-
-    fn mut_unknown_fields(&mut self) -> &mut ::protobuf::UnknownFields {
-        &mut self.unknown_fields
-    }
-
-    fn type_id(&self) -> ::std::any::TypeId {
-        ::std::any::TypeId::of::<TestTypesRepeated>()
+    fn mut_special_fields(&mut self) -> &mut ::protobuf::SpecialFields {
+        &mut self.special_fields
     }
 
     fn as_any(&self) -> &::std::any::Any {
@@ -3817,29 +3411,7 @@ impl ::protobuf::Clear for TestTypesRepeated {
         self.clear_string_field();
         self.clear_bytes_field();
         self.clear_enum_field();
-        self.unknown_fields.clear();
-    }
-}
-
-impl ::std::cmp::PartialEq for TestTypesRepeated {
-    fn eq(&self, other: &TestTypesRepeated) -> bool {
-        self.double_field == other.double_field &&
-        self.float_field == other.float_field &&
-        self.int32_field == other.int32_field &&
-        self.int64_field == other.int64_field &&
-        self.uint32_field == other.uint32_field &&
-        self.uint64_field == other.uint64_field &&
-        self.sint32_field == other.sint32_field &&
-        self.sint64_field == other.sint64_field &&
-        self.fixed32_field == other.fixed32_field &&
-        self.fixed64_field == other.fixed64_field &&
-        self.sfixed32_field == other.sfixed32_field &&
-        self.sfixed64_field == other.sfixed64_field &&
-        self.bool_field == other.bool_field &&
-        self.string_field == other.string_field &&
-        self.bytes_field == other.bytes_field &&
-        self.enum_field == other.enum_field &&
-        self.unknown_fields == other.unknown_fields
+        self.mut_unknown_fields().clear();
     }
 }
 
@@ -3849,7 +3421,7 @@ impl ::std::fmt::Debug for TestTypesRepeated {
     }
 }
 
-#[derive(Clone,Default)]
+#[derive(Clone,Default,PartialEq)]
 pub struct TestTypesRepeatedPacked {
     // message fields
     double_field: ::std::vec::Vec<f64>,
@@ -3869,8 +3441,7 @@ pub struct TestTypesRepeatedPacked {
     bytes_field: ::protobuf::RepeatedField<::std::vec::Vec<u8>>,
     enum_field: ::std::vec::Vec<TestEnumDescriptor>,
     // special fields
-    unknown_fields: ::protobuf::UnknownFields,
-    cached_size: ::std::cell::Cell<u32>,
+    special_fields: ::protobuf::SpecialFields,
 }
 
 // see codegen.rs for the explanation why impl Sync explicitly
@@ -3886,30 +3457,7 @@ impl TestTypesRepeatedPacked {
             lock: ::protobuf::lazy::ONCE_INIT,
             ptr: 0 as *const TestTypesRepeatedPacked,
         };
-        unsafe {
-            instance.get(|| {
-                TestTypesRepeatedPacked {
-                    double_field: ::std::vec::Vec::new(),
-                    float_field: ::std::vec::Vec::new(),
-                    int32_field: ::std::vec::Vec::new(),
-                    int64_field: ::std::vec::Vec::new(),
-                    uint32_field: ::std::vec::Vec::new(),
-                    uint64_field: ::std::vec::Vec::new(),
-                    sint32_field: ::std::vec::Vec::new(),
-                    sint64_field: ::std::vec::Vec::new(),
-                    fixed32_field: ::std::vec::Vec::new(),
-                    fixed64_field: ::std::vec::Vec::new(),
-                    sfixed32_field: ::std::vec::Vec::new(),
-                    sfixed64_field: ::std::vec::Vec::new(),
-                    bool_field: ::std::vec::Vec::new(),
-                    string_field: ::protobuf::RepeatedField::new(),
-                    bytes_field: ::protobuf::RepeatedField::new(),
-                    enum_field: ::std::vec::Vec::new(),
-                    unknown_fields: ::protobuf::UnknownFields::new(),
-                    cached_size: ::std::cell::Cell::new(0),
-                }
-            })
-        }
+        unsafe { instance.get(|| TestTypesRepeatedPacked::default()) }
     }
 
     // repeated double double_field = 1;
@@ -4430,9 +3978,7 @@ impl ::protobuf::Message for TestTypesRepeatedPacked {
         if !self.enum_field.is_empty() {
             my_size += ::protobuf::rt::vec_packed_enum_size(16, &self.enum_field);
         };
-        my_size += ::protobuf::rt::unknown_fields_size(self.get_unknown_fields());
-        self.cached_size.set(my_size);
-        my_size
+        self.set_cached_size(my_size)
     }
 
     fn write_to_with_cached_sizes(&self, os: &mut ::protobuf::CodedOutputStream) -> ::protobuf::ProtobufResult<()> {
@@ -4558,20 +4104,12 @@ impl ::protobuf::Message for TestTypesRepeatedPacked {
         ::std::result::Result::Ok(())
     }
 
-    fn get_cached_size(&self) -> u32 {
-        self.cached_size.get()
+    fn get_special_fields(&self) -> &::protobuf::SpecialFields {
+        &self.special_fields
     }
 
-    fn get_unknown_fields(&self) -> &::protobuf::UnknownFields {
-        &self.unknown_fields
-    }
-
-    fn mut_unknown_fields(&mut self) -> &mut ::protobuf::UnknownFields {
-        &mut self.unknown_fields
-    }
-
-    fn type_id(&self) -> ::std::any::TypeId {
-        ::std::any::TypeId::of::<TestTypesRepeatedPacked>()
+    fn mut_special_fields(&mut self) -> &mut ::protobuf::SpecialFields {
+        &mut self.special_fields
     }
 
     fn as_any(&self) -> &::std::any::Any {
@@ -4688,29 +4226,7 @@ impl ::protobuf::Clear for TestTypesRepeatedPacked {
         self.clear_string_field();
         self.clear_bytes_field();
         self.clear_enum_field();
-        self.unknown_fields.clear();
-    }
-}
-
-impl ::std::cmp::PartialEq for TestTypesRepeatedPacked {
-    fn eq(&self, other: &TestTypesRepeatedPacked) -> bool {
-        self.double_field == other.double_field &&
-        self.float_field == other.float_field &&
-        self.int32_field == other.int32_field &&
-        self.int64_field == other.int64_field &&
-        self.uint32_field == other.uint32_field &&
-        self.uint64_field == other.uint64_field &&
-        self.sint32_field == other.sint32_field &&
-        self.sint64_field == other.sint64_field &&
-        self.fixed32_field == other.fixed32_field &&
-        self.fixed64_field == other.fixed64_field &&
-        self.sfixed32_field == other.sfixed32_field &&
-        self.sfixed64_field == other.sfixed64_field &&
-        self.bool_field == other.bool_field &&
-        self.string_field == other.string_field &&
-        self.bytes_field == other.bytes_field &&
-        self.enum_field == other.enum_field &&
-        self.unknown_fields == other.unknown_fields
+        self.mut_unknown_fields().clear();
     }
 }
 
@@ -4720,7 +4236,7 @@ impl ::std::fmt::Debug for TestTypesRepeatedPacked {
     }
 }
 
-#[derive(Clone,Default)]
+#[derive(Clone,Default,PartialEq)]
 pub struct TestDefaultValues {
     // message fields
     double_field: ::std::option::Option<f64>,
@@ -4741,8 +4257,7 @@ pub struct TestDefaultValues {
     enum_field: ::std::option::Option<EnumForDefaultValue>,
     enum_field_without_default: ::std::option::Option<EnumForDefaultValue>,
     // special fields
-    unknown_fields: ::protobuf::UnknownFields,
-    cached_size: ::std::cell::Cell<u32>,
+    special_fields: ::protobuf::SpecialFields,
 }
 
 // see codegen.rs for the explanation why impl Sync explicitly
@@ -4758,31 +4273,7 @@ impl TestDefaultValues {
             lock: ::protobuf::lazy::ONCE_INIT,
             ptr: 0 as *const TestDefaultValues,
         };
-        unsafe {
-            instance.get(|| {
-                TestDefaultValues {
-                    double_field: ::std::option::Option::None,
-                    float_field: ::std::option::Option::None,
-                    int32_field: ::std::option::Option::None,
-                    int64_field: ::std::option::Option::None,
-                    uint32_field: ::std::option::Option::None,
-                    uint64_field: ::std::option::Option::None,
-                    sint32_field: ::std::option::Option::None,
-                    sint64_field: ::std::option::Option::None,
-                    fixed32_field: ::std::option::Option::None,
-                    fixed64_field: ::std::option::Option::None,
-                    sfixed32_field: ::std::option::Option::None,
-                    sfixed64_field: ::std::option::Option::None,
-                    bool_field: ::std::option::Option::None,
-                    string_field: ::protobuf::SingularField::none(),
-                    bytes_field: ::protobuf::SingularField::none(),
-                    enum_field: ::std::option::Option::None,
-                    enum_field_without_default: ::std::option::Option::None,
-                    unknown_fields: ::protobuf::UnknownFields::new(),
-                    cached_size: ::std::cell::Cell::new(0),
-                }
-            })
-        }
+        unsafe { instance.get(|| TestDefaultValues::default()) }
     }
 
     // optional double double_field = 1;
@@ -5326,9 +4817,7 @@ impl ::protobuf::Message for TestDefaultValues {
         for value in &self.enum_field_without_default {
             my_size += ::protobuf::rt::enum_size(17, *value);
         };
-        my_size += ::protobuf::rt::unknown_fields_size(self.get_unknown_fields());
-        self.cached_size.set(my_size);
-        my_size
+        self.set_cached_size(my_size)
     }
 
     fn write_to_with_cached_sizes(&self, os: &mut ::protobuf::CodedOutputStream) -> ::protobuf::ProtobufResult<()> {
@@ -5387,20 +4876,12 @@ impl ::protobuf::Message for TestDefaultValues {
         ::std::result::Result::Ok(())
     }
 
-    fn get_cached_size(&self) -> u32 {
-        self.cached_size.get()
+    fn get_special_fields(&self) -> &::protobuf::SpecialFields {
+        &self.special_fields
     }
 
-    fn get_unknown_fields(&self) -> &::protobuf::UnknownFields {
-        &self.unknown_fields
-    }
-
-    fn mut_unknown_fields(&mut self) -> &mut ::protobuf::UnknownFields {
-        &mut self.unknown_fields
-    }
-
-    fn type_id(&self) -> ::std::any::TypeId {
-        ::std::any::TypeId::of::<TestDefaultValues>()
+    fn mut_special_fields(&mut self) -> &mut ::protobuf::SpecialFields {
+        &mut self.special_fields
     }
 
     fn as_any(&self) -> &::std::any::Any {
@@ -5539,30 +5020,7 @@ impl ::protobuf::Clear for TestDefaultValues {
         self.clear_bytes_field();
         self.clear_enum_field();
         self.clear_enum_field_without_default();
-        self.unknown_fields.clear();
-    }
-}
-
-impl ::std::cmp::PartialEq for TestDefaultValues {
-    fn eq(&self, other: &TestDefaultValues) -> bool {
-        self.double_field == other.double_field &&
-        self.float_field == other.float_field &&
-        self.int32_field == other.int32_field &&
-        self.int64_field == other.int64_field &&
-        self.uint32_field == other.uint32_field &&
-        self.uint64_field == other.uint64_field &&
-        self.sint32_field == other.sint32_field &&
-        self.sint64_field == other.sint64_field &&
-        self.fixed32_field == other.fixed32_field &&
-        self.fixed64_field == other.fixed64_field &&
-        self.sfixed32_field == other.sfixed32_field &&
-        self.sfixed64_field == other.sfixed64_field &&
-        self.bool_field == other.bool_field &&
-        self.string_field == other.string_field &&
-        self.bytes_field == other.bytes_field &&
-        self.enum_field == other.enum_field &&
-        self.enum_field_without_default == other.enum_field_without_default &&
-        self.unknown_fields == other.unknown_fields
+        self.mut_unknown_fields().clear();
     }
 }
 
@@ -5572,7 +5030,7 @@ impl ::std::fmt::Debug for TestDefaultValues {
     }
 }
 
-#[derive(Clone,Default)]
+#[derive(Clone,Default,PartialEq)]
 pub struct TestExtremeDefaultValues {
     // message fields
     inf_double: ::std::option::Option<f64>,
@@ -5582,8 +5040,7 @@ pub struct TestExtremeDefaultValues {
     neg_inf_float: ::std::option::Option<f32>,
     nan_float: ::std::option::Option<f32>,
     // special fields
-    unknown_fields: ::protobuf::UnknownFields,
-    cached_size: ::std::cell::Cell<u32>,
+    special_fields: ::protobuf::SpecialFields,
 }
 
 // see codegen.rs for the explanation why impl Sync explicitly
@@ -5599,20 +5056,7 @@ impl TestExtremeDefaultValues {
             lock: ::protobuf::lazy::ONCE_INIT,
             ptr: 0 as *const TestExtremeDefaultValues,
         };
-        unsafe {
-            instance.get(|| {
-                TestExtremeDefaultValues {
-                    inf_double: ::std::option::Option::None,
-                    neg_inf_double: ::std::option::Option::None,
-                    nan_double: ::std::option::Option::None,
-                    inf_float: ::std::option::Option::None,
-                    neg_inf_float: ::std::option::Option::None,
-                    nan_float: ::std::option::Option::None,
-                    unknown_fields: ::protobuf::UnknownFields::new(),
-                    cached_size: ::std::cell::Cell::new(0),
-                }
-            })
-        }
+        unsafe { instance.get(|| TestExtremeDefaultValues::default()) }
     }
 
     // optional double inf_double = 14;
@@ -5811,9 +5255,7 @@ impl ::protobuf::Message for TestExtremeDefaultValues {
         if self.nan_float.is_some() {
             my_size += 6;
         };
-        my_size += ::protobuf::rt::unknown_fields_size(self.get_unknown_fields());
-        self.cached_size.set(my_size);
-        my_size
+        self.set_cached_size(my_size)
     }
 
     fn write_to_with_cached_sizes(&self, os: &mut ::protobuf::CodedOutputStream) -> ::protobuf::ProtobufResult<()> {
@@ -5839,20 +5281,12 @@ impl ::protobuf::Message for TestExtremeDefaultValues {
         ::std::result::Result::Ok(())
     }
 
-    fn get_cached_size(&self) -> u32 {
-        self.cached_size.get()
+    fn get_special_fields(&self) -> &::protobuf::SpecialFields {
+        &self.special_fields
     }
 
-    fn get_unknown_fields(&self) -> &::protobuf::UnknownFields {
-        &self.unknown_fields
-    }
-
-    fn mut_unknown_fields(&mut self) -> &mut ::protobuf::UnknownFields {
-        &mut self.unknown_fields
-    }
-
-    fn type_id(&self) -> ::std::any::TypeId {
-        ::std::any::TypeId::of::<TestExtremeDefaultValues>()
+    fn mut_special_fields(&mut self) -> &mut ::protobuf::SpecialFields {
+        &mut self.special_fields
     }
 
     fn as_any(&self) -> &::std::any::Any {
@@ -5925,19 +5359,7 @@ impl ::protobuf::Clear for TestExtremeDefaultValues {
         self.clear_inf_float();
         self.clear_neg_inf_float();
         self.clear_nan_float();
-        self.unknown_fields.clear();
-    }
-}
-
-impl ::std::cmp::PartialEq for TestExtremeDefaultValues {
-    fn eq(&self, other: &TestExtremeDefaultValues) -> bool {
-        self.inf_double == other.inf_double &&
-        self.neg_inf_double == other.neg_inf_double &&
-        self.nan_double == other.nan_double &&
-        self.inf_float == other.inf_float &&
-        self.neg_inf_float == other.neg_inf_float &&
-        self.nan_float == other.nan_float &&
-        self.unknown_fields == other.unknown_fields
+        self.mut_unknown_fields().clear();
     }
 }
 
@@ -5947,11 +5369,10 @@ impl ::std::fmt::Debug for TestExtremeDefaultValues {
     }
 }
 
-#[derive(Clone,Default)]
+#[derive(Clone,Default,PartialEq)]
 pub struct TestInvalidTag {
     // special fields
-    unknown_fields: ::protobuf::UnknownFields,
-    cached_size: ::std::cell::Cell<u32>,
+    special_fields: ::protobuf::SpecialFields,
 }
 
 // see codegen.rs for the explanation why impl Sync explicitly
@@ -5967,14 +5388,7 @@ impl TestInvalidTag {
             lock: ::protobuf::lazy::ONCE_INIT,
             ptr: 0 as *const TestInvalidTag,
         };
-        unsafe {
-            instance.get(|| {
-                TestInvalidTag {
-                    unknown_fields: ::protobuf::UnknownFields::new(),
-                    cached_size: ::std::cell::Cell::new(0),
-                }
-            })
-        }
+        unsafe { instance.get(|| TestInvalidTag::default()) }
     }
 }
 
@@ -5999,9 +5413,7 @@ impl ::protobuf::Message for TestInvalidTag {
     #[allow(unused_variables)]
     fn compute_size(&self) -> u32 {
         let mut my_size = 0;
-        my_size += ::protobuf::rt::unknown_fields_size(self.get_unknown_fields());
-        self.cached_size.set(my_size);
-        my_size
+        self.set_cached_size(my_size)
     }
 
     fn write_to_with_cached_sizes(&self, os: &mut ::protobuf::CodedOutputStream) -> ::protobuf::ProtobufResult<()> {
@@ -6009,20 +5421,12 @@ impl ::protobuf::Message for TestInvalidTag {
         ::std::result::Result::Ok(())
     }
 
-    fn get_cached_size(&self) -> u32 {
-        self.cached_size.get()
+    fn get_special_fields(&self) -> &::protobuf::SpecialFields {
+        &self.special_fields
     }
 
-    fn get_unknown_fields(&self) -> &::protobuf::UnknownFields {
-        &self.unknown_fields
-    }
-
-    fn mut_unknown_fields(&mut self) -> &mut ::protobuf::UnknownFields {
-        &mut self.unknown_fields
-    }
-
-    fn type_id(&self) -> ::std::any::TypeId {
-        ::std::any::TypeId::of::<TestInvalidTag>()
+    fn mut_special_fields(&mut self) -> &mut ::protobuf::SpecialFields {
+        &mut self.special_fields
     }
 
     fn as_any(&self) -> &::std::any::Any {
@@ -6059,13 +5463,7 @@ impl ::protobuf::MessageStatic for TestInvalidTag {
 
 impl ::protobuf::Clear for TestInvalidTag {
     fn clear(&mut self) {
-        self.unknown_fields.clear();
-    }
-}
-
-impl ::std::cmp::PartialEq for TestInvalidTag {
-    fn eq(&self, other: &TestInvalidTag) -> bool {
-        self.unknown_fields == other.unknown_fields
+        self.mut_unknown_fields().clear();
     }
 }
 
@@ -6075,13 +5473,12 @@ impl ::std::fmt::Debug for TestInvalidTag {
     }
 }
 
-#[derive(Clone,Default)]
+#[derive(Clone,Default,PartialEq)]
 pub struct TestTruncated {
     // message fields
     ints: ::std::vec::Vec<u32>,
     // special fields
-    unknown_fields: ::protobuf::UnknownFields,
-    cached_size: ::std::cell::Cell<u32>,
+    special_fields: ::protobuf::SpecialFields,
 }
 
 // see codegen.rs for the explanation why impl Sync explicitly
@@ -6097,15 +5494,7 @@ impl TestTruncated {
             lock: ::protobuf::lazy::ONCE_INIT,
             ptr: 0 as *const TestTruncated,
         };
-        unsafe {
-            instance.get(|| {
-                TestTruncated {
-                    ints: ::std::vec::Vec::new(),
-                    unknown_fields: ::protobuf::UnknownFields::new(),
-                    cached_size: ::std::cell::Cell::new(0),
-                }
-            })
-        }
+        unsafe { instance.get(|| TestTruncated::default()) }
     }
 
     // repeated fixed32 ints = 2;
@@ -6161,9 +5550,7 @@ impl ::protobuf::Message for TestTruncated {
         if !self.ints.is_empty() {
             my_size += 1 + ::protobuf::rt::compute_raw_varint32_size(self.ints.len() as u32) + (self.ints.len() * 4) as u32;
         };
-        my_size += ::protobuf::rt::unknown_fields_size(self.get_unknown_fields());
-        self.cached_size.set(my_size);
-        my_size
+        self.set_cached_size(my_size)
     }
 
     fn write_to_with_cached_sizes(&self, os: &mut ::protobuf::CodedOutputStream) -> ::protobuf::ProtobufResult<()> {
@@ -6179,20 +5566,12 @@ impl ::protobuf::Message for TestTruncated {
         ::std::result::Result::Ok(())
     }
 
-    fn get_cached_size(&self) -> u32 {
-        self.cached_size.get()
+    fn get_special_fields(&self) -> &::protobuf::SpecialFields {
+        &self.special_fields
     }
 
-    fn get_unknown_fields(&self) -> &::protobuf::UnknownFields {
-        &self.unknown_fields
-    }
-
-    fn mut_unknown_fields(&mut self) -> &mut ::protobuf::UnknownFields {
-        &mut self.unknown_fields
-    }
-
-    fn type_id(&self) -> ::std::any::TypeId {
-        ::std::any::TypeId::of::<TestTruncated>()
+    fn mut_special_fields(&mut self) -> &mut ::protobuf::SpecialFields {
+        &mut self.special_fields
     }
 
     fn as_any(&self) -> &::std::any::Any {
@@ -6234,14 +5613,7 @@ impl ::protobuf::MessageStatic for TestTruncated {
 impl ::protobuf::Clear for TestTruncated {
     fn clear(&mut self) {
         self.clear_ints();
-        self.unknown_fields.clear();
-    }
-}
-
-impl ::std::cmp::PartialEq for TestTruncated {
-    fn eq(&self, other: &TestTruncated) -> bool {
-        self.ints == other.ints &&
-        self.unknown_fields == other.unknown_fields
+        self.mut_unknown_fields().clear();
     }
 }
 
@@ -6251,14 +5623,13 @@ impl ::std::fmt::Debug for TestTruncated {
     }
 }
 
-#[derive(Clone,Default)]
+#[derive(Clone,Default,PartialEq)]
 pub struct TestBugSint {
     // message fields
     s32: ::std::option::Option<i32>,
     s64: ::std::option::Option<i64>,
     // special fields
-    unknown_fields: ::protobuf::UnknownFields,
-    cached_size: ::std::cell::Cell<u32>,
+    special_fields: ::protobuf::SpecialFields,
 }
 
 // see codegen.rs for the explanation why impl Sync explicitly
@@ -6274,16 +5645,7 @@ impl TestBugSint {
             lock: ::protobuf::lazy::ONCE_INIT,
             ptr: 0 as *const TestBugSint,
         };
-        unsafe {
-            instance.get(|| {
-                TestBugSint {
-                    s32: ::std::option::Option::None,
-                    s64: ::std::option::Option::None,
-                    unknown_fields: ::protobuf::UnknownFields::new(),
-                    cached_size: ::std::cell::Cell::new(0),
-                }
-            })
-        }
+        unsafe { instance.get(|| TestBugSint::default()) }
     }
 
     // optional sint32 s32 = 1;
@@ -6366,9 +5728,7 @@ impl ::protobuf::Message for TestBugSint {
         for value in &self.s64 {
             my_size += ::protobuf::rt::value_varint_zigzag_size(2, *value);
         };
-        my_size += ::protobuf::rt::unknown_fields_size(self.get_unknown_fields());
-        self.cached_size.set(my_size);
-        my_size
+        self.set_cached_size(my_size)
     }
 
     fn write_to_with_cached_sizes(&self, os: &mut ::protobuf::CodedOutputStream) -> ::protobuf::ProtobufResult<()> {
@@ -6382,20 +5742,12 @@ impl ::protobuf::Message for TestBugSint {
         ::std::result::Result::Ok(())
     }
 
-    fn get_cached_size(&self) -> u32 {
-        self.cached_size.get()
+    fn get_special_fields(&self) -> &::protobuf::SpecialFields {
+        &self.special_fields
     }
 
-    fn get_unknown_fields(&self) -> &::protobuf::UnknownFields {
-        &self.unknown_fields
-    }
-
-    fn mut_unknown_fields(&mut self) -> &mut ::protobuf::UnknownFields {
-        &mut self.unknown_fields
-    }
-
-    fn type_id(&self) -> ::std::any::TypeId {
-        ::std::any::TypeId::of::<TestBugSint>()
+    fn mut_special_fields(&mut self) -> &mut ::protobuf::SpecialFields {
+        &mut self.special_fields
     }
 
     fn as_any(&self) -> &::std::any::Any {
@@ -6444,15 +5796,7 @@ impl ::protobuf::Clear for TestBugSint {
     fn clear(&mut self) {
         self.clear_s32();
         self.clear_s64();
-        self.unknown_fields.clear();
-    }
-}
-
-impl ::std::cmp::PartialEq for TestBugSint {
-    fn eq(&self, other: &TestBugSint) -> bool {
-        self.s32 == other.s32 &&
-        self.s64 == other.s64 &&
-        self.unknown_fields == other.unknown_fields
+        self.mut_unknown_fields().clear();
     }
 }
 


### PR DESCRIPTION
The purpose is to reduce a little the automatically generated code.

The new struct implements PartialEq and is supposed to replace the *special* fields
- cached_size
- unknown_fields

On top of reducing the code (can derive PartialEq), it also hide the technical
implementation detail of cached_size's `Cell`.

Also adds a default implementation for `type_id` fn.

**This is a breaking change.**