### PR TITLE
Use full name of Box for generated into_any fn.

### DIFF
--- a/protobuf-codegen/src/message.rs
+++ b/protobuf-codegen/src/message.rs
@@ -369,7 +369,7 @@ impl<'a> MessageGen<'a> {
                 w.write_line("self as &mut dyn (::std::any::Any)");
             });
             w.def_fn(
-                "into_any(self: Box<Self>) -> ::std::boxed::Box<dyn (::std::any::Any)>",
+                "into_any(self: ::std::boxed::Box<Self>) -> ::std::boxed::Box<dyn (::std::any::Any)>",
                 |w| {
                     w.write_line("self");
                 },


### PR DESCRIPTION
This will avoid conflict if protocol file also defined a message named Box.

Signed-off-by: bin liu <bin@hyper.sh>

This will fix #491 at v2.14