### PR TITLE
Fix generated code with rust_2018_idioms

### DIFF
--- a/protobuf-codegen/src/message.rs
+++ b/protobuf-codegen/src/message.rs
@@ -189,7 +189,7 @@ impl<'a> MessageGen<'a> {
 
     fn write_write_to_with_cached_sizes(&self, w: &mut CodeWriter) {
         let sig = format!(
-            "write_to_with_cached_sizes(&self, os: &mut {}::CodedOutputStream) -> {}::ProtobufResult<()>",
+            "write_to_with_cached_sizes(&self, os: &mut {}::CodedOutputStream<'_>) -> {}::ProtobufResult<()>",
             protobuf_crate_path(&self.customize),
             protobuf_crate_path(&self.customize),
         );
@@ -292,7 +292,7 @@ impl<'a> MessageGen<'a> {
 
     fn write_merge_from(&self, w: &mut CodeWriter) {
         let sig = format!(
-            "merge_from(&mut self, is: &mut {}::CodedInputStream) -> {}::ProtobufResult<()>",
+            "merge_from(&mut self, is: &mut {}::CodedInputStream<'_>) -> {}::ProtobufResult<()>",
             protobuf_crate_path(&self.customize),
             protobuf_crate_path(&self.customize),
         );
@@ -437,7 +437,7 @@ impl<'a> MessageGen<'a> {
     fn write_impl_show(&self, w: &mut CodeWriter) {
         w.impl_for_block("::std::fmt::Debug", &format!("{}", self.type_name), |w| {
             w.def_fn(
-                "fmt(&self, f: &mut ::std::fmt::Formatter) -> ::std::fmt::Result",
+                "fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result",
                 |w| {
                     w.write_line(&format!(
                         "{}::text_format::fmt(self, f)",


### PR DESCRIPTION
Fixes #435: "hidden lifetime parameters in types are deprecated" against generated code when `rust_2018_idioms` is enabled in a project.

With these fixes the sample in #435 was able to build. Did some looking around `message.rs` and didn't find any other cases of missing lifetime parameters.