### PR TITLE
Allow missing_docs in generated code

### DIFF
--- a/src/lib/code_writer.rs
+++ b/src/lib/code_writer.rs
@@ -40,6 +40,7 @@ impl<'a> CodeWriter<'a> {
         self.write_line("");
         self.write_line("#![allow(box_pointers)]");
         self.write_line("#![allow(dead_code)]");
+        self.write_line("#![allow(missing_docs)]");
         self.write_line("#![allow(non_camel_case_types)]");
         self.write_line("#![allow(non_snake_case)]");
         self.write_line("#![allow(non_upper_case_globals)]");

--- a/src/lib/descriptor.rs
+++ b/src/lib/descriptor.rs
@@ -9,6 +9,7 @@
 
 #![allow(box_pointers)]
 #![allow(dead_code)]
+#![allow(missing_docs)]
 #![allow(non_camel_case_types)]
 #![allow(non_snake_case)]
 #![allow(non_upper_case_globals)]

--- a/src/lib/plugin.rs
+++ b/src/lib/plugin.rs
@@ -9,6 +9,7 @@
 
 #![allow(box_pointers)]
 #![allow(dead_code)]
+#![allow(missing_docs)]
 #![allow(non_camel_case_types)]
 #![allow(non_snake_case)]
 #![allow(non_upper_case_globals)]

--- a/src/test/v2/test_basic_pb_1_0_24.rs
+++ b/src/test/v2/test_basic_pb_1_0_24.rs
@@ -9,6 +9,7 @@
 
 #![allow(box_pointers)]
 #![allow(dead_code)]
+#![allow(missing_docs)]
 #![allow(non_camel_case_types)]
 #![allow(non_snake_case)]
 #![allow(non_upper_case_globals)]


### PR DESCRIPTION
This commit introduces "#![allow(missing_docs)]" into all generated
code. This makes such code safe to run inside projects that flip
on a global deny for same lint.

Signed-off-by: Brian L. Troutwine <blt@postmates.com>