### PR TITLE
implement Error for ParseErrorWithLoc

### DIFF
--- a/protobuf-test/src/common/v2/test_fmt_text_format.rs
+++ b/protobuf-test/src/common/v2/test_fmt_text_format.rs
@@ -153,3 +153,10 @@ fn test_reflect() {
     l.set_ts(special_messages_typed().into());
     test_text_format_message(&l);
 }
+
+#[test]
+fn test_parse_error() {
+    let e = protobuf::text_format::parse_from_str::<TestTypes>("nonexistent: 42").unwrap_err();
+    let _error: &dyn std::error::Error = &e;
+    assert_eq!(e.to_string(), "1:1: UnknownField(\"nonexistent\")");
+}

--- a/protobuf/src/text_format/parse.rs
+++ b/protobuf/src/text_format/parse.rs
@@ -1,3 +1,4 @@
+use std::fmt;
 use std::str;
 
 use crate::core::Message;
@@ -51,6 +52,14 @@ pub struct ParseErrorWithLoc {
     error: ParseError,
     loc: Loc,
 }
+
+impl fmt::Display for ParseErrorWithLoc {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "{}: {:?}", self.loc, self.error)
+    }
+}
+
+impl std::error::Error for ParseErrorWithLoc {}
 
 pub type ParseResult<A> = Result<A, ParseError>;
 pub type ParseWithLocResult<A> = Result<A, ParseErrorWithLoc>;


### PR DESCRIPTION
Fixes #422

This allows me to just use ? on such an error from a function that
returns failure::Error.

In the issue, I also mentioned that ParseErrorWithLoc is a private type.
(It's in a private mod and is never re-exported.) Looks like that
doesn't matter if I just want to use its Error/Display/Debug
implementations, so I didn't change it.