### PR TITLE
Fully qualify Serialize and Deserialize for serde support.

### DIFF
--- a/protobuf-codegen-pure-test/Cargo.toml
+++ b/protobuf-codegen-pure-test/Cargo.toml
@@ -24,7 +24,7 @@ env_logger  = "0.5.*"
 
 [dependencies]
 protobuf-test-common = { path = "../protobuf-test-common" }
-serde        = { version = "1.0", optional = true }
+serde        = { version = "1.0", features = ["derive"], optional = true }
 serde_derive = { version = "1.0", optional = true }
 serde_json   = { version = "1.0", optional = true }
 bytes = { version = "1.0", optional = true }

--- a/protobuf-codegen/src/enums.rs
+++ b/protobuf-codegen/src/enums.rs
@@ -165,7 +165,11 @@ impl<'a> EnumGen<'a> {
             w.comment("Note: you cannot use pattern matching for enums with allow_alias option");
         }
         w.derive(&derive);
-        serde::write_serde_attr(w, &self.customize, "derive(Serialize, Deserialize)");
+        serde::write_serde_attr(
+            w,
+            &self.customize,
+            "derive(::serde::Serialize, ::serde::Deserialize)",
+        );
         let ref type_name = self.type_name;
         w.expr_block(&format!("pub enum {}", type_name), |w| {
             for value in self.values_all() {

--- a/protobuf-codegen/src/message.rs
+++ b/protobuf-codegen/src/message.rs
@@ -575,7 +575,11 @@ impl<'a> MessageGen<'a> {
             derive.push("Debug");
         }
         w.derive(&derive);
-        serde::write_serde_attr(w, &self.customize, "derive(Serialize, Deserialize)");
+        serde::write_serde_attr(
+            w,
+            &self.customize,
+            "derive(::serde::Serialize, ::serde::Deserialize)",
+        );
         w.pub_struct(&format!("{}", self.type_name), |w| {
             if !self.fields_except_oneof().is_empty() {
                 w.comment("message fields");

--- a/protobuf-codegen/src/oneof.rs
+++ b/protobuf-codegen/src/oneof.rs
@@ -233,7 +233,11 @@ impl<'a> OneofGen<'a> {
     fn write_enum(&self, w: &mut CodeWriter) {
         let derive = vec!["Clone", "PartialEq", "Debug"];
         w.derive(&derive);
-        serde::write_serde_attr(w, &self.customize, "derive(Serialize, Deserialize)");
+        serde::write_serde_attr(
+            w,
+            &self.customize,
+            "derive(::serde::Serialize, ::serde::Deserialize)",
+        );
         w.pub_enum(&self.oneof.rust_name().ident.to_string(), |w| {
             for variant in self.variants_except_group() {
                 w.write_line(&format!(

--- a/protobuf-fuzz/Cargo.toml
+++ b/protobuf-fuzz/Cargo.toml
@@ -24,7 +24,7 @@ env_logger  = "0.5.*"
 
 [dependencies]
 protobuf-test-common = { path = "../protobuf-test-common" }
-serde        = "1.0"
+serde        = { version = "1.0", features = ["derive"] }
 serde_derive = "1.0"
 serde_json   = "1.0"
 bytes = { version = "1.0", optional = true }

--- a/protobuf-test-common/Cargo.toml
+++ b/protobuf-test-common/Cargo.toml
@@ -23,7 +23,7 @@ glob         = "0.2"
 log          = "0.*"
 env_logger   = "0.5.*"
 tempfile     = "3.0"
-serde        = { version = "1.0", optional = true }
+serde        = { version = "1.0", features = ["derive"], optional = true }
 serde_derive = { version = "1.0", optional = true }
 serde_json   = { version = "1.0", optional = true }
 bytes = { version = "1.0", optional = true }

--- a/protobuf-test/Cargo.toml
+++ b/protobuf-test/Cargo.toml
@@ -26,7 +26,7 @@ protoc-bin-vendored = { path = "../protoc-bin-vendored" }
 
 [dependencies]
 protobuf-test-common = { path = "../protobuf-test-common" }
-serde        = { version = "1.0", optional = true }
+serde        = { version = "1.0", features = ["derive"], optional = true }
 serde_derive = { version = "1.0", optional = true }
 serde_json   = { version = "1.0", optional = true }
 bytes = { version = "1.0", optional = true }

--- a/protobuf/Cargo.toml
+++ b/protobuf/Cargo.toml
@@ -22,7 +22,7 @@ default = []
 
 [dependencies]
 bytes = { version = "1.0", optional = true }
-serde        = { version = "1.0", optional = true }
+serde        = { version = "1.0", features = ["derive"], optional = true }
 serde_derive = { version = "1.0", optional = true }
 
 [package.metadata.docs.rs]


### PR DESCRIPTION
From local testing I don't think this can land as is because rust-protobuf includes serde_derive directly instead of using the derive feature of serde.

This is intended to resolve #544 and #526.