### PR TITLE
Set bytes requirement to 0.4

### DIFF
--- a/protobuf/Cargo.toml
+++ b/protobuf/Cargo.toml
@@ -19,4 +19,4 @@ bench = false
 with-bytes = ["bytes"]
 
 [dependencies]
-bytes = { version = "0.*", optional = true }
+bytes = { version = "0.4", optional = true }


### PR DESCRIPTION
protobuf uses BufMut which was only added in 0.4.