### PR TITLE
Test showing failure of reflection on sub messages, and one possible fix

### DIFF
--- a/protobuf-test/src/v2/mod.rs
+++ b/protobuf-test/src/v2/mod.rs
@@ -15,8 +15,11 @@ mod test_required_pb;
 mod test_sanitize_file_name_pb;
 mod test_special_characters_file_name__pb;
 
+mod submessage;
+
 mod test_required;
 mod test_default_values;
+mod test_submessage_reflect;
 
 mod test_oneof_default_value_pb;
 mod test_oneof_default_value;

--- a/protobuf-test/src/v2/submessage.proto
+++ b/protobuf-test/src/v2/submessage.proto
@@ -1,0 +1,9 @@
+syntax = "proto2";
+
+message M {
+  optional SubM sub_m = 1;
+}
+
+message SubM {
+  optional int32 n = 1;
+}

--- a/protobuf-test/src/v2/test_submessage_reflect.rs
+++ b/protobuf-test/src/v2/test_submessage_reflect.rs
@@ -1,0 +1,17 @@
+use super::submessage::M;
+
+use protobuf::Message;
+
+#[test]
+fn test_get_sub_message_via_reflection() {
+    let mut m = M::new();
+    m.mut_sub_m().set_n(42);
+    assert!(m.has_sub_m());
+
+    let descriptor = m.descriptor().field_by_name("sub_m");
+    assert_eq!("sub_m", descriptor.name());
+
+    let sub_m = descriptor.get_message(&m);
+    assert_eq!("SubM", sub_m.descriptor().full_name());
+    assert_eq!(42, sub_m.descriptor().field_by_name("n").get_i32(sub_m));
+}

--- a/protobuf/src/reflect/accessor.rs
+++ b/protobuf/src/reflect/accessor.rs
@@ -318,11 +318,10 @@ impl<M : Message + 'static> FieldAccessor for FieldAccessorImpl<M> {
     }
 
     fn get_message_generic<'a>(&self, m: &'a Message) -> &'a Message {
-        match self.fns {
-            FieldAccessorFunctions::SingularHasGetSet {
-                get_set: SingularGetSet::Message(ref get), ..
-            } => get.get_message(message_down_cast(m)),
-            _ => panic!(),
+        match self.get_value_option(message_down_cast(m)) {
+            Some(ProtobufValueRef::Message(v)) => v,
+            Some(_) => panic!("wrong type"),
+            None => panic!("Optional message not set."), // TODO: return empty message?
         }
     }
 


### PR DESCRIPTION
Hi!

I ran across an error while trying to extract v2 sub-messages via reflection.  I believe the attached test case is a minimal reproduction.  Without the fix I get:

---- v2::test_submessage_reflect::test_fail stdout ----
  thread 'v2::test_submessage_reflect::test_fail' panicked at 'explicit panic', /home/mrjones/src/rust-protobuf/protobuf/src/reflect/accessor.rs:325
note: Run with `RUST_BACKTRACE=1` for a backtrace.

This happens because the descriptor creates an accessor using make_singular_ptr_field_accessor which produces a FieldAccessorFunctions::Optional.  However, when using the accessor: FieldAccessorImpl::get_message_generic only has a match for FieldAccessorFunctions::SingularHasGetSet, so the Optional variant of the enum leads to a panic.

I included one possible fix, which makes get_message_generic behave more like other get_xxx_generic methods. However, I don't have very much context on this project and it's possible that there are problems with this fix.

Let me know how you'd like to proceed:
- If you'd like to just merge this feel free to go ahead.
- If you have suggestions on a better way to fix this, please let me know and I can work on it.
- If you'd prefer, I can file the reproduction instructions as a bug and drop this PR.

Thanks very much for the library, it's been very handy!

- Matt