### PR TITLE
Remove unsafe from CodedOutputStream

### DIFF
--- a/protobuf/benches/coded_input_stream.rs
+++ b/protobuf/benches/coded_input_stream.rs
@@ -63,7 +63,7 @@ fn read_byte_from_vec(b: &mut Bencher) {
 fn read_varint_12(b: &mut Bencher) {
     let mut v = Vec::new();
     {
-        let mut v = protobuf::CodedOutputStream::vec(&mut v);
+        let mut v = protobuf::CodedOutputStream::new(&mut v);
         for i in 0..1000 {
             // one or two byte varints
             v.write_raw_varint32((i * 7919) % (1 << 14)).expect("write");
@@ -85,7 +85,7 @@ fn read_varint_12(b: &mut Bencher) {
 fn read_varint_1(b: &mut Bencher) {
     let mut v = Vec::new();
     {
-        let mut v = protobuf::CodedOutputStream::vec(&mut v);
+        let mut v = protobuf::CodedOutputStream::new(&mut v);
         for i in 0..1000 {
             // one or two byte varints
             v.write_raw_varint32((i * 7919) % (1 << 7)).expect("write");

--- a/protobuf/benches/coded_input_stream.rs
+++ b/protobuf/benches/coded_input_stream.rs
@@ -6,7 +6,7 @@ extern crate protobuf;
 extern crate test;
 
 use std::io;
-use std::io::Read;
+use std::io::{Read, Write};
 
 use protobuf::stream::CodedInputStream;
 

--- a/protobuf/benches/coded_output_stream.rs
+++ b/protobuf/benches/coded_output_stream.rs
@@ -6,6 +6,7 @@ extern crate protobuf;
 extern crate test;
 
 use protobuf::stream;
+use std::io::Write;
 
 use self::test::Bencher;
 

--- a/protobuf/src/core.rs
+++ b/protobuf/src/core.rs
@@ -75,7 +75,7 @@ pub trait Message: fmt::Debug + Clear + Send + Sync + ProtobufValue {
     /// Write the message to the vec, prepend the message with message length
     /// encoded as varint.
     fn write_length_delimited_to_vec(&self, vec: &mut Vec<u8>) -> ProtobufResult<()> {
-        let mut os = CodedOutputStream::vec(vec);
+        let mut os = CodedOutputStream::new(vec);
         self.write_length_delimited_to(&mut os)?;
         os.flush()?;
         Ok(())
@@ -109,21 +109,16 @@ pub trait Message: fmt::Debug + Clear + Send + Sync + ProtobufValue {
     }
 
     /// Write the message to bytes vec.
-    ///    
+    ///
     /// > **Note**: You can use `parse_from_bytes` to do the reverse.
     fn write_to_bytes(&self) -> ProtobufResult<Vec<u8>> {
         self.check_initialized()?;
 
         let size = self.compute_size() as usize;
         let mut v = Vec::with_capacity(size);
-        // skip zerofill
-        unsafe {
-            v.set_len(size);
-        }
         {
-            let mut os = CodedOutputStream::bytes(&mut v);
+            let mut os = CodedOutputStream::new(&mut v);
             self.write_to_with_cached_sizes(&mut os)?;
-            os.check_eof();
         }
         Ok(v)
     }

--- a/protobuf/src/lib.rs
+++ b/protobuf/src/lib.rs
@@ -82,8 +82,6 @@ mod unknown;
 mod varint;
 mod zigzag;
 
-mod misc;
-
 mod buf_read_iter;
 
 // so `use protobuf::*` could work in mod descriptor and well_known_types

--- a/protobuf/src/misc.rs
+++ b/protobuf/src/misc.rs
@@ -1,37 +1,5 @@
 use std::mem;
-use std::slice;
-
-/// Slice from `vec[vec.len()..vec.capacity()]`
-pub unsafe fn remaining_capacity_as_slice_mut<A>(vec: &mut Vec<A>) -> &mut [A] {
-    slice::from_raw_parts_mut(
-        vec.as_mut_slice().as_mut_ptr().offset(vec.len() as isize),
-        vec.capacity() - vec.len(),
-    )
-}
 
 pub unsafe fn remove_lifetime_mut<A: ?Sized>(a: &mut A) -> &'static mut A {
     mem::transmute(a)
-}
-
-#[cfg(test)]
-mod test {
-    use super::*;
-
-    #[test]
-    fn test_remaining_capacity_as_slice_mut() {
-        let mut v = Vec::with_capacity(5);
-        v.push(10);
-        v.push(11);
-        v.push(12);
-        unsafe {
-            {
-                let s = remaining_capacity_as_slice_mut(&mut v);
-                assert_eq!(2, s.len());
-                s[0] = 13;
-                s[1] = 14;
-            }
-            v.set_len(5);
-        }
-        assert_eq!(vec![10, 11, 12, 13, 14], v);
-    }
 }

--- a/protobuf/src/misc.rs
+++ b/protobuf/src/misc.rs
@@ -1,5 +1,0 @@
-use std::mem;
-
-pub unsafe fn remove_lifetime_mut<A: ?Sized>(a: &mut A) -> &'static mut A {
-    mem::transmute(a)
-}

--- a/protobuf/src/stream.rs
+++ b/protobuf/src/stream.rs
@@ -735,37 +735,6 @@ impl<'a> CodedOutputStream<'a> {
         }
     }
 
-    /// `CodedOutputStream` which writes directly to bytes.
-    ///
-    /// Attempt to write more than bytes capacity results in error.
-    pub fn bytes(bytes: &'a mut [u8]) -> CodedOutputStream<'a> {
-        CodedOutputStream {
-            target: OutputTarget::Bytes,
-            buffer: bytes,
-            position: 0,
-        }
-    }
-
-    /// `CodedOutputStream` which writes directly to `Vec<u8>`.
-    pub fn vec(vec: &'a mut Vec<u8>) -> CodedOutputStream<'a> {
-        CodedOutputStream {
-            target: OutputTarget::Vec(vec),
-            buffer: &mut [],
-            position: 0,
-        }
-    }
-
-    pub fn check_eof(&self) {
-        match self.target {
-            OutputTarget::Bytes => {
-                assert_eq!(self.buffer.len() as u64, self.position as u64);
-            }
-            OutputTarget::Write(..) | OutputTarget::Vec(..) => {
-                panic!("must not be called with Writer or Vec");
-            }
-        }
-    }
-
     fn refresh_buffer(&mut self) -> ProtobufResult<()> {
         match self.target {
             OutputTarget::Write(ref mut write, _) => {

--- a/protobuf/src/stream.rs
+++ b/protobuf/src/stream.rs
@@ -737,23 +737,37 @@ impl<'a> CodedOutputStream<'a> {
     }
 
     pub fn write_raw_little_endian32(&mut self, value: u32) -> ProtobufResult<()> {
-        let bytes = unsafe { mem::transmute::<_, [u8; 4]>(value.to_le()) };
+        let bytes: [u8; 4] = [
+            ((value >>  0) & 0xff) as u8,
+            ((value >>  8) & 0xff) as u8,
+            ((value >> 16) & 0xff) as u8,
+            ((value >> 24) & 0xff) as u8,
+        ];
+
         self.write_raw_bytes(&bytes)
     }
 
     pub fn write_raw_little_endian64(&mut self, value: u64) -> ProtobufResult<()> {
-        let bytes = unsafe { mem::transmute::<_, [u8; 8]>(value.to_le()) };
+        let bytes: [u8; 8] = [
+            ((value >>  0) & 0xff) as u8,
+            ((value >>  8) & 0xff) as u8,
+            ((value >> 16) & 0xff) as u8,
+            ((value >> 24) & 0xff) as u8,
+            ((value >> 32) & 0xff) as u8,
+            ((value >> 40) & 0xff) as u8,
+            ((value >> 48) & 0xff) as u8,
+            ((value >> 56) & 0xff) as u8,
+        ];
+
         self.write_raw_bytes(&bytes)
     }
 
     pub fn write_float_no_tag(&mut self, value: f32) -> ProtobufResult<()> {
-        let bits = unsafe { mem::transmute::<f32, u32>(value) };
-        self.write_raw_little_endian32(bits)
+        self.write_raw_little_endian32(value.to_bits())
     }
 
     pub fn write_double_no_tag(&mut self, value: f64) -> ProtobufResult<()> {
-        let bits = unsafe { mem::transmute::<f64, u64>(value) };
-        self.write_raw_little_endian64(bits)
+        self.write_raw_little_endian64(value.to_bits())
     }
 
     pub fn write_float(&mut self, field_number: u32, value: f32) -> ProtobufResult<()> {

--- a/protobuf/src/stream.rs
+++ b/protobuf/src/stream.rs
@@ -15,7 +15,6 @@ use enums::ProtobufEnum;
 use error::ProtobufError;
 use error::ProtobufResult;
 use error::WireError;
-use misc::remove_lifetime_mut;
 use unknown::UnknownFields;
 use unknown::UnknownValue;
 use unknown::UnknownValueRef;

--- a/protobuf/src/stream.rs
+++ b/protobuf/src/stream.rs
@@ -641,7 +641,7 @@ impl<'a> WithCodedOutputStream for &'a mut Vec<u8> {
     where
         F: FnOnce(&mut CodedOutputStream) -> ProtobufResult<T>,
     {
-        let mut os = CodedOutputStream::vec(&mut self);
+        let mut os = CodedOutputStream::new(&mut self);
         let r = cb(&mut os)?;
         os.flush()?;
         Ok(r)
@@ -1368,11 +1368,9 @@ mod test {
         // write to &[u8]
         {
             let mut r = Vec::with_capacity(expected_bytes.len());
-            r.resize(expected_bytes.len(), 0);
             {
-                let mut os = CodedOutputStream::bytes(&mut r);
+                let mut os = CodedOutputStream::new(&mut r);
                 gen(&mut os).unwrap();
-                os.check_eof();
             }
             assert_eq!(encode_hex(&expected_bytes), encode_hex(&r));
         }
@@ -1382,7 +1380,7 @@ mod test {
             let mut r = Vec::new();
             r.extend(&[11, 22, 33, 44, 55, 66, 77]);
             {
-                let mut os = CodedOutputStream::vec(&mut r);
+                let mut os = CodedOutputStream::new(&mut r);
                 gen(&mut os).unwrap();
                 os.flush().unwrap();
             }
@@ -1489,12 +1487,10 @@ mod test {
         // write to &[u8]
         {
             let mut v = Vec::with_capacity(expected.len());
-            v.resize(expected.len(), 0);
             {
-                let mut os = CodedOutputStream::bytes(&mut v);
+                let mut os = CodedOutputStream::new(&mut v);
                 Write::write(&mut os, &expected).expect("io::Write::write");
                 Write::flush(&mut os).expect("io::Write::flush");
-                os.check_eof();
             }
             assert_eq!(expected, *v);
         }
@@ -1503,7 +1499,7 @@ mod test {
         {
             let mut v = Vec::new();
             {
-                let mut os = CodedOutputStream::vec(&mut v);
+                let mut os = CodedOutputStream::new(&mut v);
                 Write::write(&mut os, &expected).expect("io::Write::write");
                 Write::flush(&mut os).expect("io::Write::flush");
             }

--- a/protobuf/src/stream.rs
+++ b/protobuf/src/stream.rs
@@ -1,5 +1,5 @@
 use std::io;
-use std::io::Write;
+use std::io::{BufWriter, Write};
 use std::io::{BufRead, Read};
 use std::mem;
 use std::slice;
@@ -703,7 +703,7 @@ impl<'a> WithCodedInputStream for &'a Bytes {
 }
 
 pub struct CodedOutputStream<'a> {
-    target: &'a mut Write,
+    target: BufWriter<&'a mut Write>,
     buffer_storage: Vec<u8>,
     // alias to buf from target
     buffer: &'a mut [u8],
@@ -723,7 +723,7 @@ impl<'a> CodedOutputStream<'a> {
         let buffer = unsafe { remove_lifetime_mut(&mut buffer_storage as &mut [u8]) };
 
         CodedOutputStream {
-            target: writer,
+            target: BufWriter::new(writer),
             buffer_storage,
             buffer: buffer,
             position: 0,

--- a/protobuf/src/stream.rs
+++ b/protobuf/src/stream.rs
@@ -15,7 +15,6 @@ use enums::ProtobufEnum;
 use error::ProtobufError;
 use error::ProtobufResult;
 use error::WireError;
-use misc::remaining_capacity_as_slice_mut;
 use misc::remove_lifetime_mut;
 use unknown::UnknownFields;
 use unknown::UnknownValue;

--- a/protobuf/src/varint.rs
+++ b/protobuf/src/varint.rs
@@ -1,35 +1,27 @@
 /// Encode u64 as varint.
 /// Panics if buffer length is less than 10.
 #[inline]
-pub fn encode_varint64(mut value: u64, buf: &mut [u8]) -> usize {
-    assert!(buf.len() >= 10);
-
-    unsafe {
-        let mut i = 0;
-        while (value & !0x7F) > 0 {
-            *buf.get_unchecked_mut(i) = ((value & 0x7F) | 0x80) as u8;
-            value >>= 7;
-            i += 1;
-        }
-        *buf.get_unchecked_mut(i) = value as u8;
-        i + 1
+pub fn encode_varint64(mut value: u64, buf: &mut [u8; 10]) -> usize {
+    let mut i = 0;
+    while (value & !0x7F) > 0 {
+        buf[i] = ((value & 0x7F) | 0x80) as u8;
+        value >>= 7;
+        i += 1;
     }
+    buf[i] = value as u8;
+    i + 1
 }
 
 /// Encode u32 value as varint.
 /// Panics if buffer length is less than 5.
 #[inline]
-pub fn encode_varint32(mut value: u32, buf: &mut [u8]) -> usize {
-    assert!(buf.len() >= 5);
-
-    unsafe {
-        let mut i = 0;
-        while (value & !0x7F) > 0 {
-            *buf.get_unchecked_mut(i) = ((value & 0x7F) | 0x80) as u8;
-            value >>= 7;
-            i += 1;
-        }
-        *buf.get_unchecked_mut(i) = value as u8;
-        i + 1
+pub fn encode_varint32(mut value: u32, buf: &mut [u8; 5]) -> usize {
+    let mut i = 0;
+    while (value & !0x7F) > 0 {
+        buf[i] = ((value & 0x7F) | 0x80) as u8;
+        value >>= 7;
+        i += 1;
     }
+    buf[i] = value as u8;
+    i + 1
 }


### PR DESCRIPTION
This pull request removes uses of `unsafe` from `CodedOutputStream`.

I've tried to make small and methodical commits through this refactor in the hope that it makes each individual step easier to follow and makes this PR overall easier to review.

A quick summary of the changes I've made:

* Removing the `OutputTarget` enum. Since `Vec<u8>` and `&mut [u8]` already impl the `Write` trait, we can just pass vecs and slices directly to the `new` constructor that takes a `&mut Write`

* Replacing `CodedOutputStream`'s own internal buffering with `BufWriter`

* Replacing the use of `mem::transmute` in the u32 and u64 encoders with manual bit shifting

* Replacing the use of `mem::transmute` in the f32 and f64 encoders with the `to_bits` method

* Replacing the use of `get_unchecked_mut` in the varint encoder fns with regular indexing. I've changed the type of the `buf` argument to these functions to take a sized array in the hope that the compiler is smart enough to prove that we never index these buffers out of bounds and can elide the bounds check

This PR reduces the amount of uses of the `unsafe` keyword in this repo from 46 to 32.