### PR TITLE
#493 - rustfmt ignore deprecated

### DIFF
--- a/protobuf-codegen/src/code_writer.rs
+++ b/protobuf-codegen/src/code_writer.rs
@@ -59,7 +59,7 @@ impl<'a> CodeWriter<'a> {
         self.write_line("#![allow(unknown_lints)]");
         self.write_line("#![allow(clippy::all)]");
         self.write_line("");
-        self.write_line("#![cfg_attr(rustfmt, rustfmt_skip)]");
+        self.write_line("#![rustfmt::skip]");
         self.write_line("");
         self.write_line("#![allow(box_pointers)]");
         self.write_line("#![allow(dead_code)]");


### PR DESCRIPTION
Resolves #493 

**What it does:**
 - Replaces deprecated `#![cfg_attr(rustfmt, rustfmt_skip)]` with `#![rustfmt::skip]`