### PR TITLE
Fixed dead clippy issue link

### DIFF
--- a/protobuf-codegen/src/code_writer.rs
+++ b/protobuf-codegen/src/code_writer.rs
@@ -55,7 +55,7 @@ impl<'a> CodeWriter<'a> {
         self.write_line("// @generated");
 
         self.write_line("");
-        self.comment("https://github.com/Manishearth/rust-clippy/issues/702");
+        self.comment("https://github.com/rust-lang/rust-clippy/issues/702");
         self.write_line("#![allow(unknown_lints)]");
         self.write_line("#![allow(clippy::all)]");
         self.write_line("");

--- a/protobuf/src/descriptor.rs
+++ b/protobuf/src/descriptor.rs
@@ -2,7 +2,7 @@
 // .proto file is parsed by protoc --rust-out=...
 // @generated
 
-// https://github.com/Manishearth/rust-clippy/issues/702
+// https://github.com/rust-lang/rust-clippy/issues/702
 #![allow(unknown_lints)]
 #![allow(clippy::all)]
 

--- a/protobuf/src/plugin.rs
+++ b/protobuf/src/plugin.rs
@@ -2,7 +2,7 @@
 // .proto file is parsed by protoc --rust-out=...
 // @generated
 
-// https://github.com/Manishearth/rust-clippy/issues/702
+// https://github.com/rust-lang/rust-clippy/issues/702
 #![allow(unknown_lints)]
 #![allow(clippy::all)]
 

--- a/protobuf/src/rustproto.rs
+++ b/protobuf/src/rustproto.rs
@@ -2,7 +2,7 @@
 // .proto file is parsed by protoc --rust-out=...
 // @generated
 
-// https://github.com/Manishearth/rust-clippy/issues/702
+// https://github.com/rust-lang/rust-clippy/issues/702
 #![allow(unknown_lints)]
 #![allow(clippy::all)]
 

--- a/protobuf/src/well_known_types/any.rs
+++ b/protobuf/src/well_known_types/any.rs
@@ -2,7 +2,7 @@
 // .proto file is parsed by protoc --rust-out=...
 // @generated
 
-// https://github.com/Manishearth/rust-clippy/issues/702
+// https://github.com/rust-lang/rust-clippy/issues/702
 #![allow(unknown_lints)]
 #![allow(clippy::all)]
 

--- a/protobuf/src/well_known_types/api.rs
+++ b/protobuf/src/well_known_types/api.rs
@@ -2,7 +2,7 @@
 // .proto file is parsed by protoc --rust-out=...
 // @generated
 
-// https://github.com/Manishearth/rust-clippy/issues/702
+// https://github.com/rust-lang/rust-clippy/issues/702
 #![allow(unknown_lints)]
 #![allow(clippy::all)]
 

--- a/protobuf/src/well_known_types/duration.rs
+++ b/protobuf/src/well_known_types/duration.rs
@@ -2,7 +2,7 @@
 // .proto file is parsed by protoc --rust-out=...
 // @generated
 
-// https://github.com/Manishearth/rust-clippy/issues/702
+// https://github.com/rust-lang/rust-clippy/issues/702
 #![allow(unknown_lints)]
 #![allow(clippy::all)]
 

--- a/protobuf/src/well_known_types/empty.rs
+++ b/protobuf/src/well_known_types/empty.rs
@@ -2,7 +2,7 @@
 // .proto file is parsed by protoc --rust-out=...
 // @generated
 
-// https://github.com/Manishearth/rust-clippy/issues/702
+// https://github.com/rust-lang/rust-clippy/issues/702
 #![allow(unknown_lints)]
 #![allow(clippy::all)]
 

--- a/protobuf/src/well_known_types/field_mask.rs
+++ b/protobuf/src/well_known_types/field_mask.rs
@@ -2,7 +2,7 @@
 // .proto file is parsed by protoc --rust-out=...
 // @generated
 
-// https://github.com/Manishearth/rust-clippy/issues/702
+// https://github.com/rust-lang/rust-clippy/issues/702
 #![allow(unknown_lints)]
 #![allow(clippy::all)]
 

--- a/protobuf/src/well_known_types/source_context.rs
+++ b/protobuf/src/well_known_types/source_context.rs
@@ -2,7 +2,7 @@
 // .proto file is parsed by protoc --rust-out=...
 // @generated
 
-// https://github.com/Manishearth/rust-clippy/issues/702
+// https://github.com/rust-lang/rust-clippy/issues/702
 #![allow(unknown_lints)]
 #![allow(clippy::all)]
 

--- a/protobuf/src/well_known_types/struct_pb.rs
+++ b/protobuf/src/well_known_types/struct_pb.rs
@@ -2,7 +2,7 @@
 // .proto file is parsed by protoc --rust-out=...
 // @generated
 
-// https://github.com/Manishearth/rust-clippy/issues/702
+// https://github.com/rust-lang/rust-clippy/issues/702
 #![allow(unknown_lints)]
 #![allow(clippy::all)]
 

--- a/protobuf/src/well_known_types/timestamp.rs
+++ b/protobuf/src/well_known_types/timestamp.rs
@@ -2,7 +2,7 @@
 // .proto file is parsed by protoc --rust-out=...
 // @generated
 
-// https://github.com/Manishearth/rust-clippy/issues/702
+// https://github.com/rust-lang/rust-clippy/issues/702
 #![allow(unknown_lints)]
 #![allow(clippy::all)]
 

--- a/protobuf/src/well_known_types/type_pb.rs
+++ b/protobuf/src/well_known_types/type_pb.rs
@@ -2,7 +2,7 @@
 // .proto file is parsed by protoc --rust-out=...
 // @generated
 
-// https://github.com/Manishearth/rust-clippy/issues/702
+// https://github.com/rust-lang/rust-clippy/issues/702
 #![allow(unknown_lints)]
 #![allow(clippy::all)]
 

--- a/protobuf/src/well_known_types/wrappers.rs
+++ b/protobuf/src/well_known_types/wrappers.rs
@@ -2,7 +2,7 @@
 // .proto file is parsed by protoc --rust-out=...
 // @generated
 
-// https://github.com/Manishearth/rust-clippy/issues/702
+// https://github.com/rust-lang/rust-clippy/issues/702
 #![allow(unknown_lints)]
 #![allow(clippy::all)]
 


### PR DESCRIPTION
The original link: https://github.com/Manishearth/rust-clippy/issues/702 was a dead link. Replaced with correct one. https://github.com/rust-lang/rust-clippy/issues/702