### PR TITLE
Add text_format parser support for the angle bracket message syntax

### DIFF
--- a/protobuf-test/src/common/v2/test_fmt_text_format.rs
+++ b/protobuf-test/src/common/v2/test_fmt_text_format.rs
@@ -134,7 +134,25 @@ fn test_message() {
 
     test_text_format_str_descriptor(
         "test_message_singular < value: 10 >",
-        TestTypes::descriptor_static()
+        TestTypes::descriptor_static(),
+    );
+
+    assert!(
+        parse_using_rust_protobuf(
+            "test_message_singular < value: 10 }",
+            TestTypes::descriptor_static()
+        )
+        .is_err(),
+        "Parsing a message with mismatched message start and terminator symbols should fail."
+    );
+
+    assert!(
+        parse_using_rust_protobuf(
+            "test_message_singular { value: 10 >",
+            TestTypes::descriptor_static()
+        )
+        .is_err(),
+        "Parsing a message with mismatched message start and terminator symbols should fail."
     );
 }
 

--- a/protobuf-test/src/common/v2/test_fmt_text_format.rs
+++ b/protobuf-test/src/common/v2/test_fmt_text_format.rs
@@ -129,6 +129,13 @@ fn test_message() {
         "test_message_repeated { value: 10 } test_message_repeated { value: 20 }",
         TestTypes::descriptor_static(),
     );
+
+    test_text_format_str_descriptor("test_message_singular <>", TestTypes::descriptor_static());
+
+    test_text_format_str_descriptor(
+        "test_message_singular < value: 10 >",
+        TestTypes::descriptor_static()
+    );
 }
 
 #[test]

--- a/protobuf/src/text_format/lexer/tokenizer.rs
+++ b/protobuf/src/text_format/lexer/tokenizer.rs
@@ -20,6 +20,7 @@ pub enum TokenizerError {
     ExpectIdent,
     ExpectNamedIdent(String),
     ExpectChar(char),
+    ExpectAnyChar(Vec<char>),
 }
 
 pub type TokenizerResult<R> = Result<R, TokenizerError>;
@@ -197,6 +198,18 @@ impl<'a> Tokenizer<'a> {
         } else {
             Err(TokenizerError::ExpectChar(symbol))
         }
+    }
+
+    pub fn next_symbol_expect_eq_oneof(
+        &mut self,
+        symbols: &[char],
+    ) -> TokenizerResult<char> {
+        for symbol in symbols {
+            if let Ok(()) = self.next_symbol_expect_eq(*symbol) {
+                return Ok(*symbol);
+            }
+        }
+        Err(TokenizerError::ExpectAnyChar(symbols.to_owned()))
     }
 
     pub fn lookahead_is_str_lit(&mut self) -> TokenizerResult<bool> {

--- a/protobuf/src/text_format/parse.rs
+++ b/protobuf/src/text_format/parse.rs
@@ -186,11 +186,12 @@ impl<'a> Parser<'a> {
     ) -> ParseResult<Box<dyn Message>> {
         let mut message = descriptor.new_instance();
 
-        self.tokenizer.next_symbol_expect_eq('{')?;
-        while !self.tokenizer.lookahead_is_symbol('}')? {
+        let symbol = self.tokenizer.next_symbol_expect_eq_oneof(&['{', '<'])?;
+        let terminator = if symbol == '{' { '}' } else { '>' };
+        while !self.tokenizer.lookahead_is_symbol(terminator)? {
             self.merge_field(&mut *message, descriptor)?;
         }
-        self.tokenizer.next_symbol_expect_eq('}')?;
+        self.tokenizer.next_symbol_expect_eq(terminator)?;
         Ok(message)
     }
 


### PR DESCRIPTION
While the most commonly used syntax for text protobufs (at least in my experience) seems to use curly braces `{}` to indicate a submessage, there's an alternative syntax that uses angle brackets `<>` in their place. i.e., `my_message { my_field: 42 }` is equivalent to `my_message < my_field: 42 >`. (In fact, [the Go text formatter uses this syntax for its output](https://github.com/golang/protobuf/blob/822fe56949f5d56c9e2f02367c657e0e9b4d27d1/proto/text.go#L337).)

Examples from Google maintained implementations:
- [Go](https://github.com/golang/protobuf/blob/4c88cc3f1a34ffade77b79abc53335d1e511f25b/proto/text_parser.go#L485)
- [C++](https://github.com/protocolbuffers/protobuf/blob/bc1773c42c9c3c522145a3119e989e0dff2a8d54/src/google/protobuf/text_format.cc#L366)
- [Java](https://github.com/protocolbuffers/protobuf/blob/bc1773c42c9c3c522145a3119e989e0dff2a8d54/java/core/src/main/java/com/google/protobuf/TextFormat.java#L1786)

This pull request adds support and tests for this syntax. (I've also tweaked the signature of one of the test utility functions to return a Result rather than asserting that the input parses successfully, so that I can easily write a negative test case for mismatched delimiters.)

(I don't have much Rust experience yet, and usually write in garbage collected languages, so please feel free to scrutinize my style and implementation.)