### PR TITLE
Add missing `use` statement in README.md

### DIFF
--- a/protoc-rust/README.md
+++ b/protoc-rust/README.md
@@ -7,6 +7,8 @@ Example code:
 ```
 extern crate protoc_rust;
 
+use protoc_rust::Customize;
+
 protoc_rust::run(protoc_rust::Args {
     out_dir: "src/protos",
     input: &["protos/a.proto", "protos/b.proto"],


### PR DESCRIPTION
The example didn't compile when I tried it.