### PR TITLE
Fix compute_size(value: &i32) for negative number

### DIFF
--- a/protobuf-test/src/common/v2/test_map_simple.rs
+++ b/protobuf-test/src/common/v2/test_map_simple.rs
@@ -23,6 +23,13 @@ fn test_map() {
 }
 
 #[test]
+fn test_map_negative_i32_value() {
+    let mut map = TestMap::new();
+    map.mut_m().insert("two".to_owned(), -2);
+    test_serialize_deserialize("0a 10 0a 03 74 77 6f 10 fe ff ff ff ff ff ff ff ff 01", &map);
+}
+
+#[test]
 fn test_map_with_object() {
     let mut map = TestMap::new();
 

--- a/protobuf-test/src/common/v2/test_map_simple_pb.proto
+++ b/protobuf-test/src/common/v2/test_map_simple_pb.proto
@@ -5,7 +5,7 @@ option (rustproto.generate_accessors_all) = true;
 
 
 message TestMap {
-    map<string, uint32> m = 1;
+    map<string, int32> m = 1;
     map<string, TestMapEntry> mm = 2;
 }
 

--- a/protobuf/src/reflect/types.rs
+++ b/protobuf/src/reflect/types.rs
@@ -222,6 +222,10 @@ impl ProtobufType for ProtobufTypeInt32 {
     }
 
     fn compute_size(value: &i32) -> u32 {
+        // See also: https://github.com/protocolbuffers/protobuf/blob/bd00671b924310c0353a730bf8fa77c44e0a9c72/src/google/protobuf/io/coded_stream.h#L1300-L1306
+        if *value < 0 {
+            return 10
+        }
         rt::compute_raw_varint32_size(*value as u32)
     }
 


### PR DESCRIPTION
See also: https://github.com/protocolbuffers/protobuf/blob/master/src/google/protobuf/io/coded_stream.h#L1300-L1306

Output verified by 
```
protoc -I proto -I protobuf-test/src/common/v2 --decode TestMap < output.bin
```