### PR TITLE
Update version in `Cargo.toml` for example

### DIFF
--- a/protoc-rust/README.md
+++ b/protoc-rust/README.md
@@ -21,7 +21,7 @@ And in `Cargo.toml`:
 
 ```
 [build-dependencies]
-protoc-rust = "1.5"
+protoc-rust = "2.0"
 ```
 
 Note 1: This API requires `protoc` command present in `$PATH`.


### PR DESCRIPTION
Using `1.5` doesn't compile because
```
customize: Customize {
      ..Default::default()
    }
```
is not supported in `1.5`. Using `1.5` also leads to errors in the generated Rust code.