### PR TITLE
Fix enum reflection skipping field 0

### DIFF
--- a/protobuf/src/reflect/value.rs
+++ b/protobuf/src/reflect/value.rs
@@ -154,7 +154,7 @@ impl<'a> ProtobufValueRef<'a> {
             ProtobufValueRef::Bool(v) => v,
             ProtobufValueRef::String(v) => !v.is_empty(),
             ProtobufValueRef::Bytes(v) => !v.is_empty(),
-            ProtobufValueRef::Enum(v) => v.value() != 0,
+            ProtobufValueRef::Enum(_) => true,
             ProtobufValueRef::Message(_) => true,
         }
     }


### PR DESCRIPTION
I am using the `fmt::Debug` implementation for `Message` to display the content of my messages. I found out that it would never display enum fields with a value of 0. From what I understand, the previous code would assume that value 0 means it's an unset value so it would not display the field. I am unsure about the fix so let me know.

The change should also be made in master and other branches you deem necessary.

before:
```
id: 153984708 namespace: 3495091 increment_id: 6710
id: 154411414 namespace: 3495091 increment_id: 6710
id: 155458430 namespace: 3495091 increment_id: 6710
id: 158334464 namespace: 3494937 increment_type: CAMPAIGN increment_id: 50513
```

after:
```
id: 153984708 namespace: 3495091 increment_type: ADVERTISER increment_id: 6710
id: 154411414 namespace: 3495091 increment_type: ADVERTISER increment_id: 6710
id: 155458430 namespace: 3495091 increment_type: ADVERTISER increment_id: 6710
id: 158334464 namespace: 3494937 increment_type: CAMPAIGN increment_id: 50513
```