### PR TITLE
Added comma before repeated and map fields when printing to json

### DIFF
--- a/protobuf-test/src/common/v2/test_fmt_json.rs
+++ b/protobuf-test/src/common/v2/test_fmt_json.rs
@@ -331,3 +331,16 @@ fn test_use_json_name() {
     let json = json::print_to_string(&m).unwrap();
     assert_eq!("{\"Field With json_name\": true}", json);
 }
+
+#[test]
+fn test_more_than_one() {
+    let mut m = TestTypes::new();
+    m.set_bool_singular(true);
+    m.set_bool_repeated(vec![true, false, false]);
+    m.uint64_map_field.insert("foo".to_owned(), 20);
+
+    test_json_print_parse_message(
+        "{\"boolSingular\": true, \"boolRepeated\": [true, false, false], \"uint64MapField\": {\"foo\": \"20\"}}",
+        &m,
+    );
+}

--- a/protobuf/src/json/print.rs
+++ b/protobuf/src/json/print.rs
@@ -498,12 +498,14 @@ impl Printer {
                 }
                 ReflectFieldRef::Repeated(v) => {
                     if !v.is_empty() {
+                        self.print_comma_but_first(&mut first)?;
                         write!(self.buf, "\"{}\": ", json_field_name)?;
                         self.print_repeated(&v)?;
                     }
                 }
                 ReflectFieldRef::Map(v) => {
                     if !v.is_empty() {
+                        self.print_comma_but_first(&mut first)?;
                         write!(self.buf, "\"{}\": ", json_field_name)?;
                         self.print_map(&v)?;
                     }


### PR DESCRIPTION
Noticed while converting a message that had a singular field followed repeated field, while looking at the code noticed the same for maps. Was easy to repro with the added test.