### PR TITLE
Added note about protoc-rust and protobuf version

### DIFF
--- a/protoc-rust/README.md
+++ b/protoc-rust/README.md
@@ -24,8 +24,10 @@ And in `Cargo.toml`:
 protoc-rust = "1.5"
 ```
 
-Note this API requires `protoc` command present in `$PATH`.
+Note 1: This API requires `protoc` command present in `$PATH`.
 Although `protoc-gen-rust` command is not needed.
+
+Note 2: Is advisable that `protoc-rust` build-dependecy version be the same as `protobuf` dependency. 
 
 The alternative is to use
 [pure-rust .proto parser and code generator](https://github.com/stepancheg/rust-protobuf/tree/master/protobuf-codegen-pure).


### PR DESCRIPTION
I added a note in README.md of **protoc-rust** about version of **protobuf**. 

I lost some time to figure out that the problem which I was suffering in #308 was about different versions between **protoc-rust** and **protobuf**. So I added a little note about this issue.