### PR TITLE
Added ability to skip adding "null" values to generated output

### DIFF
--- a/proto/rustproto.proto
+++ b/proto/rustproto.proto
@@ -81,4 +81,6 @@ extend google.protobuf.FieldOptions {
     // Use `std::Option<T>` to store singular messages fields.
     // Note, it's not possible to have recursive messages with this option enabled.
     optional bool singular_field_option_field = 17025;
+    // Skip null fields when using `Serialize`
+    optional bool serde_derive_skip_if_null = 17032;
 }

--- a/protobuf-codegen/src/customize.rs
+++ b/protobuf-codegen/src/customize.rs
@@ -31,6 +31,8 @@ pub struct Customize {
     pub serde_derive: Option<bool>,
     /// When `serde_derive` is set, serde annotations will be guarded with `#[cfg(cfg, ...)]`.
     pub serde_derive_cfg: Option<String>,
+    /// Skip null fields when using `Serialize`
+    pub serde_derive_skip_if_null: Option<bool>,
 
     // When adding more options please keep in sync with `parse_from_parameter` below.
     /// Make sure `Customize` is always used with `..Default::default()`
@@ -83,6 +85,9 @@ impl Customize {
         if let Some(ref v) = that.serde_derive_cfg {
             self.serde_derive_cfg = Some(v.clone());
         }
+        if let Some(v) = that.serde_derive_skip_if_null {
+            self.serde_derive_skip_if_null = Some(v);
+        }
     }
 
     /// Update unset fields of self with fields from other customize
@@ -131,6 +136,8 @@ impl Customize {
                 r.serde_derive = Some(parse_bool(v)?);
             } else if n == "serde_derive_cfg" {
                 r.serde_derive_cfg = Some(v.to_owned());
+            } else if n == "serde_derive_skip_if_null" {
+                r.serde_derive_skip_if_null = Some(parse_bool(v)?);
             } else {
                 return Err(CustomizeParseParameterError::UnknownOptionName(
                     n.to_owned(),
@@ -153,6 +160,7 @@ pub fn customize_from_rustproto_for_message(source: &MessageOptions) -> Customiz
     let singular_field_option = rustproto::exts::singular_field_option.get(source);
     let serde_derive = rustproto::exts::serde_derive.get(source);
     let serde_derive_cfg = rustproto::exts::serde_derive_cfg.get(source);
+    let serde_derive_skip_if_null = None;
     Customize {
         expose_oneof,
         expose_fields,
@@ -165,6 +173,7 @@ pub fn customize_from_rustproto_for_message(source: &MessageOptions) -> Customiz
         singular_field_option,
         serde_derive,
         serde_derive_cfg,
+        serde_derive_skip_if_null,
         _future_options: (),
     }
 }
@@ -182,6 +191,7 @@ pub fn customize_from_rustproto_for_field(source: &FieldOptions) -> Customize {
     let singular_field_option = rustproto::exts::singular_field_option_field.get(source);
     let serde_derive = None;
     let serde_derive_cfg = None;
+    let serde_derive_skip_if_null = rustproto::exts::serde_derive_skip_if_null.get(source);
     Customize {
         expose_oneof,
         expose_fields,
@@ -194,6 +204,7 @@ pub fn customize_from_rustproto_for_field(source: &FieldOptions) -> Customize {
         singular_field_option,
         serde_derive,
         serde_derive_cfg,
+        serde_derive_skip_if_null,
         _future_options: (),
     }
 }
@@ -210,6 +221,7 @@ pub fn customize_from_rustproto_for_file(source: &FileOptions) -> Customize {
     let singular_field_option = rustproto::exts::singular_field_option_all.get(source);
     let serde_derive = rustproto::exts::serde_derive_all.get(source);
     let serde_derive_cfg = rustproto::exts::serde_derive_cfg_all.get(source);
+    let serde_derive_skip_if_null = None;
     Customize {
         expose_oneof,
         expose_fields,
@@ -222,6 +234,7 @@ pub fn customize_from_rustproto_for_file(source: &FileOptions) -> Customize {
         singular_field_option,
         serde_derive,
         serde_derive_cfg,
+        serde_derive_skip_if_null,
         _future_options: (),
     }
 }

--- a/protobuf/src/repeated.rs
+++ b/protobuf/src/repeated.rs
@@ -105,6 +105,12 @@ impl<T> Default for RepeatedField<T> {
 }
 
 impl<T> RepeatedField<T> {
+    /// True iff this object contains no data.
+    #[inline]
+    pub fn is_empty(&self) -> bool {
+        self.vec.is_empty()
+    }
+
     /// Create new empty container.
     #[inline]
     pub fn new() -> RepeatedField<T> {

--- a/protobuf/src/rustproto.rs
+++ b/protobuf/src/rustproto.rs
@@ -64,6 +64,8 @@ pub mod exts {
 
     pub const serde_derive_cfg: ::protobuf::ext::ExtFieldOptional<::protobuf::descriptor::MessageOptions, ::protobuf::types::ProtobufTypeString> = ::protobuf::ext::ExtFieldOptional { field_number: 17031, phantom: ::std::marker::PhantomData };
 
+    pub const serde_derive_skip_if_null: ::protobuf::ext::ExtFieldOptional<::protobuf::descriptor::FieldOptions, ::protobuf::types::ProtobufTypeBool> = ::protobuf::ext::ExtFieldOptional { field_number: 17032, phantom: ::std::marker::PhantomData };
+
     pub const expose_fields_field: ::protobuf::ext::ExtFieldOptional<::protobuf::descriptor::FieldOptions, ::protobuf::types::ProtobufTypeBool> = ::protobuf::ext::ExtFieldOptional { field_number: 17003, phantom: ::std::marker::PhantomData };
 
     pub const generate_accessors_field: ::protobuf::ext::ExtFieldOptional<::protobuf::descriptor::FieldOptions, ::protobuf::types::ProtobufTypeBool> = ::protobuf::ext::ExtFieldOptional { field_number: 17004, phantom: ::std::marker::PhantomData };


### PR DESCRIPTION
When using Serde to generate JSON from protobuf strucs, by default all values were being written to the output even when they were null. This makes the resulting output very unreadable. I double-checked the
generated output from the standard Go library for JSON and it did NOT include "null" values there. This change makes the Rust output equivalent to the Go output.

This is most likely not perfect as I'm fairly new to Rust but I wanted to put something together to start the discussion.
