### PR TITLE
ci: use $HOME variable rather than /home/travis

### DIFF
--- a/ci/run.sh
+++ b/ci/run.sh
@@ -9,7 +9,7 @@ export LD_LIBRARY_PATH="$HOME/lib"
 which protoc
 protoc --version
 if [ -z "$ON_WINDOWS" ];
-    then PKG_CONFIG_PATH="/home/travis/lib/pkgconfig" interop/cxx/compile.sh
+    then PKG_CONFIG_PATH="$HOME/lib/pkgconfig" interop/cxx/compile.sh
 fi
 export RUST_BACKTRACE=1
 


### PR DESCRIPTION
Running `ci/run.sh` locally works flawlessly, except for this hardcoded reference to the travis environment.

This PR makes the ci scripts work locally on Linux too - useful for someone just picking up the repo for the first time.