### PR TITLE
Compare semantic equivalence of FileDescriptorSets generated by codegen-pure and protoc

### DIFF
--- a/protobuf-codegen-identical-test/tests/diff.rs
+++ b/protobuf-codegen-identical-test/tests/diff.rs
@@ -140,9 +140,6 @@ fn normalize_file_descriptor(desc: &mut FileDescriptorProto) {
     }
     desc.options.clear();
 
-    // TODO: don't clear dependencies.
-    desc.dependency.clear();
-
     // TODO: don't clear services.
     desc.service.clear();
 }

--- a/protobuf-codegen-identical-test/tests/diff.rs
+++ b/protobuf-codegen-identical-test/tests/diff.rs
@@ -1,11 +1,18 @@
 use regex::Regex;
+use std::collections::HashSet;
+use std::fmt;
 use std::fmt::Write as _;
 use std::fs;
 use std::path::Path;
 use std::path::PathBuf;
 use std::path::MAIN_SEPARATOR;
 use std::str;
+use tempfile::NamedTempFile;
 
+use protobuf::descriptor::{
+    DescriptorProto, EnumDescriptorProto, FileDescriptorProto, FileDescriptorSet,
+};
+use protobuf::RepeatedField;
 use protobuf_test_common::build::copy_tests_v2_v3;
 use protobuf_test_common::build::glob_simple;
 use std::process::Command;
@@ -82,6 +89,102 @@ fn print_diff(dir: &Path, a: &Path, b: &Path) {
     print!("{}", str::from_utf8(&output.stderr).unwrap());
 }
 
+fn protoc_descriptor_set(includes: &[PathBuf], inputs: &[PathBuf]) -> FileDescriptorSet {
+    let mut temp_file = NamedTempFile::new().unwrap();
+    protoc::Protoc::from_env_path()
+        .descriptor_set_out_args()
+        .out(temp_file.path())
+        .includes(includes)
+        .inputs(inputs)
+        .write_descriptor_set()
+        .unwrap();
+    protobuf::parse_from_reader(&mut temp_file).unwrap()
+}
+
+// TODO: expose this utility from protobuf-codegen-pure crate.
+fn pure_descriptor_set(includes: &[PathBuf], inputs: &[PathBuf]) -> FileDescriptorSet {
+    let mut codegen = protobuf_codegen_pure::parse_and_typecheck(includes, inputs).unwrap();
+    let relative_paths: HashSet<_> = codegen
+        .relative_paths
+        .iter()
+        .map(|path| path.to_string_lossy())
+        .collect();
+    codegen
+        .file_descriptors
+        .retain(|fd| relative_paths.contains(fd.get_name()));
+    let mut fds = FileDescriptorSet::new();
+    fds.file = RepeatedField::from_vec(codegen.file_descriptors);
+    fds
+}
+
+fn normalize_descriptor_set(fds: &mut FileDescriptorSet) {
+    for desc in fds.file.iter_mut() {
+        normalize_file_descriptor(desc)
+    }
+}
+
+fn normalize_file_descriptor(desc: &mut FileDescriptorProto) {
+    if !desc.has_syntax() {
+        desc.set_syntax("proto2".into())
+    }
+    for desc in &mut *desc.message_type {
+        normalize_descriptor(desc)
+    }
+    for desc in desc.enum_type.iter_mut() {
+        normalize_enum_descriptor(desc)
+    }
+
+    // TODO: don't clear options.
+    for desc in &mut *desc.extension {
+        desc.options.clear();
+    }
+    desc.options.clear();
+
+    // TODO: don't clear dependencies.
+    desc.dependency.clear();
+
+    // TODO: don't clear services.
+    desc.service.clear();
+}
+
+fn normalize_enum_descriptor(desc: &mut EnumDescriptorProto) {
+    // TODO: don't clear options.
+    desc.options.clear();
+    for value in desc.value.iter_mut() {
+        value.options.clear();
+    }
+}
+
+fn normalize_descriptor(desc: &mut DescriptorProto) {
+    for desc in desc.nested_type.iter_mut() {
+        normalize_descriptor(desc);
+    }
+    for desc in desc.enum_type.iter_mut() {
+        normalize_enum_descriptor(desc);
+    }
+
+    // TODO: don't clear options.
+    desc.options.clear();
+    for field in desc.field.iter_mut() {
+        field.options.clear();
+        // TODO: don't clear default value.
+        field.clear_default_value();
+    }
+}
+
+fn pretty_message<M: protobuf::Message>(message: &M) -> String {
+    // TODO: pull this handy utility into the protobuf crate.
+    struct FormatMessage<'a, M>(&'a M);
+
+    impl<M: protobuf::Message> fmt::Display for FormatMessage<'_, M> {
+        fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+            protobuf::text_format::fmt(self.0, f)
+        }
+    }
+
+    format!("{:#}", FormatMessage(message))
+}
+
 fn test_diff_in<F>(root: &str, s: &str, include: &str, should_skip: F)
 where
     F: Fn(&str) -> bool,
@@ -140,8 +243,14 @@ where
             fs::read_to_string(&protoc_rs).expect(&format!("while reading {}", protoc_rs));
         let pure_rs_contents =
             fs::read_to_string(&pure_rs).expect(&format!("while reading {}", pure_rs));
+
+        let mut protoc_descriptors = protoc_descriptor_set(&includes, &inputs);
+        let mut pure_descriptors = pure_descriptor_set(&includes, &inputs);
+        normalize_descriptor_set(&mut protoc_descriptors);
+        normalize_descriptor_set(&mut pure_descriptors);
+
         let skip = should_skip(input.to_str().unwrap());
-        if protoc_rs_contents == pure_rs_contents {
+        if protoc_rs_contents == pure_rs_contents && protoc_descriptors == pure_descriptors {
             if !skip {
                 stats.passed += 1;
                 println!("{}: PASSED", label);
@@ -162,6 +271,22 @@ where
                 temp_dir.path(),
                 Path::new(&protoc_rs).strip_prefix(temp_dir.path()).unwrap(),
                 Path::new(&pure_rs).strip_prefix(temp_dir.path()).unwrap(),
+            );
+
+            fs::write(
+                format!("{}/{}.descriptors", protoc_dir, proto_name),
+                pretty_message(&protoc_descriptors),
+            )
+            .unwrap();
+            fs::write(
+                format!("{}/{}.descriptors", pure_dir, proto_name),
+                pretty_message(&pure_descriptors),
+            )
+            .unwrap();
+            print_diff(
+                temp_dir.path(),
+                Path::new(&format!("protoc/{}.descriptors", proto_name)),
+                Path::new(&format!("pure/{}.descriptors", proto_name)),
             );
         }
     }

--- a/protobuf-codegen-pure/src/convert.rs
+++ b/protobuf-codegen-pure/src/convert.rs
@@ -838,6 +838,8 @@ pub fn file_descriptor(
         output.set_package(package.clone());
     }
 
+    output.dependency = protobuf::RepeatedField::from_slice(&input.import_paths);
+
     let mut messages = protobuf::RepeatedField::new();
     for m in &input.messages {
         messages.push(resolver.message(&m, &ProtobufRelativePath::empty())?);


### PR DESCRIPTION
As discussed here: https://github.com/stepancheg/rust-protobuf/pull/505#issuecomment-657289523

The first commit adds the test itself, with some very aggressive normalization rules to work around various mismatches in codegen-pure. The next two commits fix two of the easier mismatches. Details in the individual commit messages.