### PR TITLE
Decode unknown enum values

### DIFF
--- a/protobuf/src/codegen/enums.rs
+++ b/protobuf/src/codegen/enums.rs
@@ -187,11 +187,16 @@ impl<'a> EnumGen<'a> {
             w.def_fn(&format!("from_i32(value: i32) -> ::std::option::Option<{}>", type_name), |w| {
                 w.match_expr("value", |w| {
                     let values = self.values_unique();
-                    for value in values {
+                    for value in values.iter() {
                         w.write_line(&format!("{} => ::std::option::Option::Some({}),",
                             value.number(), value.rust_name_outer()));
                     }
-                    w.write_line(&format!("_ => ::std::option::Option::None"));
+
+                    let first = values.first();
+                    if let Some(value) = first {
+                        w.write_line(&format!("_ => ::std::option::Option::Some({}),",
+                                              value.rust_name_outer()));
+                    }
                 });
             });
 


### PR DESCRIPTION
Hi!

Client code is now incompatible with unrecognized enum, which will result in deserializing failed for all fields. So unrecognized enum's from_i32 return the first value listed in the enum definition.

Reference: https://developers.google.com/protocol-buffers/docs/proto#updating

