### PR TITLE
Customize::_future_options must be public

### DIFF
--- a/protobuf-codegen/src/customize.rs
+++ b/protobuf-codegen/src/customize.rs
@@ -26,7 +26,7 @@ pub struct Customize {
 
     /// Make sure `Customize` is always used with `..Default::default()`
     /// for future compatibility.
-    _future_options: (),
+    pub _future_options: (),
 }
 
 #[derive(Debug)]


### PR DESCRIPTION
otherwise it doesn't work

Closes #345 