### PR TITLE
Add documentation on build-dependencies for protoc-rust

### DIFF
--- a/protoc-rust/README.md
+++ b/protoc-rust/README.md
@@ -18,7 +18,7 @@ And in `Cargo.toml`:
 
 ```
 [build-dependencies]
-protoc-rust = "1.4.1"
+protoc-rust = "1.4"
 ```
 
 Note this API requires `protoc` command present in `$PATH`.

--- a/protoc-rust/README.md
+++ b/protoc-rust/README.md
@@ -14,5 +14,12 @@ protoc_rust::run(protoc_rust::Args {
 }).expect("protoc");
 ```
 
+And in `Cargo.toml`:
+
+```
+[build-dependencies]
+protoc-rust = "1.4.1"
+```
+
 Note this API requires `protoc` command present in `$PATH`.
 Although `protoc-gen-rust` command is not needed.


### PR DESCRIPTION
I had trouble figuring out/finding documentation on the fact that `protoc-rust` has to be in `[build-dependencies]`, so I figured adding it to the README might make it more clear for other folks.