### PR TITLE
Add documentation in generated code

### DIFF
--- a/protobuf-codegen/src/code_writer.rs
+++ b/protobuf-codegen/src/code_writer.rs
@@ -270,6 +270,37 @@ impl<'a> CodeWriter<'a> {
         }
     }
 
+    fn documentation(&mut self, comment: &str) {
+        if comment.is_empty() {
+            self.write_line("///");
+        } else {
+            self.write_line(&format!("/// {}", comment));
+        }
+    }
+
+    pub fn all_documentation(
+        &mut self,
+        info: Option<&protobuf::descriptor::SourceCodeInfo>,
+        path: &[i32],
+    ) {
+        let doc = info
+            .map(|v| &v.location)
+            .and_then(|ls| ls.iter().find(|l| l.path == path))
+            .map(|l| l.get_leading_comments());
+
+        let lines = doc
+            .iter()
+            .map(|doc| doc.lines())
+            .flatten()
+            .collect::<Vec<_>>();
+
+        if !lines.iter().any(|line| line.starts_with("    ")) {
+            for doc in &lines {
+                self.documentation(doc);
+            }
+        }
+    }
+
     pub fn fn_def(&mut self, sig: &str) {
         self.write_line(&format!("fn {};", sig));
     }

--- a/protobuf-codegen/src/code_writer.rs
+++ b/protobuf-codegen/src/code_writer.rs
@@ -278,6 +278,53 @@ impl<'a> CodeWriter<'a> {
         }
     }
 
+    /// Writes the documentation of the given path.
+    ///
+    /// Protobuf paths are defined in proto/google/protobuf/descriptor.proto,
+    /// in the `SourceCodeInfo` message.
+    ///
+    /// For example, say we have a file like:
+    ///
+    /// ```ignore
+    /// message Foo {
+    ///   optional string foo = 1;
+    /// }
+    /// ```
+    ///
+    /// Let's look at just the field definition. We have the following paths:
+    ///
+    /// ```ignore
+    /// path               represents
+    /// [ 4, 0, 2, 0 ]     The whole field definition.
+    /// [ 4, 0, 2, 0, 4 ]  The label (optional).
+    /// [ 4, 0, 2, 0, 5 ]  The type (string).
+    /// [ 4, 0, 2, 0, 1 ]  The name (foo).
+    /// [ 4, 0, 2, 0, 3 ]  The number (1).
+    /// ```
+    ///
+    /// The `4`s can be obtained using simple introspection:
+    ///
+    /// ```
+    /// use protobuf::descriptor::FileDescriptorProto;
+    /// use protobuf::reflect::MessageDescriptor;
+    ///
+    /// let id = MessageDescriptor::for_type::<FileDescriptorProto>()
+    ///     .field_by_name("message_type")
+    ///     .expect("`message_type` must exist")
+    ///     .proto()
+    ///     .get_number();
+    ///
+    /// assert_eq!(id, 4);
+    /// ```
+    ///
+    /// The first `0` here means this path refers to the first message.
+    ///
+    /// The `2` then refers to the `field` field on the `DescriptorProto` message.
+    ///
+    /// Then comes another `0` to refer to the first field of the current message.
+    ///
+    /// Etc.
+
     pub fn all_documentation(
         &mut self,
         info: Option<&protobuf::descriptor::SourceCodeInfo>,

--- a/protobuf-codegen/src/code_writer.rs
+++ b/protobuf-codegen/src/code_writer.rs
@@ -294,6 +294,7 @@ impl<'a> CodeWriter<'a> {
             .flatten()
             .collect::<Vec<_>>();
 
+        // Skip comments with code blocks to avoid rustdoc trying to compile them.
         if !lines.iter().any(|line| line.starts_with("    ")) {
             for doc in &lines {
                 self.documentation(doc);

--- a/protobuf-codegen/src/enums.rs
+++ b/protobuf-codegen/src/enums.rs
@@ -55,6 +55,8 @@ pub(crate) struct EnumGen<'a> {
     type_name: RustIdentWithPath,
     lite_runtime: bool,
     customize: Customize,
+    path: &'a [i32],
+    info: Option<&'a SourceCodeInfo>,
 }
 
 impl<'a> EnumGen<'a> {
@@ -62,6 +64,8 @@ impl<'a> EnumGen<'a> {
         enum_with_scope: &'a EnumWithScope<'a>,
         customize: &Customize,
         _root_scope: &RootScope,
+        path: &'a [i32],
+        info: Option<&'a SourceCodeInfo>,
     ) -> EnumGen<'a> {
         let lite_runtime = customize.lite_runtime.unwrap_or_else(|| {
             enum_with_scope
@@ -78,6 +82,8 @@ impl<'a> EnumGen<'a> {
             type_name: enum_with_scope.rust_name().to_path(),
             lite_runtime,
             customize: customize.clone(),
+            path,
+            info,
         }
     }
 
@@ -112,7 +118,7 @@ impl<'a> EnumGen<'a> {
     }
 
     pub fn write(&self, w: &mut CodeWriter) {
-        self.write_struct(w);
+        self.write_enum(w);
         if self.allow_alias() {
             w.write_line("");
             self.write_impl_eq(w);
@@ -127,7 +133,9 @@ impl<'a> EnumGen<'a> {
         self.write_impl_value(w);
     }
 
-    fn write_struct(&self, w: &mut CodeWriter) {
+    fn write_enum(&self, w: &mut CodeWriter) {
+        w.all_documentation(self.info, self.path);
+
         let mut derive = Vec::new();
         derive.push("Clone");
         derive.push("Copy");

--- a/protobuf-codegen/src/field.rs
+++ b/protobuf-codegen/src/field.rs
@@ -580,6 +580,8 @@ pub(crate) struct FieldGen<'a> {
     pub generate_accessors: bool,
     pub generate_getter: bool,
     customize: Customize,
+    path: Vec<i32>,
+    info: Option<&'a SourceCodeInfo>,
 }
 
 impl<'a> FieldGen<'a> {
@@ -587,6 +589,8 @@ impl<'a> FieldGen<'a> {
         field: FieldWithContext<'a>,
         root_scope: &'a RootScope<'a>,
         customize: &Customize,
+        path: Vec<i32>,
+        info: Option<&'a SourceCodeInfo>,
     ) -> FieldGen<'a> {
         let mut customize = customize.clone();
         customize.update_with(&customize_from_rustproto_for_field(
@@ -691,6 +695,8 @@ impl<'a> FieldGen<'a> {
             generate_accessors,
             generate_getter,
             customize,
+            path,
+            info,
         }
     }
 
@@ -1454,6 +1460,8 @@ impl<'a> FieldGen<'a> {
         if self.proto_type == field_descriptor_proto::Type::TYPE_GROUP {
             w.comment(&format!("{}: <group>", &self.rust_name));
         } else {
+            w.all_documentation(self.info, &self.path);
+
             let vis = self.visibility();
             w.field_decl_vis(
                 vis,

--- a/protobuf-codegen/src/lib.rs
+++ b/protobuf-codegen/src/lib.rs
@@ -227,7 +227,7 @@ fn gen_file(
                 .get_number()
         });
 
-        path[0] = enum_type_number;
+        let mut path = vec![enum_type_number, 0];
         for (id, enum_type) in scope.get_enums().iter().enumerate() {
             path[1] = id as i32;
 

--- a/protobuf-codegen/src/lib.rs
+++ b/protobuf-codegen/src/lib.rs
@@ -195,8 +195,9 @@ fn gen_file(
         let message_type_number = *NESTED_TYPE_NUMBER.get(|| {
             protobuf::reflect::MessageDescriptor::for_type::<FileDescriptorProto>()
                 .field_by_name("message_type")
-                .map(|d| d.proto().get_number())
                 .expect("`message_type` must exist")
+                .proto()
+                .get_number()
         });
 
         let mut path = vec![message_type_number, 0];
@@ -221,8 +222,9 @@ fn gen_file(
         let enum_type_number = *ENUM_TYPE_NUMBER.get(|| {
             protobuf::reflect::MessageDescriptor::for_type::<FileDescriptorProto>()
                 .field_by_name("enum_type")
-                .map(|d| d.proto().get_number())
                 .expect("`enum_type` must exist")
+                .proto()
+                .get_number()
         });
 
         path[0] = enum_type_number;

--- a/protobuf-codegen/src/message.rs
+++ b/protobuf-codegen/src/message.rs
@@ -52,8 +52,9 @@ impl<'a> MessageGen<'a> {
         let field_number = *FIELD_NUMBER.get(|| {
             protobuf::reflect::MessageDescriptor::for_type::<DescriptorProto>()
                 .field_by_name("field")
-                .map(|d| d.proto().get_number())
                 .expect("`field` must exist")
+                .proto()
+                .get_number()
         });
 
         let fields: Vec<_> = message
@@ -603,8 +604,9 @@ impl<'a> MessageGen<'a> {
                 let nested_type_number = *NESTED_TYPE_NUMBER.get(|| {
                     protobuf::reflect::MessageDescriptor::for_type::<DescriptorProto>()
                         .field_by_name("nested_type")
-                        .map(|d| d.proto().get_number())
                         .expect("`nested_type` must exist")
+                        .proto()
+                        .get_number()
                 });
 
                 let mut path = self.path.to_vec();
@@ -625,8 +627,9 @@ impl<'a> MessageGen<'a> {
                 let enum_type_number = *ENUM_TYPE_NUMBER.get(|| {
                     protobuf::reflect::MessageDescriptor::for_type::<DescriptorProto>()
                         .field_by_name("enum_type")
-                        .map(|d| d.proto().get_number())
                         .expect("`enum_type` must exist")
+                        .proto()
+                        .get_number()
                 });
 
                 let len = path.len() - 2;


### PR DESCRIPTION
Notes:
- A few more things could probably be generated.
- Comments containing four spaces are ignored, because rustdoc would try to compile and run those. We could transform those to using ` ```ignore `, but that would require a full markdown parser.

Questions:
- Should this be an option?

Close #402.