### PR TITLE
Make codegen-pure's field defaults match protoc's

### DIFF
--- a/protobuf-codegen-identical-test/tests/diff.rs
+++ b/protobuf-codegen-identical-test/tests/diff.rs
@@ -164,8 +164,6 @@ fn normalize_descriptor(desc: &mut DescriptorProto) {
     desc.options.clear();
     for field in desc.field.iter_mut() {
         field.options.clear();
-        // TODO: don't clear default value.
-        field.clear_default_value();
     }
 }
 

--- a/protobuf-codegen-pure/src/convert.rs
+++ b/protobuf-codegen-pure/src/convert.rs
@@ -17,6 +17,7 @@ use crate::protobuf_codegen::ProtobufAbsolutePath;
 use crate::protobuf_codegen::ProtobufIdent;
 use crate::protobuf_codegen::ProtobufRelativePath;
 use protobuf::text_format::lexer::StrLitDecodeError;
+use protobuf::text_format::quote_bytes_to;
 
 #[derive(Debug)]
 pub enum ConvertError {
@@ -440,7 +441,9 @@ impl<'a> Resolver<'a> {
                 }
                 protobuf::descriptor::field_descriptor_proto::Type::TYPE_BYTES => {
                     if let &model::ProtobufConstant::String(ref s) = default {
-                        s.escaped.clone()
+                        let mut buf = String::new();
+                        quote_bytes_to(&s.decode_bytes()?, &mut buf);
+                        buf
                     } else {
                         return Err(ConvertError::DefaultValueIsNotStringLiteral);
                     }

--- a/protobuf-codegen-pure/src/parser.rs
+++ b/protobuf-codegen-pure/src/parser.rs
@@ -1200,7 +1200,7 @@ mod test {
         let mess = parse(msg, |p| p.next_field(MessageBodyParseMode::MessageProto2));
         assert_eq!("f", mess.name);
         assert_eq!("default", mess.options[0].name);
-        assert_eq!("10.0", mess.options[0].value.format());
+        assert_eq!("10", mess.options[0].value.format());
     }
 
     #[test]

--- a/protobuf/src/text_format/lexer/float.rs
+++ b/protobuf/src/text_format/lexer/float.rs
@@ -23,7 +23,7 @@ pub fn format_protobuf_float(f: f64) -> String {
         }
     } else {
         // TODO: make sure doesn't lose precision
-        format!("{:?}", f)
+        format!("{}", f)
     }
 }
 
@@ -53,6 +53,6 @@ mod test {
 
     #[test]
     fn test_format_protobuf_float() {
-        assert_eq!("10.0", format_protobuf_float(10.0));
+        assert_eq!("10", format_protobuf_float(10.0));
     }
 }

--- a/protobuf/src/text_format/mod.rs
+++ b/protobuf/src/text_format/mod.rs
@@ -32,6 +32,8 @@ pub use self::print::fmt;
 pub use self::print::print_to;
 pub use self::print::print_to_string;
 #[doc(hidden)]
+pub use self::print::quote_bytes_to;
+#[doc(hidden)]
 pub use self::print::quote_escape_bytes;
 
 pub use self::parse::merge_from_str;

--- a/protobuf/src/text_format/print.rs
+++ b/protobuf/src/text_format/print.rs
@@ -5,12 +5,14 @@ use crate::core::Message;
 use crate::reflect::ReflectFieldRef;
 use crate::reflect::ReflectValueRef;
 
-fn quote_bytes_to(bytes: &[u8], buf: &mut String) {
+#[doc(hidden)]
+pub fn quote_bytes_to(bytes: &[u8], buf: &mut String) {
     for &c in bytes {
         match c {
             b'\n' => buf.push_str(r"\n"),
             b'\r' => buf.push_str(r"\r"),
             b'\t' => buf.push_str(r"\t"),
+            b'\'' => buf.push_str("\\\'"),
             b'"' => buf.push_str("\\\""),
             b'\\' => buf.push_str(r"\\"),
             b'\x20'..=b'\x7e' => buf.push(c as char),
@@ -221,7 +223,7 @@ mod test {
     fn test_print_to_bytes() {
         assert_eq!("ab", escape(b"ab"));
         assert_eq!("a\\\\023", escape(b"a\\023"));
-        assert_eq!("a\\r\\n\\t '\\\"\\\\", escape(b"a\r\n\t '\"\\"));
+        assert_eq!("a\\r\\n\\t \\'\\\"\\\\", escape(b"a\r\n\t '\"\\"));
         assert_eq!("\\344\\275\\240\\345\\245\\275", escape("你好".as_bytes()));
     }
 


### PR DESCRIPTION
Split out from #510. @stepancheg I don't particularly care about these changes, but they directly fall out from not calling `field.clear_default_value()` in normalize_descriptor.

I'm quite confident that the change to `quote_bytes_to` is valid, as it just adds escaping for single quotes (`'`) like in the C++ version: https://github.com/protocolbuffers/protobuf/blob/f9d8138376765d229a32635c9209061e4e4aed8c/java/core/src/main/java/com/google/protobuf/TextFormatEscaper.java#L79-L81

I'm less sure about the float change (it's hard to say exactly what snprintf will do with `%g` on all platforms: https://github.com/protocolbuffers/protobuf/blob/c0b79c5a398f4eec51ef92784e9d940febdccc52/src/google/protobuf/stubs/strutil.cc#L1245-L1287), but it's definitely true that google/protobuf will render a default value of 10.000 as `10`, and this change matches google/protobuf on that specific case.

----

This required the following changes:

  * Suppressing trailing ".0" from rendered floats
  * Escaping single quotes in the text format
  * Normalizing escape sequences in byte-valued defaults
