### PR TITLE
add recursion limit

### DIFF
--- a/protobuf-test/src/common/v2/test_basic.rs
+++ b/protobuf-test/src/common/v2/test_basic.rs
@@ -37,6 +37,24 @@ fn test4() {
 }
 
 #[test]
+fn test_recursion_limit() {
+    let mut test1 = Test1::new();
+    test1.set_a(150);
+    let mut test3 = Test3::new();
+    test3.set_c(test1);
+    let bytes = test3.write_to_bytes().unwrap();
+    let mut is = CodedInputStream::from_bytes(&bytes);
+    let mut t = Test3::new();
+    t.merge_from(&mut is).unwrap();
+    assert_eq!(test3, t);
+
+    is = CodedInputStream::from_bytes(&bytes);
+    is.set_recursion_limit(0);
+    let mut t = Test3::new();
+    t.merge_from(&mut is).unwrap_err();
+}
+
+#[test]
 fn test_read_unpacked_expect_packed() {
     let mut test_packed_unpacked = TestPackedUnpacked::new();
     test_packed_unpacked.set_packed(Vec::new());

--- a/protobuf-test/src/common/v2/test_basic_pb.proto
+++ b/protobuf-test/src/common/v2/test_basic_pb.proto
@@ -14,6 +14,10 @@ message Test3 {
     required Test1 c = 3;
 }
 
+message TestRecursion {
+    repeated TestRecursion children = 1;
+}
+
 message Test4 {
     repeated int32 d = 4 [packed=true];
 }

--- a/protobuf/src/error.rs
+++ b/protobuf/src/error.rs
@@ -18,6 +18,7 @@ pub enum WireError {
     IncorrectVarint,
     Utf8Error,
     InvalidEnumValue(i32),
+    OverRecursionLimit,
     Other,
 }
 
@@ -55,6 +56,7 @@ impl Error for ProtobufError {
                     WireError::IncorrectVarint => "incorrect varint",
                     WireError::IncompleteMap => "incomplete map",
                     WireError::UnexpectedEof => "unexpected EOF",
+                    WireError::OverRecursionLimit => "over recursion limit",
                     WireError::Other => "other error",
                 }
             }

--- a/protobuf/src/rt.rs
+++ b/protobuf/src/rt.rs
@@ -638,8 +638,11 @@ pub fn read_repeated_message_into<M : Message + Default>(
 ) -> ProtobufResult<()> {
     match wire_type {
         WireTypeLengthDelimited => {
+            is.incr_recursion()?;
             let tmp = target.push_default();
-            is.merge_message(tmp)
+            let res = is.merge_message(tmp);
+            is.decr_recursion();
+            res
         }
         _ => Err(unexpected_wire_type(wire_type)),
     }
@@ -652,8 +655,11 @@ pub fn read_singular_message_into<M : Message + Default>(
 ) -> ProtobufResult<()> {
     match wire_type {
         WireTypeLengthDelimited => {
+            is.incr_recursion()?;
             let tmp = target.set_default();
-            is.merge_message(tmp)
+            let res = is.merge_message(tmp);
+            is.decr_recursion();
+            res
         }
         _ => Err(unexpected_wire_type(wire_type)),
     }

--- a/protobuf/src/stream.rs
+++ b/protobuf/src/stream.rs
@@ -158,6 +158,7 @@ impl<'a> CodedInputStream<'a> {
 
     // Only for internal tracing
     #[doc(hidden)]
+    #[inline]
     pub fn incr_recursion(&mut self) -> ProtobufResult<()> {
         self.recursion_budget -= 1;
         if self.recursion_budget < 0 {
@@ -168,6 +169,7 @@ impl<'a> CodedInputStream<'a> {
 
     // Only for internal tracing
     #[doc(hidden)]
+    #[inline]
     pub fn decr_recursion(&mut self) {
         self.recursion_budget += 1;
     }


### PR DESCRIPTION
Provide a way to configure recursion limit so invalid messages or deeply nested messages won't lead to stack overflow, which has no way to recover.