### PR TITLE
Edition 2018: fix idioms

### DIFF
--- a/protobuf/src/core.rs
+++ b/protobuf/src/core.rs
@@ -31,13 +31,13 @@ pub trait Message: fmt::Debug + Clear + Send + Sync + ProtobufValue {
     fn is_initialized(&self) -> bool;
 
     /// Update this message object with fields read from given stream.
-    fn merge_from(&mut self, is: &mut CodedInputStream) -> ProtobufResult<()>;
+    fn merge_from(&mut self, is: &mut CodedInputStream<'_>) -> ProtobufResult<()>;
 
     /// Write message to the stream.
     ///
     /// Sizes of this messages and nested messages must be cached
     /// by calling `compute_size` prior to this call.
-    fn write_to_with_cached_sizes(&self, os: &mut CodedOutputStream) -> ProtobufResult<()>;
+    fn write_to_with_cached_sizes(&self, os: &mut CodedOutputStream<'_>) -> ProtobufResult<()>;
 
     /// Compute and cache size of this message and all nested messages
     fn compute_size(&self) -> u32;
@@ -48,7 +48,7 @@ pub trait Message: fmt::Debug + Clear + Send + Sync + ProtobufValue {
     /// Write the message to the stream.
     ///
     /// Results in error if message is not fully initialized.
-    fn write_to(&self, os: &mut CodedOutputStream) -> ProtobufResult<()> {
+    fn write_to(&self, os: &mut CodedOutputStream<'_>) -> ProtobufResult<()> {
         self.check_initialized()?;
 
         // cache sizes
@@ -61,7 +61,7 @@ pub trait Message: fmt::Debug + Clear + Send + Sync + ProtobufValue {
 
     /// Write the message to the stream prepending the message with message length
     /// encoded as varint.
-    fn write_length_delimited_to(&self, os: &mut CodedOutputStream) -> ProtobufResult<()> {
+    fn write_length_delimited_to(&self, os: &mut CodedOutputStream<'_>) -> ProtobufResult<()> {
         let size = self.compute_size();
         os.write_raw_varint32(size)?;
         self.write_to_with_cached_sizes(os)?;
@@ -275,7 +275,7 @@ impl PartialEq for Box<Message> {
 }
 
 /// Parse message from stream.
-pub fn parse_from<M: Message>(is: &mut CodedInputStream) -> ProtobufResult<M> {
+pub fn parse_from<M: Message>(is: &mut CodedInputStream<'_>) -> ProtobufResult<M> {
     let mut r: M = Message::new();
     r.merge_from(is)?;
     r.check_initialized()?;

--- a/protobuf/src/enums.rs
+++ b/protobuf/src/enums.rs
@@ -107,7 +107,7 @@ impl<E: ProtobufEnum> Default for ProtobufEnumOrUnknown<E> {
 }
 
 impl<E: ProtobufEnum> fmt::Debug for ProtobufEnumOrUnknown<E> {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self.enum_value() {
             Ok(e) => fmt::Debug::fmt(&e, f),
             Err(e) => fmt::Debug::fmt(&e, f),

--- a/protobuf/src/error.rs
+++ b/protobuf/src/error.rs
@@ -39,7 +39,7 @@ pub enum ProtobufError {
 }
 
 impl fmt::Display for ProtobufError {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         fmt::Debug::fmt(self, f)
     }
 }

--- a/protobuf/src/json/parse.rs
+++ b/protobuf/src/json/parse.rs
@@ -697,7 +697,7 @@ impl<'a> Parser<'a> {
         let s = self.read_string()?;
         let mut lexer = Lexer::new(&s, ParserLanguage::Json);
 
-        fn next_dec(lexer: &mut Lexer) -> ParseResultWithoutLoc<(u64, u32)> {
+        fn next_dec(lexer: &mut Lexer<'_>) -> ParseResultWithoutLoc<(u64, u32)> {
             let s = lexer.take_while(|c| c >= '0' && c <= '9');
 
             if s.len() == 0 {

--- a/protobuf/src/json/print.rs
+++ b/protobuf/src/json/print.rs
@@ -368,7 +368,7 @@ impl Printer {
         Ok(())
     }
 
-    fn print_repeated(&mut self, repeated: &ReflectRepeatedRef) -> PrintResult<()> {
+    fn print_repeated(&mut self, repeated: &ReflectRepeatedRef<'_>) -> PrintResult<()> {
         self.print_list(repeated)
     }
 
@@ -391,7 +391,7 @@ impl Printer {
         Ok(())
     }
 
-    fn print_map(&mut self, map: &ReflectMapRef) -> PrintResult<()> {
+    fn print_map(&mut self, map: &ReflectMapRef<'_>) -> PrintResult<()> {
         self.print_object(map.into_iter())
     }
 

--- a/protobuf/src/json/rfc_3339.rs
+++ b/protobuf/src/json/rfc_3339.rs
@@ -415,7 +415,7 @@ impl TmUtc {
 }
 
 impl fmt::Display for TmUtc {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         if self.year > 9999 {
             write!(f, "+{}", self.year)?;
         } else if self.year < 0 {

--- a/protobuf/src/reflect/enums.rs
+++ b/protobuf/src/reflect/enums.rs
@@ -42,7 +42,7 @@ fn _assert_send_sync() {
 }
 
 impl fmt::Debug for EnumValueDescriptor {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         f.debug_struct("EnumValueDescriptor")
             .field("proto", self.proto)
             .field("value", &"...")
@@ -123,7 +123,7 @@ pub struct EnumDescriptor {
 }
 
 impl fmt::Debug for EnumDescriptor {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         f.debug_struct("EnumDescriptor")
             .field("full_name", &self.full_name)
             .field("..", &"..")

--- a/protobuf/src/reflect/map.rs
+++ b/protobuf/src/reflect/map.rs
@@ -10,13 +10,13 @@ use crate::reflect::ReflectValueRef;
 
 /// Implemented for `HashMap` with appropriate keys and values
 pub(crate) trait ReflectMap: Send + Sync + 'static {
-    fn reflect_iter(&self) -> ReflectMapIter;
+    fn reflect_iter(&self) -> ReflectMapIter<'_>;
 
     fn len(&self) -> usize;
 
     fn is_empty(&self) -> bool;
 
-    fn get(&self, key: ReflectValueRef) -> Option<&dyn ProtobufValue>;
+    fn get(&self, key: ReflectValueRef<'_>) -> Option<&dyn ProtobufValue>;
 
     fn insert(&mut self, key: ReflectValueBox, value: ReflectValueBox);
 
@@ -40,7 +40,7 @@ impl<K: ProtobufValue + Eq + Hash + 'static, V: ProtobufValue + 'static> Reflect
         self.is_empty()
     }
 
-    fn get(&self, key: ReflectValueRef) -> Option<&dyn ProtobufValue> {
+    fn get(&self, key: ReflectValueRef<'_>) -> Option<&dyn ProtobufValue> {
         // TODO: malloc for string or bytes
         let key: K = key.to_box().downcast().expect("wrong key type");
         self.get(&key).map(|v| v as &dyn ProtobufValue)
@@ -124,7 +124,7 @@ impl<'a> ReflectMapRef<'a> {
     }
 
     /// Find a value by given key.
-    pub fn get(&self, key: ReflectValueRef) -> Option<ReflectValueRef> {
+    pub fn get(&self, key: ReflectValueRef<'_>) -> Option<ReflectValueRef<'_>> {
         self.map
             .get(key)
             .map(|v| self.value_dynamic.value_to_ref(v))
@@ -194,7 +194,7 @@ impl<'a> ReflectMapMut<'a> {
     }
 
     /// Find a value for given key
-    pub fn get(&self, key: ReflectValueRef) -> Option<ReflectValueRef> {
+    pub fn get(&self, key: ReflectValueRef<'_>) -> Option<ReflectValueRef<'_>> {
         self.map
             .get(key)
             .map(|v| self.value_dynamic.value_to_ref(v))

--- a/protobuf/src/reflect/repeated.rs
+++ b/protobuf/src/reflect/repeated.rs
@@ -10,7 +10,7 @@ use crate::reflect::ReflectValueBox;
 use crate::repeated::RepeatedField;
 
 pub(crate) trait ReflectRepeated: Sync + 'static + fmt::Debug {
-    fn reflect_iter(&self) -> ReflectRepeatedIter;
+    fn reflect_iter(&self) -> ReflectRepeatedIter<'_>;
     fn len(&self) -> usize;
     fn get(&self, index: usize) -> &dyn ProtobufValue;
     fn set(&mut self, index: usize, value: ReflectValueBox);
@@ -234,7 +234,7 @@ impl<'a> PartialEq<[ReflectValueBox]> for ReflectRepeatedRef<'a> {
 }
 
 impl<'a> PartialEq<ReflectRepeatedRef<'a>> for [ReflectValueBox] {
-    fn eq(&self, other: &ReflectRepeatedRef) -> bool {
+    fn eq(&self, other: &ReflectRepeatedRef<'_>) -> bool {
         other == self
     }
 }
@@ -246,7 +246,7 @@ impl<'a> PartialEq<Vec<ReflectValueBox>> for ReflectRepeatedRef<'a> {
 }
 
 impl<'a> PartialEq<ReflectRepeatedRef<'a>> for Vec<ReflectValueBox> {
-    fn eq(&self, other: &ReflectRepeatedRef) -> bool {
+    fn eq(&self, other: &ReflectRepeatedRef<'_>) -> bool {
         self.as_slice() == other
     }
 }
@@ -360,13 +360,13 @@ impl<'a> IntoIterator for &'a ReflectRepeatedMut<'a> {
 }
 
 impl<'a> fmt::Debug for ReflectRepeatedRef<'a> {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         fmt::Debug::fmt(self.repeated, f)
     }
 }
 
 impl<'a> fmt::Debug for ReflectRepeatedMut<'a> {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         fmt::Debug::fmt(self.repeated, f)
     }
 }
@@ -378,7 +378,7 @@ impl<'a> PartialEq for ReflectRepeatedMut<'a> {
 }
 
 impl<'a> PartialEq<ReflectRepeatedRef<'a>> for ReflectRepeatedMut<'a> {
-    fn eq(&self, other: &ReflectRepeatedRef) -> bool {
+    fn eq(&self, other: &ReflectRepeatedRef<'_>) -> bool {
         PartialEq::eq(&self.as_ref(), other)
     }
 }
@@ -390,7 +390,7 @@ impl<'a> PartialEq<[ReflectValueBox]> for ReflectRepeatedMut<'a> {
 }
 
 impl<'a> PartialEq<ReflectRepeatedMut<'a>> for [ReflectValueBox] {
-    fn eq(&self, other: &ReflectRepeatedMut) -> bool {
+    fn eq(&self, other: &ReflectRepeatedMut<'_>) -> bool {
         PartialEq::eq(self, &other.as_ref())
     }
 }
@@ -402,7 +402,7 @@ impl<'a> PartialEq<Vec<ReflectValueBox>> for ReflectRepeatedMut<'a> {
 }
 
 impl<'a> PartialEq<ReflectRepeatedMut<'a>> for Vec<ReflectValueBox> {
-    fn eq(&self, other: &ReflectRepeatedMut) -> bool {
+    fn eq(&self, other: &ReflectRepeatedMut<'_>) -> bool {
         self.as_slice() == other
     }
 }

--- a/protobuf/src/reflect/runtime_type_dynamic.rs
+++ b/protobuf/src/reflect/runtime_type_dynamic.rs
@@ -22,7 +22,7 @@ pub trait RuntimeTypeDynamic: Send + Sync + 'static {
     fn value_to_ref<'a>(&self, value: &'a dyn ProtobufValue) -> ReflectValueRef<'a>;
 
     /// Default value for type
-    fn default_value_ref(&self) -> ReflectValueRef;
+    fn default_value_ref(&self) -> ReflectValueRef<'_>;
 }
 
 pub(crate) struct RuntimeTypeDynamicImpl<T: RuntimeType>(pub marker::PhantomData<T>);
@@ -40,7 +40,7 @@ impl<T: RuntimeType> RuntimeTypeDynamic for RuntimeTypeDynamicImpl<T> {
         }
     }
 
-    fn default_value_ref(&self) -> ReflectValueRef {
+    fn default_value_ref(&self) -> ReflectValueRef<'_> {
         T::default_value_ref()
     }
 }

--- a/protobuf/src/reflect/runtime_types.rs
+++ b/protobuf/src/reflect/runtime_types.rs
@@ -53,8 +53,8 @@ pub trait RuntimeType: fmt::Debug + Send + Sync + 'static {
         panic!("value {:?} cannot be converted to static ref", value)
     }
 
-    fn as_ref(value: &Self::Value) -> ReflectValueRef;
-    fn as_mut(value: &mut Self::Value) -> ReflectValueMut;
+    fn as_ref(value: &Self::Value) -> ReflectValueRef<'_>;
+    fn as_mut(value: &mut Self::Value) -> ReflectValueMut<'_>;
 
     fn is_non_zero(value: &Self::Value) -> bool;
 
@@ -67,7 +67,7 @@ pub trait RuntimeTypeWithDeref: RuntimeType {
     type DerefTarget: ?Sized;
 
     // TODO: rename to `deref`
-    fn defef_as_ref(value: &Self::DerefTarget) -> ReflectValueRef;
+    fn defef_as_ref(value: &Self::DerefTarget) -> ReflectValueRef<'_>;
 }
 
 #[derive(Debug, Copy, Clone)]
@@ -132,11 +132,11 @@ impl RuntimeType for RuntimeTypeF32 {
     fn into_static_value_ref(value: f32) -> ReflectValueRef<'static> {
         ReflectValueRef::F32(value)
     }
-    fn as_ref(value: &f32) -> ReflectValueRef {
+    fn as_ref(value: &f32) -> ReflectValueRef<'_> {
         ReflectValueRef::F32(*value)
     }
 
-    fn as_mut(_value: &mut Self::Value) -> ReflectValueMut {
+    fn as_mut(_value: &mut Self::Value) -> ReflectValueMut<'_> {
         unimplemented!()
     }
 
@@ -174,7 +174,7 @@ impl RuntimeType for RuntimeTypeF64 {
         ReflectValueRef::F64(value)
     }
 
-    fn as_ref(value: &f64) -> ReflectValueRef {
+    fn as_ref(value: &f64) -> ReflectValueRef<'_> {
         ReflectValueRef::F64(*value)
     }
 
@@ -182,7 +182,7 @@ impl RuntimeType for RuntimeTypeF64 {
         *value != 0.0
     }
 
-    fn as_mut(_value: &mut Self::Value) -> ReflectValueMut {
+    fn as_mut(_value: &mut Self::Value) -> ReflectValueMut<'_> {
         unimplemented!()
     }
 }
@@ -216,7 +216,7 @@ impl RuntimeType for RuntimeTypeI32 {
         ReflectValueRef::I32(value)
     }
 
-    fn as_ref(value: &i32) -> ReflectValueRef {
+    fn as_ref(value: &i32) -> ReflectValueRef<'_> {
         ReflectValueRef::I32(*value)
     }
 
@@ -224,7 +224,7 @@ impl RuntimeType for RuntimeTypeI32 {
         *value != 0
     }
 
-    fn as_mut(_value: &mut Self::Value) -> ReflectValueMut {
+    fn as_mut(_value: &mut Self::Value) -> ReflectValueMut<'_> {
         unimplemented!()
     }
 }
@@ -258,7 +258,7 @@ impl RuntimeType for RuntimeTypeI64 {
         ReflectValueRef::I64(value)
     }
 
-    fn as_ref(value: &i64) -> ReflectValueRef {
+    fn as_ref(value: &i64) -> ReflectValueRef<'_> {
         ReflectValueRef::I64(*value)
     }
 
@@ -266,7 +266,7 @@ impl RuntimeType for RuntimeTypeI64 {
         *value != 0
     }
 
-    fn as_mut(_value: &mut Self::Value) -> ReflectValueMut {
+    fn as_mut(_value: &mut Self::Value) -> ReflectValueMut<'_> {
         unimplemented!()
     }
 }
@@ -300,11 +300,11 @@ impl RuntimeType for RuntimeTypeU32 {
         ReflectValueRef::U32(value)
     }
 
-    fn as_ref(value: &u32) -> ReflectValueRef {
+    fn as_ref(value: &u32) -> ReflectValueRef<'_> {
         ReflectValueRef::U32(*value)
     }
 
-    fn as_mut(_value: &mut Self::Value) -> ReflectValueMut {
+    fn as_mut(_value: &mut Self::Value) -> ReflectValueMut<'_> {
         unimplemented!()
     }
 
@@ -342,7 +342,7 @@ impl RuntimeType for RuntimeTypeU64 {
         ReflectValueRef::U64(value)
     }
 
-    fn as_ref(value: &u64) -> ReflectValueRef {
+    fn as_ref(value: &u64) -> ReflectValueRef<'_> {
         ReflectValueRef::U64(*value)
     }
 
@@ -350,7 +350,7 @@ impl RuntimeType for RuntimeTypeU64 {
         *value != 0
     }
 
-    fn as_mut(_value: &mut Self::Value) -> ReflectValueMut {
+    fn as_mut(_value: &mut Self::Value) -> ReflectValueMut<'_> {
         unimplemented!()
     }
 }
@@ -384,7 +384,7 @@ impl RuntimeType for RuntimeTypeBool {
         ReflectValueRef::Bool(value)
     }
 
-    fn as_ref(value: &bool) -> ReflectValueRef {
+    fn as_ref(value: &bool) -> ReflectValueRef<'_> {
         ReflectValueRef::Bool(*value)
     }
 
@@ -392,7 +392,7 @@ impl RuntimeType for RuntimeTypeBool {
         *value
     }
 
-    fn as_mut(_value: &mut Self::Value) -> ReflectValueMut {
+    fn as_mut(_value: &mut Self::Value) -> ReflectValueMut<'_> {
         unimplemented!()
     }
 }
@@ -422,11 +422,11 @@ impl RuntimeType for RuntimeTypeString {
         ReflectValueBox::String(value)
     }
 
-    fn as_ref(value: &String) -> ReflectValueRef {
+    fn as_ref(value: &String) -> ReflectValueRef<'_> {
         ReflectValueRef::String(&*value)
     }
 
-    fn as_mut(_value: &mut Self::Value) -> ReflectValueMut {
+    fn as_mut(_value: &mut Self::Value) -> ReflectValueMut<'_> {
         unimplemented!()
     }
 
@@ -438,7 +438,7 @@ impl RuntimeType for RuntimeTypeString {
 impl RuntimeTypeWithDeref for RuntimeTypeString {
     type DerefTarget = str;
 
-    fn defef_as_ref(value: &str) -> ReflectValueRef {
+    fn defef_as_ref(value: &str) -> ReflectValueRef<'_> {
         ReflectValueRef::String(value)
     }
 }
@@ -468,11 +468,11 @@ impl RuntimeType for RuntimeTypeVecU8 {
         ReflectValueBox::Bytes(value)
     }
 
-    fn as_ref(value: &Vec<u8>) -> ReflectValueRef {
+    fn as_ref(value: &Vec<u8>) -> ReflectValueRef<'_> {
         ReflectValueRef::Bytes(value.as_slice())
     }
 
-    fn as_mut(_value: &mut Self::Value) -> ReflectValueMut {
+    fn as_mut(_value: &mut Self::Value) -> ReflectValueMut<'_> {
         unimplemented!()
     }
 
@@ -484,7 +484,7 @@ impl RuntimeType for RuntimeTypeVecU8 {
 impl RuntimeTypeWithDeref for RuntimeTypeVecU8 {
     type DerefTarget = [u8];
 
-    fn defef_as_ref(value: &[u8]) -> ReflectValueRef {
+    fn defef_as_ref(value: &[u8]) -> ReflectValueRef<'_> {
         ReflectValueRef::Bytes(value)
     }
 }
@@ -622,11 +622,11 @@ where
         ReflectValueRef::Enum(E::enum_descriptor_static(), value.value())
     }
 
-    fn as_ref(value: &E) -> ReflectValueRef {
+    fn as_ref(value: &E) -> ReflectValueRef<'_> {
         ReflectValueRef::Enum(E::enum_descriptor_static(), value.value())
     }
 
-    fn as_mut(_value: &mut Self::Value) -> ReflectValueMut {
+    fn as_mut(_value: &mut Self::Value) -> ReflectValueMut<'_> {
         unimplemented!()
     }
 
@@ -670,11 +670,11 @@ where
         ReflectValueRef::Enum(E::enum_descriptor_static(), value.value())
     }
 
-    fn as_ref(value: &ProtobufEnumOrUnknown<E>) -> ReflectValueRef {
+    fn as_ref(value: &ProtobufEnumOrUnknown<E>) -> ReflectValueRef<'_> {
         ReflectValueRef::Enum(E::enum_descriptor_static(), value.value())
     }
 
-    fn as_mut(_value: &mut Self::Value) -> ReflectValueMut {
+    fn as_mut(_value: &mut Self::Value) -> ReflectValueMut<'_> {
         unimplemented!()
     }
 
@@ -710,11 +710,11 @@ where
     fn into_value_box(value: M) -> ReflectValueBox {
         ReflectValueBox::Message(Box::new(value))
     }
-    fn as_ref(value: &M) -> ReflectValueRef {
+    fn as_ref(value: &M) -> ReflectValueRef<'_> {
         ReflectValueRef::Message(value)
     }
 
-    fn as_mut(value: &mut M) -> ReflectValueMut {
+    fn as_mut(value: &mut M) -> ReflectValueMut<'_> {
         ReflectValueMut::Message(value)
     }
 

--- a/protobuf/src/reflect/types.rs
+++ b/protobuf/src/reflect/types.rs
@@ -60,7 +60,7 @@ pub trait ProtobufType: Send + Sync + Clone + 'static {
     const WIRE_TYPE: WireType;
 
     /// Read a value from `CodedInputStream`
-    fn read(is: &mut CodedInputStream)
+    fn read(is: &mut CodedInputStream<'_>)
         -> ProtobufResult<<Self::RuntimeType as RuntimeType>::Value>;
 
     /// Take a value from `UnknownValues`
@@ -107,7 +107,7 @@ pub trait ProtobufType: Send + Sync + Clone + 'static {
     fn write_with_cached_size(
         field_number: u32,
         value: &<Self::RuntimeType as RuntimeType>::Value,
-        os: &mut CodedOutputStream,
+        os: &mut CodedOutputStream<'_>,
     ) -> ProtobufResult<()>;
 }
 
@@ -189,7 +189,7 @@ impl ProtobufType for ProtobufTypeFloat {
 
     const WIRE_TYPE: WireType = WireType::WireTypeFixed32;
 
-    fn read(is: &mut CodedInputStream) -> ProtobufResult<f32> {
+    fn read(is: &mut CodedInputStream<'_>) -> ProtobufResult<f32> {
         is.read_float()
     }
 
@@ -209,7 +209,7 @@ impl ProtobufType for ProtobufTypeFloat {
     fn write_with_cached_size(
         field_number: u32,
         value: &f32,
-        os: &mut CodedOutputStream,
+        os: &mut CodedOutputStream<'_>,
     ) -> ProtobufResult<()> {
         os.write_float(field_number, *value)
     }
@@ -224,7 +224,7 @@ impl ProtobufType for ProtobufTypeDouble {
 
     const WIRE_TYPE: WireType = WireType::WireTypeFixed64;
 
-    fn read(is: &mut CodedInputStream) -> ProtobufResult<f64> {
+    fn read(is: &mut CodedInputStream<'_>) -> ProtobufResult<f64> {
         is.read_double()
     }
 
@@ -244,7 +244,7 @@ impl ProtobufType for ProtobufTypeDouble {
     fn write_with_cached_size(
         field_number: u32,
         value: &f64,
-        os: &mut CodedOutputStream,
+        os: &mut CodedOutputStream<'_>,
     ) -> ProtobufResult<()> {
         os.write_double(field_number, *value)
     }
@@ -259,7 +259,7 @@ impl ProtobufType for ProtobufTypeInt32 {
 
     const WIRE_TYPE: WireType = WireType::WireTypeVarint;
 
-    fn read(is: &mut CodedInputStream) -> ProtobufResult<i32> {
+    fn read(is: &mut CodedInputStream<'_>) -> ProtobufResult<i32> {
         is.read_int32()
     }
 
@@ -274,7 +274,7 @@ impl ProtobufType for ProtobufTypeInt32 {
     fn write_with_cached_size(
         field_number: u32,
         value: &i32,
-        os: &mut CodedOutputStream,
+        os: &mut CodedOutputStream<'_>,
     ) -> ProtobufResult<()> {
         os.write_int32(field_number, *value)
     }
@@ -289,7 +289,7 @@ impl ProtobufType for ProtobufTypeInt64 {
 
     const WIRE_TYPE: WireType = WireType::WireTypeVarint;
 
-    fn read(is: &mut CodedInputStream) -> ProtobufResult<i64> {
+    fn read(is: &mut CodedInputStream<'_>) -> ProtobufResult<i64> {
         is.read_int64()
     }
 
@@ -304,7 +304,7 @@ impl ProtobufType for ProtobufTypeInt64 {
     fn write_with_cached_size(
         field_number: u32,
         value: &i64,
-        os: &mut CodedOutputStream,
+        os: &mut CodedOutputStream<'_>,
     ) -> ProtobufResult<()> {
         os.write_int64(field_number, *value)
     }
@@ -315,7 +315,7 @@ impl ProtobufType for ProtobufTypeUint32 {
 
     const WIRE_TYPE: WireType = WireType::WireTypeVarint;
 
-    fn read(is: &mut CodedInputStream) -> ProtobufResult<u32> {
+    fn read(is: &mut CodedInputStream<'_>) -> ProtobufResult<u32> {
         is.read_uint32()
     }
 
@@ -330,7 +330,7 @@ impl ProtobufType for ProtobufTypeUint32 {
     fn write_with_cached_size(
         field_number: u32,
         value: &u32,
-        os: &mut CodedOutputStream,
+        os: &mut CodedOutputStream<'_>,
     ) -> ProtobufResult<()> {
         os.write_uint32(field_number, *value)
     }
@@ -341,7 +341,7 @@ impl ProtobufType for ProtobufTypeUint64 {
 
     const WIRE_TYPE: WireType = WireType::WireTypeVarint;
 
-    fn read(is: &mut CodedInputStream) -> ProtobufResult<u64> {
+    fn read(is: &mut CodedInputStream<'_>) -> ProtobufResult<u64> {
         is.read_uint64()
     }
 
@@ -356,7 +356,7 @@ impl ProtobufType for ProtobufTypeUint64 {
     fn write_with_cached_size(
         field_number: u32,
         value: &u64,
-        os: &mut CodedOutputStream,
+        os: &mut CodedOutputStream<'_>,
     ) -> ProtobufResult<()> {
         os.write_uint64(field_number, *value)
     }
@@ -367,7 +367,7 @@ impl ProtobufType for ProtobufTypeSint32 {
 
     const WIRE_TYPE: WireType = WireType::WireTypeVarint;
 
-    fn read(is: &mut CodedInputStream) -> ProtobufResult<i32> {
+    fn read(is: &mut CodedInputStream<'_>) -> ProtobufResult<i32> {
         is.read_sint32()
     }
 
@@ -382,7 +382,7 @@ impl ProtobufType for ProtobufTypeSint32 {
     fn write_with_cached_size(
         field_number: u32,
         value: &i32,
-        os: &mut CodedOutputStream,
+        os: &mut CodedOutputStream<'_>,
     ) -> ProtobufResult<()> {
         os.write_sint32(field_number, *value)
     }
@@ -393,7 +393,7 @@ impl ProtobufType for ProtobufTypeSint64 {
 
     const WIRE_TYPE: WireType = WireType::WireTypeVarint;
 
-    fn read(is: &mut CodedInputStream) -> ProtobufResult<i64> {
+    fn read(is: &mut CodedInputStream<'_>) -> ProtobufResult<i64> {
         is.read_sint64()
     }
 
@@ -408,7 +408,7 @@ impl ProtobufType for ProtobufTypeSint64 {
     fn write_with_cached_size(
         field_number: u32,
         value: &i64,
-        os: &mut CodedOutputStream,
+        os: &mut CodedOutputStream<'_>,
     ) -> ProtobufResult<()> {
         os.write_sint64(field_number, *value)
     }
@@ -419,7 +419,7 @@ impl ProtobufType for ProtobufTypeFixed32 {
 
     const WIRE_TYPE: WireType = WireType::WireTypeFixed32;
 
-    fn read(is: &mut CodedInputStream) -> ProtobufResult<u32> {
+    fn read(is: &mut CodedInputStream<'_>) -> ProtobufResult<u32> {
         is.read_fixed32()
     }
 
@@ -434,7 +434,7 @@ impl ProtobufType for ProtobufTypeFixed32 {
     fn write_with_cached_size(
         field_number: u32,
         value: &u32,
-        os: &mut CodedOutputStream,
+        os: &mut CodedOutputStream<'_>,
     ) -> ProtobufResult<()> {
         os.write_fixed32(field_number, *value)
     }
@@ -449,7 +449,7 @@ impl ProtobufType for ProtobufTypeFixed64 {
 
     const WIRE_TYPE: WireType = WireType::WireTypeFixed64;
 
-    fn read(is: &mut CodedInputStream) -> ProtobufResult<u64> {
+    fn read(is: &mut CodedInputStream<'_>) -> ProtobufResult<u64> {
         is.read_fixed64()
     }
 
@@ -464,7 +464,7 @@ impl ProtobufType for ProtobufTypeFixed64 {
     fn write_with_cached_size(
         field_number: u32,
         value: &u64,
-        os: &mut CodedOutputStream,
+        os: &mut CodedOutputStream<'_>,
     ) -> ProtobufResult<()> {
         os.write_fixed64(field_number, *value)
     }
@@ -479,7 +479,7 @@ impl ProtobufType for ProtobufTypeSfixed32 {
 
     const WIRE_TYPE: WireType = WireType::WireTypeFixed32;
 
-    fn read(is: &mut CodedInputStream) -> ProtobufResult<i32> {
+    fn read(is: &mut CodedInputStream<'_>) -> ProtobufResult<i32> {
         is.read_sfixed32()
     }
 
@@ -494,7 +494,7 @@ impl ProtobufType for ProtobufTypeSfixed32 {
     fn write_with_cached_size(
         field_number: u32,
         value: &i32,
-        os: &mut CodedOutputStream,
+        os: &mut CodedOutputStream<'_>,
     ) -> ProtobufResult<()> {
         os.write_sfixed32(field_number, *value)
     }
@@ -509,7 +509,7 @@ impl ProtobufType for ProtobufTypeSfixed64 {
 
     const WIRE_TYPE: WireType = WireType::WireTypeFixed64;
 
-    fn read(is: &mut CodedInputStream) -> ProtobufResult<i64> {
+    fn read(is: &mut CodedInputStream<'_>) -> ProtobufResult<i64> {
         is.read_sfixed64()
     }
 
@@ -524,7 +524,7 @@ impl ProtobufType for ProtobufTypeSfixed64 {
     fn write_with_cached_size(
         field_number: u32,
         value: &i64,
-        os: &mut CodedOutputStream,
+        os: &mut CodedOutputStream<'_>,
     ) -> ProtobufResult<()> {
         os.write_sfixed64(field_number, *value)
     }
@@ -539,7 +539,7 @@ impl ProtobufType for ProtobufTypeBool {
 
     const WIRE_TYPE: WireType = WireType::WireTypeVarint;
 
-    fn read(is: &mut CodedInputStream) -> ProtobufResult<bool> {
+    fn read(is: &mut CodedInputStream<'_>) -> ProtobufResult<bool> {
         is.read_bool()
     }
 
@@ -554,7 +554,7 @@ impl ProtobufType for ProtobufTypeBool {
     fn write_with_cached_size(
         field_number: u32,
         value: &bool,
-        os: &mut CodedOutputStream,
+        os: &mut CodedOutputStream<'_>,
     ) -> ProtobufResult<()> {
         os.write_bool(field_number, *value)
     }
@@ -565,7 +565,7 @@ impl ProtobufType for ProtobufTypeString {
 
     const WIRE_TYPE: WireType = WireType::WireTypeLengthDelimited;
 
-    fn read(is: &mut CodedInputStream) -> ProtobufResult<String> {
+    fn read(is: &mut CodedInputStream<'_>) -> ProtobufResult<String> {
         is.read_string()
     }
 
@@ -582,7 +582,7 @@ impl ProtobufType for ProtobufTypeString {
     fn write_with_cached_size(
         field_number: u32,
         value: &String,
-        os: &mut CodedOutputStream,
+        os: &mut CodedOutputStream<'_>,
     ) -> ProtobufResult<()> {
         os.write_string(field_number, &value)
     }
@@ -593,7 +593,7 @@ impl ProtobufType for ProtobufTypeBytes {
 
     const WIRE_TYPE: WireType = WireType::WireTypeLengthDelimited;
 
-    fn read(is: &mut CodedInputStream) -> ProtobufResult<Vec<u8>> {
+    fn read(is: &mut CodedInputStream<'_>) -> ProtobufResult<Vec<u8>> {
         is.read_bytes()
     }
 
@@ -608,7 +608,7 @@ impl ProtobufType for ProtobufTypeBytes {
     fn write_with_cached_size(
         field_number: u32,
         value: &Vec<u8>,
-        os: &mut CodedOutputStream,
+        os: &mut CodedOutputStream<'_>,
     ) -> ProtobufResult<()> {
         os.write_bytes(field_number, &value)
     }
@@ -673,7 +673,7 @@ impl<E: ProtobufEnum + ProtobufValue + fmt::Debug> ProtobufType for ProtobufType
 
     const WIRE_TYPE: WireType = WireType::WireTypeVarint;
 
-    fn read(is: &mut CodedInputStream) -> ProtobufResult<E> {
+    fn read(is: &mut CodedInputStream<'_>) -> ProtobufResult<E> {
         is.read_enum()
     }
 
@@ -690,7 +690,7 @@ impl<E: ProtobufEnum + ProtobufValue + fmt::Debug> ProtobufType for ProtobufType
     fn write_with_cached_size(
         field_number: u32,
         value: &E,
-        os: &mut CodedOutputStream,
+        os: &mut CodedOutputStream<'_>,
     ) -> ProtobufResult<()> {
         os.write_enum_obj(field_number, *value)
     }
@@ -701,7 +701,7 @@ impl<E: ProtobufEnum + ProtobufValue + fmt::Debug> ProtobufType for ProtobufType
 
     const WIRE_TYPE: WireType = WireType::WireTypeVarint;
 
-    fn read(is: &mut CodedInputStream) -> ProtobufResult<ProtobufEnumOrUnknown<E>> {
+    fn read(is: &mut CodedInputStream<'_>) -> ProtobufResult<ProtobufEnumOrUnknown<E>> {
         is.read_enum_or_unknown()
     }
 
@@ -717,7 +717,7 @@ impl<E: ProtobufEnum + ProtobufValue + fmt::Debug> ProtobufType for ProtobufType
     fn write_with_cached_size(
         field_number: u32,
         value: &ProtobufEnumOrUnknown<E>,
-        os: &mut CodedOutputStream,
+        os: &mut CodedOutputStream<'_>,
     ) -> ProtobufResult<()> {
         os.write_enum_or_unknown(field_number, *value)
     }
@@ -728,7 +728,7 @@ impl<M: Message + Clone + ProtobufValue + Default> ProtobufType for ProtobufType
 
     const WIRE_TYPE: WireType = WireType::WireTypeLengthDelimited;
 
-    fn read(is: &mut CodedInputStream) -> ProtobufResult<M> {
+    fn read(is: &mut CodedInputStream<'_>) -> ProtobufResult<M> {
         is.read_message()
     }
 
@@ -753,7 +753,7 @@ impl<M: Message + Clone + ProtobufValue + Default> ProtobufType for ProtobufType
     fn write_with_cached_size(
         field_number: u32,
         value: &<Self::RuntimeType as RuntimeType>::Value,
-        os: &mut CodedOutputStream,
+        os: &mut CodedOutputStream<'_>,
     ) -> ProtobufResult<()> {
         os.write_tag(field_number, WireType::WireTypeLengthDelimited)?;
         os.write_raw_varint32(value.get_cached_size())?;

--- a/protobuf/src/reflect/value.rs
+++ b/protobuf/src/reflect/value.rs
@@ -349,7 +349,7 @@ type StringOrChars = Chars;
 
 impl ReflectValueBox {
     /// As ref
-    pub fn as_value_ref(&self) -> ReflectValueRef {
+    pub fn as_value_ref(&self) -> ReflectValueRef<'_> {
         use std::ops::Deref;
         match *self {
             ReflectValueBox::U32(v) => ReflectValueRef::U32(v),
@@ -394,7 +394,7 @@ impl ReflectValueBox {
 }
 
 impl<'a> PartialEq for ReflectValueRef<'a> {
-    fn eq(&self, other: &ReflectValueRef) -> bool {
+    fn eq(&self, other: &ReflectValueRef<'_>) -> bool {
         use self::ReflectValueRef::*;
         match (self, other) {
             (U32(a), U32(b)) => a == b,
@@ -424,7 +424,7 @@ impl<'a> PartialEq for ReflectValueBox {
 }
 
 impl<'a> PartialEq<ReflectValueRef<'a>> for ReflectValueBox {
-    fn eq(&self, other: &ReflectValueRef) -> bool {
+    fn eq(&self, other: &ReflectValueRef<'_>) -> bool {
         self.as_value_ref() == *other
     }
 }

--- a/protobuf/src/repeated.rs
+++ b/protobuf/src/repeated.rs
@@ -463,7 +463,7 @@ impl<T> IndexMut<usize> for RepeatedField<T> {
 
 impl<T: fmt::Debug> fmt::Debug for RepeatedField<T> {
     #[inline]
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         self.as_ref().fmt(f)
     }
 }

--- a/protobuf/src/rt.rs
+++ b/protobuf/src/rt.rs
@@ -305,7 +305,7 @@ pub fn unknown_fields_size(unknown_fields: &UnknownFields) -> u32 {
 /// Read repeated `int32` field into given vec.
 pub fn read_repeated_int32_into(
     wire_type: WireType,
-    is: &mut CodedInputStream,
+    is: &mut CodedInputStream<'_>,
     target: &mut Vec<i32>,
 ) -> ProtobufResult<()> {
     match wire_type {
@@ -321,7 +321,7 @@ pub fn read_repeated_int32_into(
 /// Read repeated `int64` field into given vec.
 pub fn read_repeated_int64_into(
     wire_type: WireType,
-    is: &mut CodedInputStream,
+    is: &mut CodedInputStream<'_>,
     target: &mut Vec<i64>,
 ) -> ProtobufResult<()> {
     match wire_type {
@@ -337,7 +337,7 @@ pub fn read_repeated_int64_into(
 /// Read repeated `uint32` field into given vec.
 pub fn read_repeated_uint32_into(
     wire_type: WireType,
-    is: &mut CodedInputStream,
+    is: &mut CodedInputStream<'_>,
     target: &mut Vec<u32>,
 ) -> ProtobufResult<()> {
     match wire_type {
@@ -353,7 +353,7 @@ pub fn read_repeated_uint32_into(
 /// Read repeated `uint64` field into given vec.
 pub fn read_repeated_uint64_into(
     wire_type: WireType,
-    is: &mut CodedInputStream,
+    is: &mut CodedInputStream<'_>,
     target: &mut Vec<u64>,
 ) -> ProtobufResult<()> {
     match wire_type {
@@ -369,7 +369,7 @@ pub fn read_repeated_uint64_into(
 /// Read repeated `sint32` field into given vec.
 pub fn read_repeated_sint32_into(
     wire_type: WireType,
-    is: &mut CodedInputStream,
+    is: &mut CodedInputStream<'_>,
     target: &mut Vec<i32>,
 ) -> ProtobufResult<()> {
     match wire_type {
@@ -385,7 +385,7 @@ pub fn read_repeated_sint32_into(
 /// Read repeated `sint64` field into given vec.
 pub fn read_repeated_sint64_into(
     wire_type: WireType,
-    is: &mut CodedInputStream,
+    is: &mut CodedInputStream<'_>,
     target: &mut Vec<i64>,
 ) -> ProtobufResult<()> {
     match wire_type {
@@ -401,7 +401,7 @@ pub fn read_repeated_sint64_into(
 /// Read repeated `fixed32` field into given vec.
 pub fn read_repeated_fixed32_into(
     wire_type: WireType,
-    is: &mut CodedInputStream,
+    is: &mut CodedInputStream<'_>,
     target: &mut Vec<u32>,
 ) -> ProtobufResult<()> {
     match wire_type {
@@ -417,7 +417,7 @@ pub fn read_repeated_fixed32_into(
 /// Read repeated `fixed64` field into given vec.
 pub fn read_repeated_fixed64_into(
     wire_type: WireType,
-    is: &mut CodedInputStream,
+    is: &mut CodedInputStream<'_>,
     target: &mut Vec<u64>,
 ) -> ProtobufResult<()> {
     match wire_type {
@@ -433,7 +433,7 @@ pub fn read_repeated_fixed64_into(
 /// Read repeated `sfixed32` field into given vec.
 pub fn read_repeated_sfixed32_into(
     wire_type: WireType,
-    is: &mut CodedInputStream,
+    is: &mut CodedInputStream<'_>,
     target: &mut Vec<i32>,
 ) -> ProtobufResult<()> {
     match wire_type {
@@ -449,7 +449,7 @@ pub fn read_repeated_sfixed32_into(
 /// Read repeated `sfixed64` field into given vec.
 pub fn read_repeated_sfixed64_into(
     wire_type: WireType,
-    is: &mut CodedInputStream,
+    is: &mut CodedInputStream<'_>,
     target: &mut Vec<i64>,
 ) -> ProtobufResult<()> {
     match wire_type {
@@ -465,7 +465,7 @@ pub fn read_repeated_sfixed64_into(
 /// Read repeated `double` field into given vec.
 pub fn read_repeated_double_into(
     wire_type: WireType,
-    is: &mut CodedInputStream,
+    is: &mut CodedInputStream<'_>,
     target: &mut Vec<f64>,
 ) -> ProtobufResult<()> {
     match wire_type {
@@ -481,7 +481,7 @@ pub fn read_repeated_double_into(
 /// Read repeated `float` field into given vec.
 pub fn read_repeated_float_into(
     wire_type: WireType,
-    is: &mut CodedInputStream,
+    is: &mut CodedInputStream<'_>,
     target: &mut Vec<f32>,
 ) -> ProtobufResult<()> {
     match wire_type {
@@ -497,7 +497,7 @@ pub fn read_repeated_float_into(
 /// Read repeated `bool` field into given vec.
 pub fn read_repeated_bool_into(
     wire_type: WireType,
-    is: &mut CodedInputStream,
+    is: &mut CodedInputStream<'_>,
     target: &mut Vec<bool>,
 ) -> ProtobufResult<()> {
     match wire_type {
@@ -514,7 +514,7 @@ pub fn read_repeated_bool_into(
 /// This function is no longer called from generated code, remove in 1.5.
 pub fn read_repeated_enum_into<E: ProtobufEnum>(
     wire_type: WireType,
-    is: &mut CodedInputStream,
+    is: &mut CodedInputStream<'_>,
     target: &mut Vec<E>,
 ) -> ProtobufResult<()> {
     match wire_type {
@@ -530,7 +530,7 @@ pub fn read_repeated_enum_into<E: ProtobufEnum>(
 /// Helper function to read single enum value.
 #[inline]
 fn read_enum_with_unknown_fields_into<E: ProtobufEnum, C>(
-    is: &mut CodedInputStream,
+    is: &mut CodedInputStream<'_>,
     target: C,
     field_number: u32,
     unknown_fields: &mut UnknownFields,
@@ -547,7 +547,7 @@ where
 }
 
 fn read_repeated_packed_enum_with_unknown_fields_into<E: ProtobufEnum>(
-    is: &mut CodedInputStream,
+    is: &mut CodedInputStream<'_>,
     target: &mut Vec<E>,
     field_number: u32,
     unknown_fields: &mut UnknownFields,
@@ -562,7 +562,7 @@ fn read_repeated_packed_enum_with_unknown_fields_into<E: ProtobufEnum>(
 }
 
 fn read_repeated_packed_enum_or_unknown_into<E: ProtobufEnum>(
-    is: &mut CodedInputStream,
+    is: &mut CodedInputStream<'_>,
     target: &mut Vec<ProtobufEnumOrUnknown<E>>,
 ) -> ProtobufResult<()> {
     let len = is.read_raw_varint64()?;
@@ -582,7 +582,7 @@ fn read_repeated_packed_enum_or_unknown_into<E: ProtobufEnum>(
 /// [here](https://github.com/stepancheg/rust-protobuf/issues/233#issuecomment-375142710)
 pub fn read_repeated_enum_with_unknown_fields_into<E: ProtobufEnum>(
     wire_type: WireType,
-    is: &mut CodedInputStream,
+    is: &mut CodedInputStream<'_>,
     target: &mut Vec<E>,
     field_number: u32,
     unknown_fields: &mut UnknownFields,
@@ -609,7 +609,7 @@ pub fn read_repeated_enum_with_unknown_fields_into<E: ProtobufEnum>(
 /// [here](https://github.com/stepancheg/rust-protobuf/issues/233#issuecomment-375142710)
 pub fn read_repeated_enum_or_unknown_into<E: ProtobufEnum>(
     wire_type: WireType,
-    is: &mut CodedInputStream,
+    is: &mut CodedInputStream<'_>,
     target: &mut Vec<ProtobufEnumOrUnknown<E>>,
 ) -> ProtobufResult<()> {
     match wire_type {
@@ -630,7 +630,7 @@ pub fn read_repeated_enum_or_unknown_into<E: ProtobufEnum>(
 /// [here](https://github.com/stepancheg/rust-protobuf/issues/233#issuecomment-375142710)
 pub fn read_proto3_enum_with_unknown_fields_into<E: ProtobufEnum>(
     wire_type: WireType,
-    is: &mut CodedInputStream,
+    is: &mut CodedInputStream<'_>,
     target: &mut E,
     field_number: u32,
     unknown_fields: &mut UnknownFields,
@@ -650,7 +650,7 @@ pub fn read_proto3_enum_with_unknown_fields_into<E: ProtobufEnum>(
 /// [here](https://github.com/stepancheg/rust-protobuf/issues/233#issuecomment-375142710)
 pub fn read_proto2_enum_with_unknown_fields_into<E: ProtobufEnum>(
     wire_type: WireType,
-    is: &mut CodedInputStream,
+    is: &mut CodedInputStream<'_>,
     target: &mut Option<E>,
     field_number: u32,
     unknown_fields: &mut UnknownFields,
@@ -665,7 +665,7 @@ pub fn read_proto2_enum_with_unknown_fields_into<E: ProtobufEnum>(
 /// Read repeated `string` field into given vec.
 pub fn read_repeated_string_into<V>(
     wire_type: WireType,
-    is: &mut CodedInputStream,
+    is: &mut CodedInputStream<'_>,
     target: &mut V,
 ) -> ProtobufResult<()>
 where
@@ -702,7 +702,7 @@ where
 /// Read singular `string` field.
 pub fn read_singular_string_into(
     wire_type: WireType,
-    is: &mut CodedInputStream,
+    is: &mut CodedInputStream<'_>,
     target: &mut SingularField<String>,
 ) -> ProtobufResult<()> {
     match wire_type {
@@ -733,7 +733,7 @@ pub fn read_singular_carllerche_string_into(
 /// Read singular `string` field for proto3.
 pub fn read_singular_proto3_string_into(
     wire_type: WireType,
-    is: &mut CodedInputStream,
+    is: &mut CodedInputStream<'_>,
     target: &mut String,
 ) -> ProtobufResult<()> {
     match wire_type {
@@ -761,7 +761,7 @@ pub fn read_singular_proto3_carllerche_string_into(
 /// Read repeated `bytes` field into given vec.
 pub fn read_repeated_bytes_into<V>(
     wire_type: WireType,
-    is: &mut CodedInputStream,
+    is: &mut CodedInputStream<'_>,
     target: &mut V,
 ) -> ProtobufResult<()>
 where
@@ -798,7 +798,7 @@ where
 /// Read singular `bytes` field.
 pub fn read_singular_bytes_into(
     wire_type: WireType,
-    is: &mut CodedInputStream,
+    is: &mut CodedInputStream<'_>,
     target: &mut SingularField<Vec<u8>>,
 ) -> ProtobufResult<()> {
     match wire_type {
@@ -829,7 +829,7 @@ pub fn read_singular_carllerche_bytes_into(
 /// Read singular `bytes` field for proto3.
 pub fn read_singular_proto3_bytes_into(
     wire_type: WireType,
-    is: &mut CodedInputStream,
+    is: &mut CodedInputStream<'_>,
     target: &mut Vec<u8>,
 ) -> ProtobufResult<()> {
     match wire_type {
@@ -857,7 +857,7 @@ pub fn read_singular_proto3_carllerche_bytes_into(
 /// Read repeated `message` field.
 pub fn read_repeated_message_into_repeated_field<M: Message + Default>(
     wire_type: WireType,
-    is: &mut CodedInputStream,
+    is: &mut CodedInputStream<'_>,
     target: &mut RepeatedField<M>,
 ) -> ProtobufResult<()> {
     match wire_type {
@@ -875,7 +875,7 @@ pub fn read_repeated_message_into_repeated_field<M: Message + Default>(
 /// Read repeated `message` field.
 pub fn read_repeated_message_into_vec<M: Message + Default>(
     wire_type: WireType,
-    is: &mut CodedInputStream,
+    is: &mut CodedInputStream<'_>,
     target: &mut Vec<M>,
 ) -> ProtobufResult<()> {
     match wire_type {
@@ -898,7 +898,7 @@ pub fn read_repeated_message_into_vec<M: Message + Default>(
 /// Read singular `message` field.
 pub fn read_singular_message_into<M, O>(
     wire_type: WireType,
-    is: &mut CodedInputStream,
+    is: &mut CodedInputStream<'_>,
     target: &mut O,
 ) -> ProtobufResult<()>
 where
@@ -917,7 +917,7 @@ where
     }
 }
 
-fn skip_group(is: &mut CodedInputStream) -> ProtobufResult<()> {
+fn skip_group(is: &mut CodedInputStream<'_>) -> ProtobufResult<()> {
     loop {
         let (_, wire_type) = is.read_tag_unpack()?;
         if wire_type == wire_format::WireTypeEndGroup {
@@ -932,7 +932,7 @@ fn skip_group(is: &mut CodedInputStream) -> ProtobufResult<()> {
 pub fn read_unknown_or_skip_group(
     field_number: u32,
     wire_type: WireType,
-    is: &mut CodedInputStream,
+    is: &mut CodedInputStream<'_>,
     unknown_fields: &mut UnknownFields,
 ) -> ProtobufResult<()> {
     match wire_type {
@@ -981,7 +981,7 @@ where
 pub fn write_map_with_cached_sizes<K, V>(
     field_number: u32,
     map: &HashMap<<K::RuntimeType as RuntimeType>::Value, <V::RuntimeType as RuntimeType>::Value>,
-    os: &mut CodedOutputStream,
+    os: &mut CodedOutputStream<'_>,
 ) -> ProtobufResult<()>
 where
     K: ProtobufType,
@@ -1009,7 +1009,7 @@ where
 pub fn write_message_field_with_cached_size<M>(
     field_number: u32,
     message: &M,
-    os: &mut CodedOutputStream,
+    os: &mut CodedOutputStream<'_>,
 ) -> ProtobufResult<()>
 where
     M: Message,
@@ -1022,7 +1022,7 @@ where
 /// Read `map` field.
 pub fn read_map_into<K, V>(
     wire_type: WireType,
-    is: &mut CodedInputStream,
+    is: &mut CodedInputStream<'_>,
     target: &mut HashMap<
         <K::RuntimeType as RuntimeType>::Value,
         <V::RuntimeType as RuntimeType>::Value,

--- a/protobuf/src/singular.rs
+++ b/protobuf/src/singular.rs
@@ -523,7 +523,7 @@ impl<T: Clone> Clone for SingularPtrField<T> {
 
 impl<T: fmt::Debug> fmt::Debug for SingularField<T> {
     #[inline]
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         if self.is_some() {
             write!(f, "Some({:?})", *self.as_ref().unwrap())
         } else {
@@ -534,7 +534,7 @@ impl<T: fmt::Debug> fmt::Debug for SingularField<T> {
 
 impl<T: fmt::Debug> fmt::Debug for SingularPtrField<T> {
     #[inline]
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         if self.is_some() {
             write!(f, "Some({:?})", *self.as_ref().unwrap())
         } else {

--- a/protobuf/src/text_format/lexer/json_number_lit.rs
+++ b/protobuf/src/text_format/lexer/json_number_lit.rs
@@ -4,7 +4,7 @@ use std::fmt;
 pub struct JsonNumberLit(pub(crate) String);
 
 impl fmt::Display for JsonNumberLit {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         fmt::Display::fmt(&self.0, f)
     }
 }

--- a/protobuf/src/text_format/lexer/lexer_impl.rs
+++ b/protobuf/src/text_format/lexer/lexer_impl.rs
@@ -700,7 +700,7 @@ mod test {
 
     fn lex<P, R>(input: &str, parse_what: P) -> R
     where
-        P: FnOnce(&mut Lexer) -> LexerResult<R>,
+        P: FnOnce(&mut Lexer<'_>) -> LexerResult<R>,
     {
         let mut lexer = Lexer::new(input, ParserLanguage::Proto);
         let r = parse_what(&mut lexer).expect(&format!("lexer failed at {}", lexer.loc));
@@ -710,7 +710,7 @@ mod test {
 
     fn lex_opt<P, R>(input: &str, parse_what: P) -> R
     where
-        P: FnOnce(&mut Lexer) -> LexerResult<Option<R>>,
+        P: FnOnce(&mut Lexer<'_>) -> LexerResult<Option<R>>,
     {
         let mut lexer = Lexer::new(input, ParserLanguage::Proto);
         let o = parse_what(&mut lexer).expect(&format!("lexer failed at {}", lexer.loc));

--- a/protobuf/src/text_format/lexer/loc.rs
+++ b/protobuf/src/text_format/lexer/loc.rs
@@ -13,7 +13,7 @@ pub struct Loc {
 }
 
 impl fmt::Display for Loc {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         write!(f, "{}:{}", self.line, self.col)
     }
 }

--- a/protobuf/src/text_format/lexer/tokenizer.rs
+++ b/protobuf/src/text_format/lexer/tokenizer.rs
@@ -284,7 +284,7 @@ mod test {
 
     fn tokenize<P, R>(input: &str, what: P) -> R
     where
-        P: FnOnce(&mut Tokenizer) -> TokenizerResult<R>,
+        P: FnOnce(&mut Tokenizer<'_>) -> TokenizerResult<R>,
     {
         let mut tokenizer = Tokenizer::new(input, ParserLanguage::Proto);
         let r = what(&mut tokenizer).expect(&format!("parse failed at {}", tokenizer.loc()));

--- a/protobuf/src/text_format/print.rs
+++ b/protobuf/src/text_format/print.rs
@@ -77,7 +77,7 @@ fn print_field(
     indent: usize,
     first: &mut bool,
     field_name: &str,
-    value: ReflectValueRef,
+    value: ReflectValueRef<'_>,
 ) {
     print_start_field(buf, pretty, indent, first, field_name);
 
@@ -188,7 +188,7 @@ pub fn print_to_string(m: &dyn Message) -> String {
 }
 
 /// Text-format to `fmt::Formatter`.
-pub fn fmt(m: &dyn Message, f: &mut fmt::Formatter) -> fmt::Result {
+pub fn fmt(m: &dyn Message, f: &mut fmt::Formatter<'_>) -> fmt::Result {
     let pretty = f.alternate();
     f.write_str(&print_to_string_internal(m, pretty))
 }


### PR DESCRIPTION
I'm having some problems with protobuf and cbindgen. `syn` cannot parse the crate because it uses an old way of writing trait functions.

See https://github.com/dtolnay/syn/issues/733

As a first step I've ran `cargo fix --edition-idioms`.