### PR TITLE
Embed rustproto.proto and WKT protos in protobuf-codegen-pure

### DIFF
--- a/protobuf-codegen-pure-test/build.rs
+++ b/protobuf-codegen-pure-test/build.rs
@@ -81,17 +81,15 @@ fn copy_tests(dir: &str) {
 fn gen_in_dir(dir: &str, include_dir: &str) {
     gen_in_dir_impl(
         dir,
-        include_dir,
         |GenInDirArgs {
              out_dir,
              input,
-             includes,
              customize,
          }| {
             protobuf_codegen_pure::Codegen::new()
                 .out_dir(out_dir)
                 .inputs(input)
-                .includes(includes)
+                .includes(&[include_dir])
                 .customize(customize)
                 .run()
         },

--- a/protobuf-codegen-pure/src/lib.rs
+++ b/protobuf-codegen-pure/src/lib.rs
@@ -205,6 +205,15 @@ impl<'a> Run<'a> {
         let content = fs::read_to_string(fs_path)
             .map_err(|e| amend_io_error(e, format!("failed to read {:?}", fs_path)))?;
 
+        self.add_file_content(protobuf_path, fs_path, &content)
+    }
+
+    fn add_file_content(
+        &mut self,
+        protobuf_path: &Path,
+        fs_path: &Path,
+        content: &str,
+    ) -> io::Result<()> {
         let parsed = model::FileDescriptor::parse(content).map_err(|e| {
             io::Error::new(
                 io::ErrorKind::Other,
@@ -251,13 +260,32 @@ impl<'a> Run<'a> {
             }
         }
 
-        Err(io::Error::new(
-            io::ErrorKind::Other,
-            format!(
-                "protobuf path {:?} is not found in import path {:?}",
-                protobuf_path, self.includes
-            ),
-        ))
+        let embedded = match protobuf_path.to_str() {
+            Some("rustproto.proto") => Some(RUSTPROTO_PROTO),
+            Some("google/protobuf/any.proto") => Some(ANY_PROTO),
+            Some("google/protobuf/api.proto") => Some(API_PROTO),
+            Some("google/protobuf/descriptor.proto") => Some(DESCRIPTOR_PROTO),
+            Some("google/protobuf/duration.proto") => Some(DURATION_PROTO),
+            Some("google/protobuf/empty.proto") => Some(EMPTY_PROTO),
+            Some("google/protobuf/field_mask.proto") => Some(FIELD_MASK_PROTO),
+            Some("google/protobuf/source_context.proto") => Some(SOURCE_CONTEXT_PROTO),
+            Some("google/protobuf/struct.proto") => Some(STRUCT_PROTO),
+            Some("google/protobuf/timestamp.proto") => Some(TIMESTAMP_PROTO),
+            Some("google/protobuf/type.proto") => Some(TYPE_PROTO),
+            Some("google/protobuf/wrappers.proto") => Some(WRAPPERS_PROTO),
+            _ => None,
+        };
+
+        match embedded {
+            Some(content) => self.add_file_content(protobuf_path, protobuf_path, content),
+            None => Err(io::Error::new(
+                io::ErrorKind::Other,
+                format!(
+                    "protobuf path {:?} is not found in import path {:?}",
+                    protobuf_path, self.includes
+                ),
+            )),
+        }
     }
 
     fn add_fs_file(&mut self, fs_path: &Path) -> io::Result<PathBuf> {
@@ -317,3 +345,16 @@ pub fn parse_and_typecheck(
         file_descriptors,
     })
 }
+
+const RUSTPROTO_PROTO: &str = include_str!("../../proto/rustproto.proto");
+const ANY_PROTO: &str = include_str!("../../proto/google/protobuf/any.proto");
+const API_PROTO: &str = include_str!("../../proto/google/protobuf/api.proto");
+const DESCRIPTOR_PROTO: &str = include_str!("../../proto/google/protobuf/descriptor.proto");
+const DURATION_PROTO: &str = include_str!("../../proto/google/protobuf/duration.proto");
+const EMPTY_PROTO: &str = include_str!("../../proto/google/protobuf/empty.proto");
+const FIELD_MASK_PROTO: &str = include_str!("../../proto/google/protobuf/field_mask.proto");
+const SOURCE_CONTEXT_PROTO: &str = include_str!("../../proto/google/protobuf/source_context.proto");
+const STRUCT_PROTO: &str = include_str!("../../proto/google/protobuf/struct.proto");
+const TIMESTAMP_PROTO: &str = include_str!("../../proto/google/protobuf/timestamp.proto");
+const TYPE_PROTO: &str = include_str!("../../proto/google/protobuf/type.proto");
+const WRAPPERS_PROTO: &str = include_str!("../../proto/google/protobuf/wrappers.proto");

--- a/protobuf-test-common/src/build.rs
+++ b/protobuf-test-common/src/build.rs
@@ -106,7 +106,6 @@ pub fn cfg_serde() {
 pub struct GenInDirArgs<'a> {
     pub out_dir: &'a str,
     pub input: &'a [&'a str],
-    pub includes: &'a [&'a str],
     pub customize: Customize,
 }
 
@@ -202,7 +201,7 @@ fn check_test_version(file_path: &Path) {
     );
 }
 
-pub fn gen_in_dir_impl<F, E>(dir: &str, include_dir: &str, gen: F)
+pub fn gen_in_dir_impl<F, E>(dir: &str, gen: F)
 where
     F: for<'a> Fn(GenInDirArgs<'a>) -> Result<(), E>,
     E: fmt::Debug,
@@ -220,11 +219,9 @@ where
 
     assert!(!protos.is_empty(), "no protos found in {}", dir);
 
-    let includes = ["../proto", include_dir];
-
     eprintln!(
-        "invoking protobubf compiler: out_dir: {:?}, input: {:?}, includes: {:?}",
-        dir, protos, includes
+        "invoking protobuf compiler: out_dir: {:?}, input: {:?}",
+        dir, protos
     );
 
     let customize = Customize {
@@ -235,7 +232,6 @@ where
     gen(GenInDirArgs {
         out_dir: dir,
         input: &protos.iter().map(|a| a.as_ref()).collect::<Vec<&str>>(),
-        includes: &includes,
         customize,
     })
     .expect("codegen failed");

--- a/protobuf-test/build.rs
+++ b/protobuf-test/build.rs
@@ -16,17 +16,15 @@ use protobuf_test_common::build::*;
 fn gen_in_dir(dir: &str, include_dir: &str) {
     gen_in_dir_impl(
         dir,
-        include_dir,
         |GenInDirArgs {
              out_dir,
              input,
-             includes,
              customize,
          }| {
             protoc_rust::Codegen::new()
                 .out_dir(out_dir)
                 .inputs(input)
-                .includes(includes)
+                .includes(&["../proto", include_dir])
                 .customize(customize)
                 .run()
         },


### PR DESCRIPTION
Embed the definitions of rustproto.proto and the well-known type protos
in the protobuf-codegen-pure crate. This ensures that the correct
versions of these proto files are available in every installation of
protobuf-codegen-pure. (Previously, users needed to acquire their own
copy of these protos and configure their include paths accordingly.)

Users can still override these embedded definitions by supplying a file
of the correct name, which will be preferred to the embedded
definitions.

Fix #312.

----

@stepancheg not sure if there's an easier or better way to do this. This was the simplest thing I could come up with.