### PR TITLE
Add serde(default) to map fields.

### DIFF
--- a/protobuf-codegen/src/field/mod.rs
+++ b/protobuf-codegen/src/field/mod.rs
@@ -1211,6 +1211,9 @@ impl<'a> FieldGen<'a> {
 
             match self.kind {
                 FieldKind::Map(..) => serde::write_serde_attr(w, &self.customize, "serde(default)"),
+                FieldKind::Repeated(..) if self.customize.repeated_field_vec == Some(true) => {
+                    serde::write_serde_attr(w, &self.customize, "serde(default)")
+                },
                 _ => {},
             }
 

--- a/protobuf-codegen/src/field/mod.rs
+++ b/protobuf-codegen/src/field/mod.rs
@@ -27,6 +27,7 @@ use crate::scope::MessageOrEnumWithScope;
 use crate::scope::MessageWithScope;
 use crate::scope::RootScope;
 use crate::scope::WithScope;
+use crate::serde;
 use crate::syntax::Syntax;
 use protobuf::wire_format::WireType;
 
@@ -1207,6 +1208,11 @@ impl<'a> FieldGen<'a> {
             w.comment(&format!("{}: <group>", &self.rust_name));
         } else {
             w.all_documentation(self.info, &self.path);
+
+            match self.kind {
+                FieldKind::Map(..) => serde::write_serde_attr(w, &self.customize, "serde(default)"),
+                _ => {},
+            }
 
             let vis = self.visibility();
             w.field_decl_vis(

--- a/protobuf-test/src/common/v2/test_serde_derive.rs
+++ b/protobuf-test/src/common/v2/test_serde_derive.rs
@@ -122,3 +122,9 @@ fn test_deserialize_with_missing_map() {
     let deserialized: TestSerdeMap = serde_json::from_str(&"{}").unwrap();
     assert_eq!(deserialized.test_map, HashMap::new());
 }
+
+#[test]
+fn test_deserialize_with_missing_repeated_vector() {
+    let deserialized: TestSerdeVec = serde_json::from_str(&"{}").unwrap();
+    assert_eq!(0, deserialized.test_repeated.len());
+}

--- a/protobuf-test/src/common/v2/test_serde_derive.rs
+++ b/protobuf-test/src/common/v2/test_serde_derive.rs
@@ -116,3 +116,9 @@ fn test_map() {
     let deserialized: TestSerdeMap = serde_json::from_str(&serialized).unwrap();
     assert_eq!(deserialized, map);
 }
+
+#[test]
+fn test_deserialize_with_missing_map() {
+    let deserialized: TestSerdeMap = serde_json::from_str(&"{}").unwrap();
+    assert_eq!(deserialized.test_map, HashMap::new());
+}

--- a/protobuf-test/src/common/v2/test_serde_derive_pb.proto
+++ b/protobuf-test/src/common/v2/test_serde_derive_pb.proto
@@ -44,3 +44,8 @@ message RepeatedMessage {
 message TestSerdeMap {
     map<uint32, uint32> test_map = 1;
 }
+
+message TestSerdeVec {
+    option (rustproto.repeated_field_vec) = true;
+    repeated string test_repeated = 1;
+}


### PR DESCRIPTION
Hi! :wave: 

I've started to use this library to migrate an API from using raw JSON to use Protocol Buffers, and I bumped into a particular case. My JSON document has a couple of optional Map fields, they are not serialized when there are no values on them. I would expect this library to create empty HashMap objects for those fields. That's my understanding on how defaults work on protobuf definitions, but I might be wrong.

I modified the code generator to add `#[serde(default)]` to HashMap fields.

This is an example:

- Given this definition:

```
message TestStruct {
  uint64 id = 1;
  map<string, string> optional_map = 2;
}
```

and this JSON payload:
```
{"id": "1"}
```

I would expect the deserialization to pass this test:

```
let s: TestStruct = serde_json::from_str(&r#"{"id": 1}"#).unwrap();
assert_eq!(1, m.id);
assert_eq!(HashMap::new(), m.optional_map);
```

Without this change, the current version in master fails because the optional field is missing from the payload.

I'd really appreciate your feedback :raised_hands: 

Signed-off-by: David Calavera <david.calavera@gmail.com>