### PR TITLE
Embed rustproto.proto and WKT protos in protobuf-codegen-pure

### DIFF
--- a/protobuf-codegen-pure-test/build.rs
+++ b/protobuf-codegen-pure-test/build.rs
@@ -66,18 +66,16 @@ fn copy_tests(dir: &str) {
 fn gen_in_dir(dir: &str, include_dir: &str) {
     gen_in_dir_impl(
         dir,
-        include_dir,
         true,
         |GenInDirArgs {
              out_dir,
              input,
-             includes,
              customize,
          }| {
             protobuf_codegen_pure::run(protobuf_codegen_pure::Args {
                 out_dir,
                 input,
-                includes,
+                includes: &[include_dir],
                 customize,
             })
         },

--- a/protobuf-codegen-pure/src/lib.rs
+++ b/protobuf-codegen-pure/src/lib.rs
@@ -234,6 +234,15 @@ impl<'a> Run<'a> {
         let mut content = String::new();
         fs::File::open(fs_path)?.read_to_string(&mut content)?;
 
+        self.add_file_content(protobuf_path, fs_path, &content)
+    }
+
+    fn add_file_content(
+        &mut self,
+        protobuf_path: &str,
+        fs_path: &Path,
+        content: &str,
+    ) -> io::Result<()> {
         let parsed = model::FileDescriptor::parse(content).map_err(|e| {
             io::Error::new(
                 io::ErrorKind::Other,
@@ -282,13 +291,34 @@ impl<'a> Run<'a> {
             }
         }
 
-        Err(io::Error::new(
-            io::ErrorKind::Other,
-            format!(
-                "protobuf path {:?} is not found in import path {:?}",
-                protobuf_path, self.includes
-            ),
-        ))
+        let embedded = match protobuf_path {
+            "rustproto.proto" => Some(RUSTPROTO_PROTO),
+            "google/protobuf/any.proto" => Some(ANY_PROTO),
+            "google/protobuf/api.proto" => Some(API_PROTO),
+            "google/protobuf/descriptor.proto" => Some(DESCRIPTOR_PROTO),
+            "google/protobuf/duration.proto" => Some(DURATION_PROTO),
+            "google/protobuf/empty.proto" => Some(EMPTY_PROTO),
+            "google/protobuf/field_mask.proto" => Some(FIELD_MASK_PROTO),
+            "google/protobuf/source_context.proto" => Some(SOURCE_CONTEXT_PROTO),
+            "google/protobuf/struct.proto" => Some(STRUCT_PROTO),
+            "google/protobuf/timestamp.proto" => Some(TIMESTAMP_PROTO),
+            "google/protobuf/type.proto" => Some(TYPE_PROTO),
+            "google/protobuf/wrappers.proto" => Some(WRAPPERS_PROTO),
+            _ => None,
+        };
+
+        match embedded {
+            Some(content) => {
+                self.add_file_content(protobuf_path, Path::new(protobuf_path), content)
+            }
+            None => Err(io::Error::new(
+                io::ErrorKind::Other,
+                format!(
+                    "protobuf path {:?} is not found in import path {:?}",
+                    protobuf_path, self.includes
+                ),
+            )),
+        }
     }
 
     fn add_fs_file(&mut self, fs_path: &Path) -> io::Result<String> {
@@ -348,6 +378,19 @@ pub fn parse_and_typecheck(
         file_descriptors,
     })
 }
+
+const RUSTPROTO_PROTO: &str = include_str!("../../proto/rustproto.proto");
+const ANY_PROTO: &str = include_str!("../../proto/google/protobuf/any.proto");
+const API_PROTO: &str = include_str!("../../proto/google/protobuf/api.proto");
+const DESCRIPTOR_PROTO: &str = include_str!("../../proto/google/protobuf/descriptor.proto");
+const DURATION_PROTO: &str = include_str!("../../proto/google/protobuf/duration.proto");
+const EMPTY_PROTO: &str = include_str!("../../proto/google/protobuf/empty.proto");
+const FIELD_MASK_PROTO: &str = include_str!("../../proto/google/protobuf/field_mask.proto");
+const SOURCE_CONTEXT_PROTO: &str = include_str!("../../proto/google/protobuf/source_context.proto");
+const STRUCT_PROTO: &str = include_str!("../../proto/google/protobuf/struct.proto");
+const TIMESTAMP_PROTO: &str = include_str!("../../proto/google/protobuf/timestamp.proto");
+const TYPE_PROTO: &str = include_str!("../../proto/google/protobuf/type.proto");
+const WRAPPERS_PROTO: &str = include_str!("../../proto/google/protobuf/wrappers.proto");
 
 /// Like `protoc --rust_out=...` but without requiring `protoc` or `protoc-gen-rust`
 /// commands in `$PATH`.

--- a/protobuf-test-common/src/build.rs
+++ b/protobuf-test-common/src/build.rs
@@ -87,7 +87,6 @@ pub fn clean_old_files() {
 pub struct GenInDirArgs<'a> {
     pub out_dir: &'a str,
     pub input: &'a [&'a str],
-    pub includes: &'a [&'a str],
     pub customize: Customize,
 }
 
@@ -126,7 +125,7 @@ pub fn gen_mod_rs_in_dir(dir: &str) {
     mod_rs.flush().expect("flush");
 }
 
-pub fn gen_in_dir_impl<F, E>(dir: &str, include_dir: &str, protoc3: bool, gen: F)
+pub fn gen_in_dir_impl<F, E>(dir: &str, protoc3: bool, gen: F)
 where
     F: for<'a> Fn(GenInDirArgs<'a>) -> Result<(), E>,
     E: fmt::Debug,
@@ -148,7 +147,6 @@ where
     gen(GenInDirArgs {
         out_dir: dir,
         input: &protos.iter().map(|a| a.as_ref()).collect::<Vec<&str>>(),
-        includes: &["../proto", include_dir],
         ..Default::default()
     })
     .expect("protoc");

--- a/protobuf-test/build.rs
+++ b/protobuf-test/build.rs
@@ -24,18 +24,16 @@ fn gen_in_dir(dir: &str, include_dir: &str) {
     let v3 = protoc_is_v3();
     gen_in_dir_impl(
         dir,
-        include_dir,
         v3,
         |GenInDirArgs {
              out_dir,
              input,
-             includes,
              customize,
          }| {
             protoc_rust::run(protoc_rust::Args {
                 out_dir,
                 input,
-                includes,
+                includes: &["../proto", include_dir],
                 customize,
             })
         },


### PR DESCRIPTION
@stepancheg this is a backport of #507 for the v2.17 branch. Are you open to that?

Embed the definitions of rustproto.proto and the well-known type protos
in the protobuf-codegen-pure crate. This ensures that the correct
versions of these proto files are available in every installation of
protobuf-codegen-pure. (Previously, users needed to acquire their own
copy of these protos and configure their include paths accordingly.)

Users can still override these embedded definitions by supplying a file
of the correct name, which will be preferred to the embedded
definitions.

This is a backport of aed791f7d.