### PR TITLE
Introduce benchmark tests

### DIFF
--- a/benches/stream.rs
+++ b/benches/stream.rs
@@ -1,0 +1,42 @@
+#![feature(test)]
+
+extern crate test;
+extern crate protobuf;
+
+use protobuf::stream;
+
+use self::test::Bencher;
+
+#[inline]
+fn buffer_write_byte(os: &mut stream::CodedOutputStream) {
+    for i in 0..10 {
+        os.write_raw_byte(i as u8).unwrap();
+    }
+    os.flush().unwrap();
+}
+
+#[inline]
+fn buffer_write_bytes(os: &mut stream::CodedOutputStream) {
+    for _ in 0..10 {
+        os.write_raw_bytes(b"1234567890").unwrap();
+    }
+    os.flush().unwrap();
+}
+
+#[bench]
+fn bench_buffer(b: &mut Bencher) {
+    b.iter(|| {
+        let mut v = Vec::new();
+        let mut os = stream::CodedOutputStream::new(&mut v);
+        buffer_write_byte(&mut os);
+    });
+}
+
+#[bench]
+fn bench_buffer_bytes(b: &mut Bencher) {
+    b.iter(|| {
+        let mut v = Vec::new();
+        let mut os = stream::CodedOutputStream::new(&mut v);
+        buffer_write_bytes(&mut os);
+    });
+}


### PR DESCRIPTION
In a previous commit I mentioned that I could not determine how to run src/perftest. This commit introduces Rust's builtin-ish benchmark tests to make performance related work somewhat more direct. I got the idea after looking at @siddontang's benchmark code--of which this is an adaptation--on #186.

The motivation here is `CodedInputStream::read` showing up as a CPU hotspot in a program of mine. I'd like to give a go at optimizing it and having `cargo bench` at hand would be convenient.

Out of curiousity I ran these benchmarks to compare the work between c69b1373 and edfc86ac to move to copy_from_slice in write_raw_bytes.

    ➜  rust-protobuf git:(c69b137) ✗ cargo bench > /tmp/c69b1373
    . . .
    ➜  rust-protobuf git:(edfc86a) ✗ cargo bench > /tmp/edfc86ac
    . . .
    ➜  rust-protobuf git:(edfc86a) ✗ cargo benchcmp /tmp/c69b1373 /tmp/edfc86ac
     name                c69b1373 ns/iter  edfc86ac ns/iter  diff ns/iter  diff %
     bench_buffer        96                91                          -5  -5.21%
     bench_buffer_bytes  121               124                          3   2.48%

Basically the same, plus or minus CPU jitter on my host.

Signed-off-by: Brian L. Troutwine <blt@postmates.com>