### PR TITLE
Always set json name when its default differs from field name

### DIFF
--- a/protobuf-codegen-pure/src/convert.rs
+++ b/protobuf-codegen-pure/src/convert.rs
@@ -8,6 +8,7 @@ use crate::model;
 use protobuf;
 use protobuf::descriptor::field_descriptor_proto;
 use protobuf::prelude::*;
+use protobuf::json::json_name;
 use protobuf::Message;
 
 use crate::model::FieldOrOneOf;
@@ -208,6 +209,8 @@ impl<'a> Resolver<'a> {
         }
 
         output.set_label(field_descriptor_proto::Label::LABEL_OPTIONAL);
+
+        output.set_json_name(json_name(&name));
 
         output
     }
@@ -428,6 +431,8 @@ impl<'a> Resolver<'a> {
 
         if let Some(json_name) = input.options.as_slice().by_name_string("json_name")? {
             output.set_json_name(json_name);
+        } else {
+            output.set_json_name(json_name(&input.name));
         }
 
         Ok(output)

--- a/protobuf-test/src/common/v2/test_reflect.rs
+++ b/protobuf-test/src/common/v2/test_reflect.rs
@@ -245,3 +245,13 @@ fn test_get_reflect_map() {
         _ => panic!(),
     }
 }
+
+#[test]
+fn test_json_name() {
+    let descriptor = M::descriptor_static().get_field_by_name("sub_m").unwrap();
+    // Note that we intentionally do not call `descriptor.json_name()`, since
+    // that will compute a JSON name if one is not already present in the proto.
+    // We want to verify that the compiler has encoded the correct JSON name in
+    // the descriptor itself.
+    assert_eq!("subM", descriptor.proto().get_json_name());
+}

--- a/protobuf/src/json/json_name.rs
+++ b/protobuf/src/json/json_name.rs
@@ -1,6 +1,6 @@
 /// Implementation must match exactly
 /// `ToJsonName()` function in C++ `descriptor.cc`.
-pub(crate) fn json_name(input: &str) -> String {
+pub fn json_name(input: &str) -> String {
     let mut capitalize_next = false;
     let mut result = String::with_capacity(input.len());
 

--- a/protobuf/src/json/mod.rs
+++ b/protobuf/src/json/mod.rs
@@ -9,7 +9,8 @@ mod print;
 mod rfc_3339;
 mod well_known_wrapper;
 
-pub(crate) use self::json_name::json_name;
+#[doc(hidden)]
+pub use self::json_name::json_name;
 pub use self::parse::merge_from_str;
 pub use self::parse::merge_from_str_with_options;
 pub use self::parse::parse_dynamic_from_str;


### PR DESCRIPTION
If not set explicitly, a default JSON name must be computed by the Protobuf compiler. This is required for compatibility with protoc.

The basic gist is that protobuf-codegen-pure is generating incorrect file descriptor data by not setting the JSON name field. In protoc, if the `json_name` option is not provided by the user, it sets the JSON name to the lowerCamelCased name of the field. Not following these rules breaks libraries that do dynamic reflection on the `FileDescriptorSet`, like serde_protobuf.

@stepancheg this is something that was caught by #502 as submitted, though not by the version of the test that's currently on master. If you have suggestions on how to write a test for this, I'd love to hear them. The reason #502 was testing for textually identical output on the file descriptor data is because testing for textually identical output is a cheap + easy way of asserting semantically identical output. It is of course a stricter condition than necessary (e.g., as you mentioned, `syntax = proto2` and omitting syntax are semantically identical).