### PR TITLE
Allow .proto3 file extensions

### DIFF
--- a/protobuf/src/descriptorx.rs
+++ b/protobuf/src/descriptorx.rs
@@ -23,8 +23,7 @@ fn ident_continue(c: char) -> bool {
 
 pub fn proto_path_to_rust_mod(path: &str) -> String {
     let without_dir = strx::remove_to(path, '/');
-    let without_suffix = strx::remove_suffix(without_dir, ".proto")
-        .expect(&format!("file name must end with .proto: {}", path));
+    let without_suffix = strx::remove_suffix(without_dir, ".proto");
 
     let name = without_suffix
         .chars()
@@ -615,4 +614,25 @@ pub fn find_enum_by_rust_name<'a>(
         .into_iter()
         .find(|e| e.rust_name() == rust_name)
         .unwrap()
+}
+
+#[cfg(test)]
+mod test {
+
+    use super::proto_path_to_rust_mod;
+
+    #[test]
+    fn test_mod_path_proto_ext() {
+        assert_eq!("proto", proto_path_to_rust_mod("proto.proto"));
+    }
+
+    #[test]
+    fn test_mod_path_unknown_ext() {
+        assert_eq!("proto_proto3", proto_path_to_rust_mod("proto.proto3"));
+    }
+
+    #[test]
+    fn test_mod_path_empty_ext() {
+        assert_eq!("proto", proto_path_to_rust_mod("proto"));
+    }
 }

--- a/protobuf/src/strx.rs
+++ b/protobuf/src/strx.rs
@@ -5,11 +5,11 @@ pub fn remove_to<'s>(s: &'s str, c: char) -> &'s str {
     }
 }
 
-pub fn remove_suffix<'s>(s: &'s str, suffix: &str) -> Option<&'s str> {
+pub fn remove_suffix<'s>(s: &'s str, suffix: &str) -> &'s str {
     if !s.ends_with(suffix) {
-        None
+        s
     } else {
-        Some(&s[..(s.len() - suffix.len())])
+        &s[..(s.len() - suffix.len())]
     }
 }
 
@@ -28,8 +28,8 @@ mod test {
 
     #[test]
     fn test_remove_suffix() {
-        assert_eq!(Some("bbb"), remove_suffix("bbbaaa", "aaa"));
-        assert_eq!(None, remove_suffix("aaa", "bbb"));
+        assert_eq!("bbb", remove_suffix("bbbaaa", "aaa"));
+        assert_eq!("aaa", remove_suffix("aaa", "bbb"));
     }
 
 }


### PR DESCRIPTION
Currently `rust_protoc` cannot compile [onnx.proto3](https://github.com/onnx/onnx/blob/master/onnx/onnx.proto3) but for no other reason than it ends with `.proto3` instead of `.proto`. This PR remedies this by also trying to remove a `.proto3` extension.