### PR TITLE
Add Send + Sync bound on Message trait

### DIFF
--- a/src/lib/core.rs
+++ b/src/lib/core.rs
@@ -21,7 +21,7 @@ use error::ProtobufError;
 use error::ProtobufResult;
 
 
-pub trait Message : fmt::Debug + Clear + Any + 'static {
+pub trait Message: fmt::Debug + Clear + Any + Send + Sync {
     // All generated Message types also implement MessageStatic.
     // However, rust doesn't allow these types to be extended by
     // Message.


### PR DESCRIPTION
All concrete message types are already `Send + Sync`, but adding it as a
trait bound allows abstract `Message` trait objects (e.g.
`Box<Message>`) to be shared and sent across threads.

The explicit `'static` bound is removed, because `Any` already implies
`'static`.