### PR TITLE
Allow non-camelcased json_name

### DIFF
--- a/protobuf-test/src/common/v2/test_fmt_json.rs
+++ b/protobuf-test/src/common/v2/test_fmt_json.rs
@@ -323,3 +323,11 @@ fn test_reflect() {
         test_json_message(&*m);
     }
 }
+
+#[test]
+fn test_use_json_name() {
+    let mut m = TestJsonName::new();
+    m.set_field_with_json_name(true);
+    let json = json::print_to_string(&m).unwrap();
+    assert_eq!("{\"Field With json_name\": true}", json);
+}

--- a/protobuf-test/src/common/v2/test_fmt_json_pb.proto
+++ b/protobuf-test/src/common/v2/test_fmt_json_pb.proto
@@ -84,3 +84,7 @@ message TestIncludeDefaultValues {
         bool bbb = 4;
     }
 }
+
+message TestJsonName {
+    optional bool field_with_json_name = 1 [json_name = "Field With json_name"];
+}

--- a/protobuf/src/reflect/field.rs
+++ b/protobuf/src/reflect/field.rs
@@ -79,11 +79,16 @@ impl FieldDescriptor {
         proto: &'static FieldDescriptorProto,
     ) -> FieldDescriptor {
         assert_eq!(proto.get_name(), accessor.name);
+        let json_name = if !proto.get_json_name().is_empty() {
+            proto.get_json_name().to_string()
+        } else {
+            json_name(proto.get_name())
+        };
         FieldDescriptor {
             proto,
             accessor,
             // probably could be lazy-init
-            json_name: json_name(proto.get_name()),
+            json_name,
         }
     }
 

--- a/protobuf/src/reflect/message.rs
+++ b/protobuf/src/reflect/message.rs
@@ -118,11 +118,11 @@ impl MessageDescriptor {
                 .insert(f.get_name().to_owned(), i)
                 .is_none());
 
-            let json_name = json::json_name(f.get_name());
-
-            if !f.get_json_name().is_empty() {
-                assert_eq!(json_name, f.get_json_name());
-            }
+            let json_name = if !f.get_json_name().is_empty() {
+                f.get_json_name().to_string()
+            } else {
+                json::json_name(f.get_name())
+            };
 
             if json_name != f.get_name() {
                 assert!(index_by_name_or_json_name.insert(json_name, i).is_none());


### PR DESCRIPTION
This fixes #447 by using the `json_name` option if it is set when parsing and printing