### PR TITLE
Fix oneof's named as keywords in 2.x

### DIFF
--- a/protobuf-codegen/src/message.rs
+++ b/protobuf-codegen/src/message.rs
@@ -475,7 +475,7 @@ impl<'a> MessageGen<'a> {
                     };
                     w.field_decl_vis(
                         vis,
-                        oneof.name(),
+                        &oneof.name(),
                         &oneof.full_storage_type().to_code(&self.customize),
                     );
                 }

--- a/protobuf-codegen/src/oneof.rs
+++ b/protobuf-codegen/src/oneof.rs
@@ -55,7 +55,7 @@ impl OneofField {
 
         OneofField {
             elem: elem,
-            oneof_name: oneof.name().to_string(),
+            oneof_name: oneof.name(),
             oneof_type_name: RustType::Oneof(oneof.rust_name()),
             boxed: boxed,
         }
@@ -144,12 +144,8 @@ impl<'a> OneofGen<'a> {
         }
     }
 
-    pub fn name(&self) -> &str {
-        match self.oneof.oneof.get_name() {
-            "type" => "field_type",
-            "box" => "field_box",
-            x => x,
-        }
+    pub fn name(&self) -> String {
+        self.oneof.name()
     }
 
     pub fn variants_except_group(&'a self) -> Vec<OneofVariantGen<'a>> {

--- a/protobuf-test/src/common/v2/test_ident_pb.proto
+++ b/protobuf-test/src/common/v2/test_ident_pb.proto
@@ -28,11 +28,17 @@ message Outer {
     message fn {}
 }
 
-// oneof named type
+// oneof named keywords
 
 message TestType {
     oneof type {
         string s = 1;
+    }
+    oneof box {
+        string fn = 4;
+    }
+    oneof move {
+        string dyn = 5;
     }
     repeated string struct = 2;
     repeated uint32 ref = 3;

--- a/protobuf/src/descriptorx.rs
+++ b/protobuf/src/descriptorx.rs
@@ -576,11 +576,11 @@ pub struct OneofWithContext<'a> {
 
 impl<'a> OneofWithContext<'a> {
     /// Oneof rust name
-    pub fn name(&'a self) -> &'a str {
-        match self.oneof.get_name() {
-            "type" => "field_type",
-            "box" => "field_box",
-            x => x,
+    pub fn name(&'a self) -> String {
+        if rust::is_rust_keyword(self.oneof.get_name()) {
+            format!("field_{}", self.oneof.get_name())
+        } else {
+            self.oneof.get_name().to_owned()
         }
     }
 


### PR DESCRIPTION
Appears to fix https://github.com/stepancheg/rust-protobuf/issues/474 for my use case.

Adding a small proof-of-concept as a test case.