### PR TITLE
Remove `MessageStatic` trait

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## [Unreleased]
 
+- [Drop `MessageStatic` trait](https://github.com/stepancheg/rust-protobuf/issues/214)
 - [`protobuf-codegen` is a separate crate](https://github.com/stepancheg/rust-protobuf/pull/261)
 - [Drop old reflection
   accessors](https://github.com/stepancheg/rust-protobuf/commit/7a03aee4e67bdd25ae6c403f37386707a0ab5eb9).

--- a/perftest/vs-cxx/perftest.rs
+++ b/perftest/vs-cxx/perftest.rs
@@ -2,7 +2,6 @@ extern crate protobuf;
 extern crate rand;
 extern crate time;
 
-use std::default::Default;
 use std::fs::File;
 use std::path::Path;
 
@@ -11,7 +10,6 @@ use rand::StdRng;
 use rand::SeedableRng;
 
 use protobuf::Message;
-use protobuf::MessageStatic;
 use perftest_data::PerftestData;
 
 mod perftest_data;
@@ -36,7 +34,7 @@ struct TestRunner {
 }
 
 impl TestRunner {
-    fn run_test<M : Message + MessageStatic>(&self, name: &str, data: &[M]) {
+    fn run_test<M : Message + Clone + PartialEq>(&self, name: &str, data: &[M]) {
         assert!(data.len() > 0, "empty string for test: {}", name);
 
         let mut rng: StdRng = SeedableRng::from_seed(&[10, 20, 30, 40][..]);
@@ -76,7 +74,7 @@ impl TestRunner {
             random_data.len() as u64,
             || {
                 let mut coded_input_stream = protobuf::CodedInputStream::from_bytes(&buf);
-                let mut msg: M = Default::default();
+                let mut msg: M = Message::new();
                 let mut count = 0;
                 while !coded_input_stream.eof().unwrap() {
                     msg.clear();
@@ -90,7 +88,7 @@ impl TestRunner {
         assert_eq!(random_data.len(), merged);
     }
 
-    fn test<M : Message + MessageStatic>(&mut self, name: &str, data: &[M]) {
+    fn test<M : Message + Clone + PartialEq>(&mut self, name: &str, data: &[M]) {
         if self.selected.as_ref().map(|s| *s == name).unwrap_or(true) {
             self.run_test(name, data);
             self.any_matched = true;

--- a/protobuf-codegen/src/message.rs
+++ b/protobuf-codegen/src/message.rs
@@ -316,13 +316,9 @@ impl<'a> MessageGen<'a> {
             });
             w.write_line("");
             w.def_fn("descriptor(&self) -> &'static ::protobuf::reflect::MessageDescriptor", |w| {
-                w.write_line("::protobuf::MessageStatic::descriptor_static(None::<Self>)");
+                w.write_line("::protobuf::Message::descriptor_static(None::<Self>)");
             });
-        });
-    }
-
-    fn write_impl_message_static(&self, w: &mut CodeWriter) {
-        w.impl_for_block("::protobuf::MessageStatic", &self.type_name, |w| {
+            w.write_line("");
             w.def_fn(&format!("new() -> {}", self.type_name), |w| {
                 w.write_line(&format!("{}::new()", self.type_name));
             });
@@ -428,8 +424,6 @@ impl<'a> MessageGen<'a> {
         self.write_impl_self(w);
         w.write_line("");
         self.write_impl_message(w);
-        w.write_line("");
-        self.write_impl_message_static(w);
         w.write_line("");
         self.write_impl_clear(w);
         if !self.lite_runtime {

--- a/protobuf-test/src/test.rs
+++ b/protobuf-test/src/test.rs
@@ -3,19 +3,19 @@ use protobuf::hex::decode_hex;
 
 use protobuf::*;
 
-pub fn test_serialize_deserialize_length_delimited<M : Message + MessageStatic>(msg: &M) {
+pub fn test_serialize_deserialize_length_delimited<M : Message + PartialEq>(msg: &M) {
     let serialized_bytes = msg.write_length_delimited_to_bytes().unwrap();
     let parsed = parse_length_delimited_from_bytes::<M>(&serialized_bytes).unwrap();
     assert!(*msg == parsed);
 }
 
-pub fn test_serialize_deserialize_no_hex<M : Message + MessageStatic>(msg: &M) {
+pub fn test_serialize_deserialize_no_hex<M : Message + PartialEq>(msg: &M) {
     let serialized_bytes = msg.write_to_bytes().unwrap();
     let parsed = parse_from_bytes::<M>(&serialized_bytes).unwrap();
     assert!(*msg == parsed);
 }
 
-pub fn test_serialize_deserialize<M : Message + MessageStatic>(hex: &str, msg: &M) {
+pub fn test_serialize_deserialize<M : Message + PartialEq>(hex: &str, msg: &M) {
     let expected_bytes = decode_hex(hex);
     let expected_hex = encode_hex(&expected_bytes);
     let serialized = msg.write_to_bytes().unwrap();
@@ -34,13 +34,13 @@ pub fn test_serialize_deserialize<M : Message + MessageStatic>(hex: &str, msg: &
     test_serialize_deserialize_length_delimited(msg);
 }
 
-pub fn test_deserialize<M : Message + MessageStatic>(hex: &str, msg: &M) {
+pub fn test_deserialize<M : Message + PartialEq>(hex: &str, msg: &M) {
     let bytes = decode_hex(hex);
     let parsed = parse_from_bytes::<M>(&bytes).unwrap();
     assert!(*msg == parsed);
 }
 
-pub fn test_serialize<M : Message + MessageStatic>(hex: &str, msg: &M) {
+pub fn test_serialize<M : Message>(hex: &str, msg: &M) {
     let hex = encode_hex(&decode_hex(hex));
 
     let serialized = msg.write_to_bytes().unwrap();

--- a/protobuf/src/descriptor.rs
+++ b/protobuf/src/descriptor.rs
@@ -150,11 +150,9 @@ impl ::protobuf::Message for FileDescriptorSet {
     }
 
     fn descriptor(&self) -> &'static ::protobuf::reflect::MessageDescriptor {
-        ::protobuf::MessageStatic::descriptor_static(None::<Self>)
+        ::protobuf::Message::descriptor_static(None::<Self>)
     }
-}
 
-impl ::protobuf::MessageStatic for FileDescriptorSet {
     fn new() -> FileDescriptorSet {
         FileDescriptorSet::new()
     }
@@ -892,11 +890,9 @@ impl ::protobuf::Message for FileDescriptorProto {
     }
 
     fn descriptor(&self) -> &'static ::protobuf::reflect::MessageDescriptor {
-        ::protobuf::MessageStatic::descriptor_static(None::<Self>)
+        ::protobuf::Message::descriptor_static(None::<Self>)
     }
-}
 
-impl ::protobuf::MessageStatic for FileDescriptorProto {
     fn new() -> FileDescriptorProto {
         FileDescriptorProto::new()
     }
@@ -1600,11 +1596,9 @@ impl ::protobuf::Message for DescriptorProto {
     }
 
     fn descriptor(&self) -> &'static ::protobuf::reflect::MessageDescriptor {
-        ::protobuf::MessageStatic::descriptor_static(None::<Self>)
+        ::protobuf::Message::descriptor_static(None::<Self>)
     }
-}
 
-impl ::protobuf::MessageStatic for DescriptorProto {
     fn new() -> DescriptorProto {
         DescriptorProto::new()
     }
@@ -1865,11 +1859,9 @@ impl ::protobuf::Message for DescriptorProto_ExtensionRange {
     }
 
     fn descriptor(&self) -> &'static ::protobuf::reflect::MessageDescriptor {
-        ::protobuf::MessageStatic::descriptor_static(None::<Self>)
+        ::protobuf::Message::descriptor_static(None::<Self>)
     }
-}
 
-impl ::protobuf::MessageStatic for DescriptorProto_ExtensionRange {
     fn new() -> DescriptorProto_ExtensionRange {
         DescriptorProto_ExtensionRange::new()
     }
@@ -2082,11 +2074,9 @@ impl ::protobuf::Message for DescriptorProto_ReservedRange {
     }
 
     fn descriptor(&self) -> &'static ::protobuf::reflect::MessageDescriptor {
-        ::protobuf::MessageStatic::descriptor_static(None::<Self>)
+        ::protobuf::Message::descriptor_static(None::<Self>)
     }
-}
 
-impl ::protobuf::MessageStatic for DescriptorProto_ReservedRange {
     fn new() -> DescriptorProto_ReservedRange {
         DescriptorProto_ReservedRange::new()
     }
@@ -2710,11 +2700,9 @@ impl ::protobuf::Message for FieldDescriptorProto {
     }
 
     fn descriptor(&self) -> &'static ::protobuf::reflect::MessageDescriptor {
-        ::protobuf::MessageStatic::descriptor_static(None::<Self>)
+        ::protobuf::Message::descriptor_static(None::<Self>)
     }
-}
 
-impl ::protobuf::MessageStatic for FieldDescriptorProto {
     fn new() -> FieldDescriptorProto {
         FieldDescriptorProto::new()
     }
@@ -3155,11 +3143,9 @@ impl ::protobuf::Message for OneofDescriptorProto {
     }
 
     fn descriptor(&self) -> &'static ::protobuf::reflect::MessageDescriptor {
-        ::protobuf::MessageStatic::descriptor_static(None::<Self>)
+        ::protobuf::Message::descriptor_static(None::<Self>)
     }
-}
 
-impl ::protobuf::MessageStatic for OneofDescriptorProto {
     fn new() -> OneofDescriptorProto {
         OneofDescriptorProto::new()
     }
@@ -3454,11 +3440,9 @@ impl ::protobuf::Message for EnumDescriptorProto {
     }
 
     fn descriptor(&self) -> &'static ::protobuf::reflect::MessageDescriptor {
-        ::protobuf::MessageStatic::descriptor_static(None::<Self>)
+        ::protobuf::Message::descriptor_static(None::<Self>)
     }
-}
 
-impl ::protobuf::MessageStatic for EnumDescriptorProto {
     fn new() -> EnumDescriptorProto {
         EnumDescriptorProto::new()
     }
@@ -3749,11 +3733,9 @@ impl ::protobuf::Message for EnumValueDescriptorProto {
     }
 
     fn descriptor(&self) -> &'static ::protobuf::reflect::MessageDescriptor {
-        ::protobuf::MessageStatic::descriptor_static(None::<Self>)
+        ::protobuf::Message::descriptor_static(None::<Self>)
     }
-}
 
-impl ::protobuf::MessageStatic for EnumValueDescriptorProto {
     fn new() -> EnumValueDescriptorProto {
         EnumValueDescriptorProto::new()
     }
@@ -4054,11 +4036,9 @@ impl ::protobuf::Message for ServiceDescriptorProto {
     }
 
     fn descriptor(&self) -> &'static ::protobuf::reflect::MessageDescriptor {
-        ::protobuf::MessageStatic::descriptor_static(None::<Self>)
+        ::protobuf::Message::descriptor_static(None::<Self>)
     }
-}
 
-impl ::protobuf::MessageStatic for ServiceDescriptorProto {
     fn new() -> ServiceDescriptorProto {
         ServiceDescriptorProto::new()
     }
@@ -4498,11 +4478,9 @@ impl ::protobuf::Message for MethodDescriptorProto {
     }
 
     fn descriptor(&self) -> &'static ::protobuf::reflect::MessageDescriptor {
-        ::protobuf::MessageStatic::descriptor_static(None::<Self>)
+        ::protobuf::Message::descriptor_static(None::<Self>)
     }
-}
 
-impl ::protobuf::MessageStatic for MethodDescriptorProto {
     fn new() -> MethodDescriptorProto {
         MethodDescriptorProto::new()
     }
@@ -5347,11 +5325,9 @@ impl ::protobuf::Message for FileOptions {
     }
 
     fn descriptor(&self) -> &'static ::protobuf::reflect::MessageDescriptor {
-        ::protobuf::MessageStatic::descriptor_static(None::<Self>)
+        ::protobuf::Message::descriptor_static(None::<Self>)
     }
-}
 
-impl ::protobuf::MessageStatic for FileOptions {
     fn new() -> FileOptions {
         FileOptions::new()
     }
@@ -5827,11 +5803,9 @@ impl ::protobuf::Message for MessageOptions {
     }
 
     fn descriptor(&self) -> &'static ::protobuf::reflect::MessageDescriptor {
-        ::protobuf::MessageStatic::descriptor_static(None::<Self>)
+        ::protobuf::Message::descriptor_static(None::<Self>)
     }
-}
 
-impl ::protobuf::MessageStatic for MessageOptions {
     fn new() -> MessageOptions {
         MessageOptions::new()
     }
@@ -6277,11 +6251,9 @@ impl ::protobuf::Message for FieldOptions {
     }
 
     fn descriptor(&self) -> &'static ::protobuf::reflect::MessageDescriptor {
-        ::protobuf::MessageStatic::descriptor_static(None::<Self>)
+        ::protobuf::Message::descriptor_static(None::<Self>)
     }
-}
 
-impl ::protobuf::MessageStatic for FieldOptions {
     fn new() -> FieldOptions {
         FieldOptions::new()
     }
@@ -6597,11 +6569,9 @@ impl ::protobuf::Message for OneofOptions {
     }
 
     fn descriptor(&self) -> &'static ::protobuf::reflect::MessageDescriptor {
-        ::protobuf::MessageStatic::descriptor_static(None::<Self>)
+        ::protobuf::Message::descriptor_static(None::<Self>)
     }
-}
 
-impl ::protobuf::MessageStatic for OneofOptions {
     fn new() -> OneofOptions {
         OneofOptions::new()
     }
@@ -6859,11 +6829,9 @@ impl ::protobuf::Message for EnumOptions {
     }
 
     fn descriptor(&self) -> &'static ::protobuf::reflect::MessageDescriptor {
-        ::protobuf::MessageStatic::descriptor_static(None::<Self>)
+        ::protobuf::Message::descriptor_static(None::<Self>)
     }
-}
 
-impl ::protobuf::MessageStatic for EnumOptions {
     fn new() -> EnumOptions {
         EnumOptions::new()
     }
@@ -7092,11 +7060,9 @@ impl ::protobuf::Message for EnumValueOptions {
     }
 
     fn descriptor(&self) -> &'static ::protobuf::reflect::MessageDescriptor {
-        ::protobuf::MessageStatic::descriptor_static(None::<Self>)
+        ::protobuf::Message::descriptor_static(None::<Self>)
     }
-}
 
-impl ::protobuf::MessageStatic for EnumValueOptions {
     fn new() -> EnumValueOptions {
         EnumValueOptions::new()
     }
@@ -7319,11 +7285,9 @@ impl ::protobuf::Message for ServiceOptions {
     }
 
     fn descriptor(&self) -> &'static ::protobuf::reflect::MessageDescriptor {
-        ::protobuf::MessageStatic::descriptor_static(None::<Self>)
+        ::protobuf::Message::descriptor_static(None::<Self>)
     }
-}
 
-impl ::protobuf::MessageStatic for ServiceOptions {
     fn new() -> ServiceOptions {
         ServiceOptions::new()
     }
@@ -7546,11 +7510,9 @@ impl ::protobuf::Message for MethodOptions {
     }
 
     fn descriptor(&self) -> &'static ::protobuf::reflect::MessageDescriptor {
-        ::protobuf::MessageStatic::descriptor_static(None::<Self>)
+        ::protobuf::Message::descriptor_static(None::<Self>)
     }
-}
 
-impl ::protobuf::MessageStatic for MethodOptions {
     fn new() -> MethodOptions {
         MethodOptions::new()
     }
@@ -8017,11 +7979,9 @@ impl ::protobuf::Message for UninterpretedOption {
     }
 
     fn descriptor(&self) -> &'static ::protobuf::reflect::MessageDescriptor {
-        ::protobuf::MessageStatic::descriptor_static(None::<Self>)
+        ::protobuf::Message::descriptor_static(None::<Self>)
     }
-}
 
-impl ::protobuf::MessageStatic for UninterpretedOption {
     fn new() -> UninterpretedOption {
         UninterpretedOption::new()
     }
@@ -8283,11 +8243,9 @@ impl ::protobuf::Message for UninterpretedOption_NamePart {
     }
 
     fn descriptor(&self) -> &'static ::protobuf::reflect::MessageDescriptor {
-        ::protobuf::MessageStatic::descriptor_static(None::<Self>)
+        ::protobuf::Message::descriptor_static(None::<Self>)
     }
-}
 
-impl ::protobuf::MessageStatic for UninterpretedOption_NamePart {
     fn new() -> UninterpretedOption_NamePart {
         UninterpretedOption_NamePart::new()
     }
@@ -8469,11 +8427,9 @@ impl ::protobuf::Message for SourceCodeInfo {
     }
 
     fn descriptor(&self) -> &'static ::protobuf::reflect::MessageDescriptor {
-        ::protobuf::MessageStatic::descriptor_static(None::<Self>)
+        ::protobuf::Message::descriptor_static(None::<Self>)
     }
-}
 
-impl ::protobuf::MessageStatic for SourceCodeInfo {
     fn new() -> SourceCodeInfo {
         SourceCodeInfo::new()
     }
@@ -8845,11 +8801,9 @@ impl ::protobuf::Message for SourceCodeInfo_Location {
     }
 
     fn descriptor(&self) -> &'static ::protobuf::reflect::MessageDescriptor {
-        ::protobuf::MessageStatic::descriptor_static(None::<Self>)
+        ::protobuf::Message::descriptor_static(None::<Self>)
     }
-}
 
-impl ::protobuf::MessageStatic for SourceCodeInfo_Location {
     fn new() -> SourceCodeInfo_Location {
         SourceCodeInfo_Location::new()
     }
@@ -9049,11 +9003,9 @@ impl ::protobuf::Message for GeneratedCodeInfo {
     }
 
     fn descriptor(&self) -> &'static ::protobuf::reflect::MessageDescriptor {
-        ::protobuf::MessageStatic::descriptor_static(None::<Self>)
+        ::protobuf::Message::descriptor_static(None::<Self>)
     }
-}
 
-impl ::protobuf::MessageStatic for GeneratedCodeInfo {
     fn new() -> GeneratedCodeInfo {
         GeneratedCodeInfo::new()
     }
@@ -9362,11 +9314,9 @@ impl ::protobuf::Message for GeneratedCodeInfo_Annotation {
     }
 
     fn descriptor(&self) -> &'static ::protobuf::reflect::MessageDescriptor {
-        ::protobuf::MessageStatic::descriptor_static(None::<Self>)
+        ::protobuf::Message::descriptor_static(None::<Self>)
     }
-}
 
-impl ::protobuf::MessageStatic for GeneratedCodeInfo_Annotation {
     fn new() -> GeneratedCodeInfo_Annotation {
         GeneratedCodeInfo_Annotation::new()
     }

--- a/protobuf/src/lib.rs
+++ b/protobuf/src/lib.rs
@@ -17,7 +17,6 @@ pub use singular::SingularField;
 pub use singular::SingularPtrField;
 pub use clear::Clear;
 pub use core::Message;
-pub use core::MessageStatic;
 pub use core::ProtobufEnum;
 pub use core::parse_from_bytes;
 pub use core::parse_from_reader;

--- a/protobuf/src/plugin.rs
+++ b/protobuf/src/plugin.rs
@@ -247,11 +247,9 @@ impl ::protobuf::Message for CodeGeneratorRequest {
     }
 
     fn descriptor(&self) -> &'static ::protobuf::reflect::MessageDescriptor {
-        ::protobuf::MessageStatic::descriptor_static(None::<Self>)
+        ::protobuf::Message::descriptor_static(None::<Self>)
     }
-}
 
-impl ::protobuf::MessageStatic for CodeGeneratorRequest {
     fn new() -> CodeGeneratorRequest {
         CodeGeneratorRequest::new()
     }
@@ -493,11 +491,9 @@ impl ::protobuf::Message for CodeGeneratorResponse {
     }
 
     fn descriptor(&self) -> &'static ::protobuf::reflect::MessageDescriptor {
-        ::protobuf::MessageStatic::descriptor_static(None::<Self>)
+        ::protobuf::Message::descriptor_static(None::<Self>)
     }
-}
 
-impl ::protobuf::MessageStatic for CodeGeneratorResponse {
     fn new() -> CodeGeneratorResponse {
         CodeGeneratorResponse::new()
     }
@@ -790,11 +786,9 @@ impl ::protobuf::Message for CodeGeneratorResponse_File {
     }
 
     fn descriptor(&self) -> &'static ::protobuf::reflect::MessageDescriptor {
-        ::protobuf::MessageStatic::descriptor_static(None::<Self>)
+        ::protobuf::Message::descriptor_static(None::<Self>)
     }
-}
 
-impl ::protobuf::MessageStatic for CodeGeneratorResponse_File {
     fn new() -> CodeGeneratorResponse_File {
         CodeGeneratorResponse_File::new()
     }

--- a/protobuf/src/reflect/mod.rs
+++ b/protobuf/src/reflect/mod.rs
@@ -5,7 +5,6 @@ use std::default::Default;
 use std::marker;
 
 use core::Message;
-use core::MessageStatic;
 use core::ProtobufEnum;
 use descriptor::FileDescriptorProto;
 use descriptor::DescriptorProto;
@@ -154,8 +153,8 @@ pub struct MessageDescriptor {
 }
 
 impl MessageDescriptor {
-    pub fn for_type<M : MessageStatic>() -> &'static MessageDescriptor {
-        MessageStatic::descriptor_static(None::<M>)
+    pub fn for_type<M : Message>() -> &'static MessageDescriptor {
+        Message::descriptor_static(None::<M>)
     }
 
     pub fn new<M : 'static + Message + Default>(

--- a/protobuf/src/stream.rs
+++ b/protobuf/src/stream.rs
@@ -13,7 +13,6 @@ use varint;
 use misc::remaining_capacity_as_slice_mut;
 use misc::remove_lifetime_mut;
 use core::Message;
-use core::MessageStatic;
 use core::ProtobufEnum;
 use unknown::UnknownFields;
 use unknown::UnknownValue;
@@ -700,8 +699,8 @@ impl<'a> CodedInputStream<'a> {
         Ok(())
     }
 
-    pub fn read_message<M : Message + MessageStatic>(&mut self) -> ProtobufResult<M> {
-        let mut r: M = MessageStatic::new();
+    pub fn read_message<M : Message>(&mut self) -> ProtobufResult<M> {
+        let mut r: M = Message::new();
         self.merge_message(&mut r)?;
         r.check_initialized()?;
         Ok(r)

--- a/protobuf/src/types.rs
+++ b/protobuf/src/types.rs
@@ -10,7 +10,6 @@ use stream::CodedOutputStream;
 use error::ProtobufResult;
 use core::ProtobufEnum;
 use core::Message;
-use core::MessageStatic;
 use wire_format::WireType;
 use rt;
 use reflect::ProtobufValue;
@@ -527,7 +526,7 @@ impl<E : ProtobufEnum + ProtobufValue> ProtobufType for ProtobufTypeEnum<E> {
     }
 }
 
-impl<M : Message + MessageStatic + ProtobufValue> ProtobufType for ProtobufTypeMessage<M> {
+impl<M : Message + Clone + ProtobufValue> ProtobufType for ProtobufTypeMessage<M> {
     type Value = M;
 
     fn wire_type() -> WireType {

--- a/protobuf/src/well_known_types/any.rs
+++ b/protobuf/src/well_known_types/any.rs
@@ -187,11 +187,9 @@ impl ::protobuf::Message for Any {
     }
 
     fn descriptor(&self) -> &'static ::protobuf::reflect::MessageDescriptor {
-        ::protobuf::MessageStatic::descriptor_static(None::<Self>)
+        ::protobuf::Message::descriptor_static(None::<Self>)
     }
-}
 
-impl ::protobuf::MessageStatic for Any {
     fn new() -> Any {
         Any::new()
     }

--- a/protobuf/src/well_known_types/api.rs
+++ b/protobuf/src/well_known_types/api.rs
@@ -436,11 +436,9 @@ impl ::protobuf::Message for Api {
     }
 
     fn descriptor(&self) -> &'static ::protobuf::reflect::MessageDescriptor {
-        ::protobuf::MessageStatic::descriptor_static(None::<Self>)
+        ::protobuf::Message::descriptor_static(None::<Self>)
     }
-}
 
-impl ::protobuf::MessageStatic for Api {
     fn new() -> Api {
         Api::new()
     }
@@ -895,11 +893,9 @@ impl ::protobuf::Message for Method {
     }
 
     fn descriptor(&self) -> &'static ::protobuf::reflect::MessageDescriptor {
-        ::protobuf::MessageStatic::descriptor_static(None::<Self>)
+        ::protobuf::Message::descriptor_static(None::<Self>)
     }
-}
 
-impl ::protobuf::MessageStatic for Method {
     fn new() -> Method {
         Method::new()
     }
@@ -1148,11 +1144,9 @@ impl ::protobuf::Message for Mixin {
     }
 
     fn descriptor(&self) -> &'static ::protobuf::reflect::MessageDescriptor {
-        ::protobuf::MessageStatic::descriptor_static(None::<Self>)
+        ::protobuf::Message::descriptor_static(None::<Self>)
     }
-}
 
-impl ::protobuf::MessageStatic for Mixin {
     fn new() -> Mixin {
         Mixin::new()
     }

--- a/protobuf/src/well_known_types/duration.rs
+++ b/protobuf/src/well_known_types/duration.rs
@@ -173,11 +173,9 @@ impl ::protobuf::Message for Duration {
     }
 
     fn descriptor(&self) -> &'static ::protobuf::reflect::MessageDescriptor {
-        ::protobuf::MessageStatic::descriptor_static(None::<Self>)
+        ::protobuf::Message::descriptor_static(None::<Self>)
     }
-}
 
-impl ::protobuf::MessageStatic for Duration {
     fn new() -> Duration {
         Duration::new()
     }

--- a/protobuf/src/well_known_types/empty.rs
+++ b/protobuf/src/well_known_types/empty.rs
@@ -98,11 +98,9 @@ impl ::protobuf::Message for Empty {
     }
 
     fn descriptor(&self) -> &'static ::protobuf::reflect::MessageDescriptor {
-        ::protobuf::MessageStatic::descriptor_static(None::<Self>)
+        ::protobuf::Message::descriptor_static(None::<Self>)
     }
-}
 
-impl ::protobuf::MessageStatic for Empty {
     fn new() -> Empty {
         Empty::new()
     }

--- a/protobuf/src/well_known_types/field_mask.rs
+++ b/protobuf/src/well_known_types/field_mask.rs
@@ -142,11 +142,9 @@ impl ::protobuf::Message for FieldMask {
     }
 
     fn descriptor(&self) -> &'static ::protobuf::reflect::MessageDescriptor {
-        ::protobuf::MessageStatic::descriptor_static(None::<Self>)
+        ::protobuf::Message::descriptor_static(None::<Self>)
     }
-}
 
-impl ::protobuf::MessageStatic for FieldMask {
     fn new() -> FieldMask {
         FieldMask::new()
     }

--- a/protobuf/src/well_known_types/source_context.rs
+++ b/protobuf/src/well_known_types/source_context.rs
@@ -143,11 +143,9 @@ impl ::protobuf::Message for SourceContext {
     }
 
     fn descriptor(&self) -> &'static ::protobuf::reflect::MessageDescriptor {
-        ::protobuf::MessageStatic::descriptor_static(None::<Self>)
+        ::protobuf::Message::descriptor_static(None::<Self>)
     }
-}
 
-impl ::protobuf::MessageStatic for SourceContext {
     fn new() -> SourceContext {
         SourceContext::new()
     }

--- a/protobuf/src/well_known_types/struct_pb.rs
+++ b/protobuf/src/well_known_types/struct_pb.rs
@@ -138,11 +138,9 @@ impl ::protobuf::Message for Struct {
     }
 
     fn descriptor(&self) -> &'static ::protobuf::reflect::MessageDescriptor {
-        ::protobuf::MessageStatic::descriptor_static(None::<Self>)
+        ::protobuf::Message::descriptor_static(None::<Self>)
     }
-}
 
-impl ::protobuf::MessageStatic for Struct {
     fn new() -> Struct {
         Struct::new()
     }
@@ -596,11 +594,9 @@ impl ::protobuf::Message for Value {
     }
 
     fn descriptor(&self) -> &'static ::protobuf::reflect::MessageDescriptor {
-        ::protobuf::MessageStatic::descriptor_static(None::<Self>)
+        ::protobuf::Message::descriptor_static(None::<Self>)
     }
-}
 
-impl ::protobuf::MessageStatic for Value {
     fn new() -> Value {
         Value::new()
     }
@@ -806,11 +802,9 @@ impl ::protobuf::Message for ListValue {
     }
 
     fn descriptor(&self) -> &'static ::protobuf::reflect::MessageDescriptor {
-        ::protobuf::MessageStatic::descriptor_static(None::<Self>)
+        ::protobuf::Message::descriptor_static(None::<Self>)
     }
-}
 
-impl ::protobuf::MessageStatic for ListValue {
     fn new() -> ListValue {
         ListValue::new()
     }

--- a/protobuf/src/well_known_types/timestamp.rs
+++ b/protobuf/src/well_known_types/timestamp.rs
@@ -173,11 +173,9 @@ impl ::protobuf::Message for Timestamp {
     }
 
     fn descriptor(&self) -> &'static ::protobuf::reflect::MessageDescriptor {
-        ::protobuf::MessageStatic::descriptor_static(None::<Self>)
+        ::protobuf::Message::descriptor_static(None::<Self>)
     }
-}
 
-impl ::protobuf::MessageStatic for Timestamp {
     fn new() -> Timestamp {
         Timestamp::new()
     }

--- a/protobuf/src/well_known_types/type_pb.rs
+++ b/protobuf/src/well_known_types/type_pb.rs
@@ -384,11 +384,9 @@ impl ::protobuf::Message for Type {
     }
 
     fn descriptor(&self) -> &'static ::protobuf::reflect::MessageDescriptor {
-        ::protobuf::MessageStatic::descriptor_static(None::<Self>)
+        ::protobuf::Message::descriptor_static(None::<Self>)
     }
-}
 
-impl ::protobuf::MessageStatic for Type {
     fn new() -> Type {
         Type::new()
     }
@@ -955,11 +953,9 @@ impl ::protobuf::Message for Field {
     }
 
     fn descriptor(&self) -> &'static ::protobuf::reflect::MessageDescriptor {
-        ::protobuf::MessageStatic::descriptor_static(None::<Self>)
+        ::protobuf::Message::descriptor_static(None::<Self>)
     }
-}
 
-impl ::protobuf::MessageStatic for Field {
     fn new() -> Field {
         Field::new()
     }
@@ -1547,11 +1543,9 @@ impl ::protobuf::Message for Enum {
     }
 
     fn descriptor(&self) -> &'static ::protobuf::reflect::MessageDescriptor {
-        ::protobuf::MessageStatic::descriptor_static(None::<Self>)
+        ::protobuf::Message::descriptor_static(None::<Self>)
     }
-}
 
-impl ::protobuf::MessageStatic for Enum {
     fn new() -> Enum {
         Enum::new()
     }
@@ -1832,11 +1826,9 @@ impl ::protobuf::Message for EnumValue {
     }
 
     fn descriptor(&self) -> &'static ::protobuf::reflect::MessageDescriptor {
-        ::protobuf::MessageStatic::descriptor_static(None::<Self>)
+        ::protobuf::Message::descriptor_static(None::<Self>)
     }
-}
 
-impl ::protobuf::MessageStatic for EnumValue {
     fn new() -> EnumValue {
         EnumValue::new()
     }
@@ -2076,11 +2068,9 @@ impl ::protobuf::Message for Option {
     }
 
     fn descriptor(&self) -> &'static ::protobuf::reflect::MessageDescriptor {
-        ::protobuf::MessageStatic::descriptor_static(None::<Self>)
+        ::protobuf::Message::descriptor_static(None::<Self>)
     }
-}
 
-impl ::protobuf::MessageStatic for Option {
     fn new() -> Option {
         Option::new()
     }

--- a/protobuf/src/well_known_types/wrappers.rs
+++ b/protobuf/src/well_known_types/wrappers.rs
@@ -136,11 +136,9 @@ impl ::protobuf::Message for DoubleValue {
     }
 
     fn descriptor(&self) -> &'static ::protobuf::reflect::MessageDescriptor {
-        ::protobuf::MessageStatic::descriptor_static(None::<Self>)
+        ::protobuf::Message::descriptor_static(None::<Self>)
     }
-}
 
-impl ::protobuf::MessageStatic for DoubleValue {
     fn new() -> DoubleValue {
         DoubleValue::new()
     }
@@ -302,11 +300,9 @@ impl ::protobuf::Message for FloatValue {
     }
 
     fn descriptor(&self) -> &'static ::protobuf::reflect::MessageDescriptor {
-        ::protobuf::MessageStatic::descriptor_static(None::<Self>)
+        ::protobuf::Message::descriptor_static(None::<Self>)
     }
-}
 
-impl ::protobuf::MessageStatic for FloatValue {
     fn new() -> FloatValue {
         FloatValue::new()
     }
@@ -468,11 +464,9 @@ impl ::protobuf::Message for Int64Value {
     }
 
     fn descriptor(&self) -> &'static ::protobuf::reflect::MessageDescriptor {
-        ::protobuf::MessageStatic::descriptor_static(None::<Self>)
+        ::protobuf::Message::descriptor_static(None::<Self>)
     }
-}
 
-impl ::protobuf::MessageStatic for Int64Value {
     fn new() -> Int64Value {
         Int64Value::new()
     }
@@ -634,11 +628,9 @@ impl ::protobuf::Message for UInt64Value {
     }
 
     fn descriptor(&self) -> &'static ::protobuf::reflect::MessageDescriptor {
-        ::protobuf::MessageStatic::descriptor_static(None::<Self>)
+        ::protobuf::Message::descriptor_static(None::<Self>)
     }
-}
 
-impl ::protobuf::MessageStatic for UInt64Value {
     fn new() -> UInt64Value {
         UInt64Value::new()
     }
@@ -800,11 +792,9 @@ impl ::protobuf::Message for Int32Value {
     }
 
     fn descriptor(&self) -> &'static ::protobuf::reflect::MessageDescriptor {
-        ::protobuf::MessageStatic::descriptor_static(None::<Self>)
+        ::protobuf::Message::descriptor_static(None::<Self>)
     }
-}
 
-impl ::protobuf::MessageStatic for Int32Value {
     fn new() -> Int32Value {
         Int32Value::new()
     }
@@ -966,11 +956,9 @@ impl ::protobuf::Message for UInt32Value {
     }
 
     fn descriptor(&self) -> &'static ::protobuf::reflect::MessageDescriptor {
-        ::protobuf::MessageStatic::descriptor_static(None::<Self>)
+        ::protobuf::Message::descriptor_static(None::<Self>)
     }
-}
 
-impl ::protobuf::MessageStatic for UInt32Value {
     fn new() -> UInt32Value {
         UInt32Value::new()
     }
@@ -1132,11 +1120,9 @@ impl ::protobuf::Message for BoolValue {
     }
 
     fn descriptor(&self) -> &'static ::protobuf::reflect::MessageDescriptor {
-        ::protobuf::MessageStatic::descriptor_static(None::<Self>)
+        ::protobuf::Message::descriptor_static(None::<Self>)
     }
-}
 
-impl ::protobuf::MessageStatic for BoolValue {
     fn new() -> BoolValue {
         BoolValue::new()
     }
@@ -1305,11 +1291,9 @@ impl ::protobuf::Message for StringValue {
     }
 
     fn descriptor(&self) -> &'static ::protobuf::reflect::MessageDescriptor {
-        ::protobuf::MessageStatic::descriptor_static(None::<Self>)
+        ::protobuf::Message::descriptor_static(None::<Self>)
     }
-}
 
-impl ::protobuf::MessageStatic for StringValue {
     fn new() -> StringValue {
         StringValue::new()
     }
@@ -1478,11 +1462,9 @@ impl ::protobuf::Message for BytesValue {
     }
 
     fn descriptor(&self) -> &'static ::protobuf::reflect::MessageDescriptor {
-        ::protobuf::MessageStatic::descriptor_static(None::<Self>)
+        ::protobuf::Message::descriptor_static(None::<Self>)
     }
-}
 
-impl ::protobuf::MessageStatic for BytesValue {
     fn new() -> BytesValue {
         BytesValue::new()
     }


### PR DESCRIPTION
`MessageStatic` is an artifact of very old days of Rust.  It is not
needed today, because function can have `Self : Sized` constraints
today.

This change is backward incompatible.

Closes issue #214