### PR TITLE
Fix parsing of RPC input and output types

### DIFF
--- a/protobuf-codegen-pure/src/parser.rs
+++ b/protobuf-codegen-pure/src/parser.rs
@@ -974,12 +974,12 @@ impl<'a> Parser<'a> {
             let name = self.tokenizer.next_ident()?;
             self.tokenizer.next_symbol_expect_eq('(')?;
             let client_streaming = self.tokenizer.next_ident_if_eq("stream")?;
-            let input_type = self.tokenizer.next_ident()?;
+            let input_type = self.next_message_or_enum_type()?;
             self.tokenizer.next_symbol_expect_eq(')')?;
             self.tokenizer.next_ident_expect_eq("returns")?;
             self.tokenizer.next_symbol_expect_eq('(')?;
             let server_streaming = self.tokenizer.next_ident_if_eq("stream")?;
-            let output_type = self.tokenizer.next_ident()?;
+            let output_type = self.next_message_or_enum_type()?;
             self.tokenizer.next_symbol_expect_eq(')')?;
             let options = self.next_options_or_colon()?;
             Ok(Some(Method {

--- a/protobuf-test/src/common/v2/test_service.rs
+++ b/protobuf-test/src/common/v2/test_service.rs
@@ -1,0 +1,10 @@
+use super::test_service_pb::*;
+
+#[test]
+fn test_service() {
+    // The request/response types should still
+    // get generated, even though we ignore the
+    // service definition in the same file.
+    let _ = Request::new();
+    let _ = Response::new();
+}

--- a/protobuf-test/src/common/v2/test_service_pb.proto
+++ b/protobuf-test/src/common/v2/test_service_pb.proto
@@ -1,0 +1,34 @@
+syntax = "proto2";
+
+import "google/protobuf/descriptor.proto";
+
+import "test_basic_pb.proto";
+
+package service;
+
+extend google.protobuf.MethodOptions {
+    optional FancyMethodOptions fancy = 50000;
+}
+
+message FancyMethodOptions {
+    optional bool dotted = 1;
+}
+
+service Service {
+    rpc ShortForm(Request) returns(Response);
+    rpc LongForm(Request) returns(Response) {
+        option (service.fancy).dotted = true;
+    }
+    // Dots in request and response types.
+    rpc DottyShortForm(basic.Test1) returns(basic.Test2);
+    rpc DottyLongForm(basic.Test1) returns(basic.Test2) {
+        // Alternate form of above.
+        option (fancy).dotted = true;
+    }
+}
+
+message Request {
+}
+
+message Response {
+}


### PR DESCRIPTION
They can be fully-qualified message type names — not necessarily
just a single identifier.
