### PR TITLE
Omit package in file descriptor proto when empty

### DIFF
--- a/protobuf-codegen-pure/src/model.rs
+++ b/protobuf-codegen-pure/src/model.rs
@@ -308,7 +308,7 @@ pub struct FileDescriptor {
     /// Imports
     pub import_paths: Vec<String>,
     /// Package
-    pub package: String,
+    pub package: Option<String>,
     /// Protobuf Syntax
     pub syntax: Syntax,
     /// Top level messages

--- a/protobuf-codegen-pure/src/parser.rs
+++ b/protobuf-codegen-pure/src/parser.rs
@@ -1077,7 +1077,7 @@ impl<'a> Parser<'a> {
         self.syntax = syntax;
 
         let mut import_paths = Vec::new();
-        let mut package = String::new();
+        let mut package = None;
         let mut messages = Vec::new();
         let mut enums = Vec::new();
         let mut extensions = Vec::new();
@@ -1091,7 +1091,7 @@ impl<'a> Parser<'a> {
             }
 
             if let Some(next_package) = self.next_package_opt()? {
-                package = next_package.to_owned();
+                package = Some(next_package);
                 continue;
             }
 
@@ -1269,7 +1269,18 @@ mod test {
     }
     "#;
         let desc = parse(msg, |p| p.next_proto());
-        assert_eq!("foo.bar".to_string(), desc.package);
+        assert_eq!(Some("foo.bar".to_string()), desc.package);
+    }
+
+    #[test]
+    fn test_no_package() {
+        let msg = r#"
+    message A {
+        optional int32 a = 1;
+    }
+    "#;
+        let desc = parse(msg, |p| p.next_proto());
+        assert_eq!(None, desc.package);
     }
 
     #[test]

--- a/protobuf-codegen/src/protobuf_name.rs
+++ b/protobuf-codegen/src/protobuf_name.rs
@@ -251,14 +251,18 @@ impl ProtobufAbsolutePath {
         self.path.is_empty()
     }
 
-    pub fn from_path_without_dot(path: &str) -> ProtobufAbsolutePath {
-        if path.is_empty() {
-            ProtobufAbsolutePath::root()
-        } else {
-            assert!(!path.starts_with("."));
-            assert!(!path.ends_with("."));
-            ProtobufAbsolutePath::new(format!(".{}", path))
+    pub fn from_package_path(path: Option<&str>) -> ProtobufAbsolutePath {
+        match path {
+            None => ProtobufAbsolutePath::root(),
+            Some(path) => ProtobufAbsolutePath::from_path_without_dot(path),
         }
+    }
+
+    pub fn from_path_without_dot(path: &str) -> ProtobufAbsolutePath {
+        assert!(!path.is_empty());
+        assert!(!path.starts_with("."));
+        assert!(!path.ends_with("."));
+        ProtobufAbsolutePath::new(format!(".{}", path))
     }
 
     pub fn from_path_maybe_dot(path: &str) -> ProtobufAbsolutePath {

--- a/protobuf-test/src/common/v2/test_reflect_no_package.rs
+++ b/protobuf-test/src/common/v2/test_reflect_no_package.rs
@@ -1,0 +1,5 @@
+#[test]
+fn test_no_package() {
+    let file_descriptor = super::test_reflect_no_package_pb::file_descriptor_proto();
+    assert!(!file_descriptor.has_package());
+}

--- a/protobuf-test/src/common/v2/test_reflect_no_package_pb.proto
+++ b/protobuf-test/src/common/v2/test_reflect_no_package_pb.proto
@@ -1,0 +1,7 @@
+// This file intentionally has no `package` declaration.
+
+syntax = "proto2";
+
+message Ignored {
+    optional int32 i = 1;
+}


### PR DESCRIPTION
A protobuf file with no package is observably different from a protobuf
file with an empty package, since descriptor.proto uses proto2 syntax.

@stepancheg I promise this is the last one for a while! For context, the specific issue I'm having is with serde-protobuf, which has this logic

https://github.com/dflemstr/serde-protobuf/blob/864507a01b85123a6b3bfff6fc665c04ade11b93/src/descriptor.rs#L361-L365

This logic works fine for `FileDescriptorProto`s generated by protoc, which omits the `package` field entirely if the declaration is omitted from the `.proto`, but not for `FileDescriptorProto`s generated by protobuf-codegen-pure, which sets the package field to the empty string if the `package` declaration is omitted from the `.proto`.

One could argue that this is a bug in serde-protobuf, but who knows how much other code there is out there that depends on this behavior—seemed a bit safer to just make protobuf-codegen-pure's output match protoc's output.