### PR TITLE
Dynamic Message improve

### DIFF
--- a/protobuf-codegen/src/customize.rs
+++ b/protobuf-codegen/src/customize.rs
@@ -35,6 +35,8 @@ pub struct Customize {
     /// Used internally to generate protos bundled in protobuf crate
     /// like `descriptor.proto`
     pub inside_protobuf: Option<bool>,
+    /// Generate file descriptor set for dynamic message and reflect
+    pub file_descriptor_set_out: Option<bool>,
 
     // When adding more options please keep in sync with `parse_from_parameter` below.
     /// Make sure `Customize` is always used with `..Default::default()`
@@ -87,6 +89,9 @@ impl Customize {
         if let Some(v) = that.inside_protobuf {
             self.inside_protobuf = Some(v);
         }
+        if let Some(v) = that.file_descriptor_set_out {
+            self.file_descriptor_set_out = Some(v);
+        }
     }
 
     /// Update unset fields of self with fields from other customize
@@ -135,6 +140,8 @@ impl Customize {
                 r.gen_mod_rs = Some(parse_bool(v)?);
             } else if n == "inside_protobuf" {
                 r.inside_protobuf = Some(parse_bool(v)?);
+            } else if n == "file_descriptor_set_out" {
+                r.file_descriptor_set_out = Some(parse_bool(v)?)
             } else {
                 return Err(CustomizeParseParameterError::UnknownOptionName(
                     n.to_owned(),
@@ -157,6 +164,7 @@ pub fn customize_from_rustproto_for_message(source: &MessageOptions) -> Customiz
     let lite_runtime = None;
     let gen_mod_rs = None;
     let inside_protobuf = None;
+    let file_descriptor_set_out = None;
     Customize {
         expose_oneof,
         expose_fields,
@@ -169,6 +177,7 @@ pub fn customize_from_rustproto_for_message(source: &MessageOptions) -> Customiz
         lite_runtime,
         gen_mod_rs,
         inside_protobuf,
+        file_descriptor_set_out,
         _future_options: (),
     }
 }
@@ -186,6 +195,7 @@ pub fn customize_from_rustproto_for_field(source: &FieldOptions) -> Customize {
     let lite_runtime = None;
     let gen_mod_rs = None;
     let inside_protobuf = None;
+    let file_descriptor_set_out = None;
     Customize {
         expose_oneof,
         expose_fields,
@@ -198,6 +208,7 @@ pub fn customize_from_rustproto_for_field(source: &FieldOptions) -> Customize {
         lite_runtime,
         gen_mod_rs,
         inside_protobuf,
+        file_descriptor_set_out,
         _future_options: (),
     }
 }
@@ -214,6 +225,7 @@ pub fn customize_from_rustproto_for_file(source: &FileOptions) -> Customize {
     let lite_runtime = rustproto::exts::lite_runtime_all.get(source);
     let gen_mod_rs = None;
     let inside_protobuf = None;
+    let file_descriptor_set_out = None;
     Customize {
         expose_oneof,
         expose_fields,
@@ -226,6 +238,7 @@ pub fn customize_from_rustproto_for_file(source: &FileOptions) -> Customize {
         lite_runtime,
         inside_protobuf,
         gen_mod_rs,
+        file_descriptor_set_out,
         _future_options: (),
     }
 }

--- a/protobuf/src/coded_input_stream.rs
+++ b/protobuf/src/coded_input_stream.rs
@@ -15,7 +15,7 @@ use crate::error::ProtobufResult;
 use crate::error::WireError;
 use crate::message::Message;
 use crate::unknown::UnknownValue;
-use crate::wire_format;
+use crate::{wire_format, MessageDyn};
 use crate::zigzag::decode_zig_zag_32;
 use crate::zigzag::decode_zig_zag_64;
 
@@ -605,10 +605,10 @@ impl<'a> CodedInputStream<'a> {
     }
 
     /// Read message, do not check if message is initialized
-    pub fn merge_message<M: Message>(&mut self, message: &mut M) -> ProtobufResult<()> {
+    pub fn merge_message(&mut self, message: &mut dyn MessageDyn) -> ProtobufResult<()> {
         let len = self.read_raw_varint64()?;
         let old_limit = self.push_limit(len)?;
-        message.merge_from(self)?;
+        message.merge_from_dyn(self)?;
         self.pop_limit(old_limit);
         Ok(())
     }

--- a/protobuf/src/coded_input_stream.rs
+++ b/protobuf/src/coded_input_stream.rs
@@ -605,7 +605,16 @@ impl<'a> CodedInputStream<'a> {
     }
 
     /// Read message, do not check if message is initialized
-    pub fn merge_message(&mut self, message: &mut dyn MessageDyn) -> ProtobufResult<()> {
+    pub fn merge_message<M: Message>(&mut self, message: &mut M) -> ProtobufResult<()> {
+        let len = self.read_raw_varint64()?;
+        let old_limit = self.push_limit(len)?;
+        message.merge_from(self)?;
+        self.pop_limit(old_limit);
+        Ok(())
+    }
+
+    /// Merge message
+    pub fn merge_message_dyn(&mut self, message: &mut dyn MessageDyn) -> ProtobufResult<()> {
         let len = self.read_raw_varint64()?;
         let old_limit = self.push_limit(len)?;
         message.merge_from_dyn(self)?;

--- a/protobuf/src/coded_input_stream.rs
+++ b/protobuf/src/coded_input_stream.rs
@@ -15,9 +15,9 @@ use crate::error::ProtobufResult;
 use crate::error::WireError;
 use crate::message::Message;
 use crate::unknown::UnknownValue;
-use crate::{wire_format, MessageDyn};
 use crate::zigzag::decode_zig_zag_32;
 use crate::zigzag::decode_zig_zag_64;
+use crate::{wire_format, MessageDyn};
 
 use crate::enums::ProtobufEnumOrUnknown;
 use crate::reflect::types::ProtobufType;

--- a/protobuf/src/coded_output_stream.rs
+++ b/protobuf/src/coded_output_stream.rs
@@ -1,6 +1,5 @@
 use crate::misc::remaining_capacity_as_slice_mut;
 use crate::misc::remove_lifetime_mut;
-use crate::{varint, MessageDyn};
 use crate::wire_format;
 use crate::zigzag::encode_zig_zag_32;
 use crate::zigzag::encode_zig_zag_64;
@@ -10,6 +9,7 @@ use crate::ProtobufEnumOrUnknown;
 use crate::ProtobufResult;
 use crate::UnknownFields;
 use crate::UnknownValueRef;
+use crate::{varint, MessageDyn};
 use std::io;
 use std::io::Write;
 
@@ -505,12 +505,12 @@ impl<'a> CodedOutputStream<'a> {
     pub fn write_message_no_tag<M: Message>(&mut self, msg: &M) -> ProtobufResult<()> {
         msg.write_length_delimited_to(self)
     }
-    
+
     /// Write dynamic message
-    pub fn write_message_no_tag_dyn(&mut self, msg: &dyn MessageDyn) -> ProtobufResult<()>{
+    pub fn write_message_no_tag_dyn(&mut self, msg: &dyn MessageDyn) -> ProtobufResult<()> {
         let size = msg.compute_size_dyn();
         self.write_raw_varint32(size)?;
-        msg.write_to_dyn(self)?;        
+        msg.write_to_dyn(self)?;
         Ok(())
     }
 
@@ -534,9 +534,13 @@ impl<'a> CodedOutputStream<'a> {
         self.write_message_no_tag(msg)?;
         Ok(())
     }
-    
+
     /// Write dynamic `message` field
-    pub fn write_message_dyn(&mut self, field_number: u32, msg: &dyn MessageDyn) -> ProtobufResult<()> {
+    pub fn write_message_dyn(
+        &mut self,
+        field_number: u32,
+        msg: &dyn MessageDyn,
+    ) -> ProtobufResult<()> {
         self.write_tag(field_number, wire_format::WireTypeLengthDelimited)?;
         self.write_message_no_tag_dyn(msg)?;
         Ok(())

--- a/protobuf/src/reflect/dynamic/mod.rs
+++ b/protobuf/src/reflect/dynamic/mod.rs
@@ -639,7 +639,7 @@ fn compute_singular_size(rtb: &RuntimeTypeBox, field_number: u32, v: &ReflectVal
         RuntimeTypeBox::Message(_) => {
             let msg_v = v.to_message().unwrap();
             let len = msg_v.compute_size_dyn();
-            1 + compute_raw_varint32_size(len) + len
+            tag_size(field_number) + compute_raw_varint32_size(len) + len
         }
     }
 }

--- a/protobuf/src/reflect/dynamic/mod.rs
+++ b/protobuf/src/reflect/dynamic/mod.rs
@@ -189,6 +189,10 @@ impl DynamicMessage {
     /// set all fields to default value
     pub fn set_fields_default(&mut self) {
         self.init_fields();
+        let syntax = self.descriptor.file_descriptor_proto().get_syntax();
+        if syntax != "proto3" {
+            return; // for proto2, default value is unset
+        }
         if !self.fields.is_empty() {
             for field_desc in self.descriptor.fields() {
                 self.fields[field_desc.index].set_default_for_merge(&field_desc);

--- a/protobuf/src/reflect/dynamic/mod.rs
+++ b/protobuf/src/reflect/dynamic/mod.rs
@@ -324,7 +324,7 @@ impl Message for DynamicMessage {
                         RuntimeTypeBox::Message(msg_desc) => {
                             let mut msg_inst = msg_desc.new_instance();
                             is.incr_recursion()?;
-                            is.merge_message(DynamicMessage::downcast_mut(msg_inst.as_mut()))?;
+                            is.merge_message_dyn(msg_inst.as_mut())?;
                             is.decr_recursion();
                             ReflectValueBox::from(msg_inst)
                         }
@@ -442,7 +442,7 @@ impl Message for DynamicMessage {
                         }
                         RuntimeTypeBox::Message(msg_desc) => {
                             let mut msg_inst = msg_desc.new_instance();
-                            is.merge_message(DynamicMessage::downcast_mut(msg_inst.as_mut()))?;
+                            is.merge_message_dyn(msg_inst.as_mut())?;
                             let msg_val = ReflectValueBox::from(msg_inst);
                             repeated_mut.push(msg_val);
                         }

--- a/protobuf/src/reflect/dynamic/mod.rs
+++ b/protobuf/src/reflect/dynamic/mod.rs
@@ -462,7 +462,7 @@ impl Message for DynamicMessage {
             match field_desc.runtime_field_type() {
                 RuntimeFieldType::Singular(rtb) => {
                     if let Some(v) = field_desc.get_singular(self) {
-                        if v._is_non_zero() {
+                        if v.is_non_zero() {
                             // ignore default value
                             singular_write_to(&rtb, field_number, &v, os)?;
                         }
@@ -491,7 +491,7 @@ impl Message for DynamicMessage {
             match field_desc.runtime_field_type() {
                 RuntimeFieldType::Singular(rtb) => {
                     if let Some(v) = field_desc.get_singular(self) {
-                        if v._is_non_zero() {
+                        if v.is_non_zero() {
                             // ignore default value
                             m_size += compute_singular_size(&rtb, field_number, &v);
                         }

--- a/protobuf/src/reflect/dynamic/mod.rs
+++ b/protobuf/src/reflect/dynamic/mod.rs
@@ -16,7 +16,7 @@ use crate::reflect::RuntimeFieldType;
 use crate::reflect::{FieldDescriptor, RuntimeTypeBox};
 use crate::reflect::{MessageDescriptor, ReflectValueRef};
 use crate::rt::{
-    bytes_size, compute_raw_varint32_size, string_size, unexpected_wire_type, value_size,
+    bytes_size, compute_raw_varint32_size, string_size, tag_size, unexpected_wire_type, value_size,
 };
 use crate::wire_format::WireType;
 use crate::Clear;
@@ -188,8 +188,7 @@ impl DynamicMessage {
     pub fn set_fields_default(&mut self) {
         self.init_fields();
         if !self.fields.is_empty() {
-            let fields_desc: Vec<FieldDescriptor> = self.descriptor.fields().collect();
-            for field_desc in fields_desc {
+            for field_desc in self.descriptor.fields() {
                 self.fields[field_desc.index].set_default_for_merge(&field_desc);
             }
         }
@@ -274,8 +273,7 @@ impl Message for DynamicMessage {
     }
 
     fn is_initialized(&self) -> bool {
-        let fields: Vec<FieldDescriptor> = self.descriptor.fields().collect();
-        for f in &fields {
+        for f in self.descriptor.fields() {
             match f.runtime_field_type() {
                 RuntimeFieldType::Singular(rtb) => {
                     if !self.check_singular_initialized(&rtb, &f) {
@@ -459,8 +457,7 @@ impl Message for DynamicMessage {
     }
 
     fn write_to_with_cached_sizes(&self, os: &mut CodedOutputStream) -> ProtobufResult<()> {
-        let fields: Vec<FieldDescriptor> = self.descriptor.fields().collect();
-        for field_desc in &fields {
+        for field_desc in self.descriptor.fields() {
             let field_number = field_desc.get_proto_num() as u32;
             match field_desc.runtime_field_type() {
                 RuntimeFieldType::Singular(rtb) => {
@@ -489,8 +486,7 @@ impl Message for DynamicMessage {
 
     fn compute_size(&self) -> u32 {
         let mut m_size = 0;
-        let fields: Vec<FieldDescriptor> = self.descriptor.fields().collect();
-        for field_desc in &fields {
+        for field_desc in self.descriptor.fields() {
             let field_number = field_desc.get_proto_num();
             match field_desc.runtime_field_type() {
                 RuntimeFieldType::Singular(rtb) => {

--- a/protobuf/src/reflect/dynamic/mod.rs
+++ b/protobuf/src/reflect/dynamic/mod.rs
@@ -324,8 +324,7 @@ impl Message for DynamicMessage {
                         RuntimeTypeBox::Message(msg_desc) => {
                             let mut msg_inst = msg_desc.new_instance();
                             is.incr_recursion()?;
-                            is.merge_message(msg_inst.as_mut())
-                                .expect("merge sub message failed");
+                            is.merge_message(DynamicMessage::downcast_mut(msg_inst.as_mut()))?;
                             is.decr_recursion();
                             ReflectValueBox::from(msg_inst)
                         }
@@ -443,8 +442,7 @@ impl Message for DynamicMessage {
                         }
                         RuntimeTypeBox::Message(msg_desc) => {
                             let mut msg_inst = msg_desc.new_instance();
-                            is.merge_message(msg_inst.as_mut())
-                                .expect("merge sub message failed");
+                            is.merge_message(DynamicMessage::downcast_mut(msg_inst.as_mut()))?;
                             let msg_val = ReflectValueBox::from(msg_inst);
                             repeated_mut.push(msg_val);
                         }

--- a/protobuf/src/reflect/dynamic/mod.rs
+++ b/protobuf/src/reflect/dynamic/mod.rs
@@ -293,7 +293,6 @@ impl Message for DynamicMessage {
                     self.set_field(&field_desc, val);
                 }
                 RuntimeFieldType::Repeated(rtb) => {
-                    println!("merging repeated {:?}", rtb);
                     let mut repeated_mut = self.mut_repeated(&field_desc);
 
                     match rtb {

--- a/protobuf/src/reflect/field/mod.rs
+++ b/protobuf/src/reflect/field/mod.rs
@@ -125,6 +125,11 @@ impl FieldDescriptor {
         &self.message_descriptor.get_index().fields[self.index]
     }
 
+    /// Get field_number defined in proto
+    pub(crate) fn get_proto_num(&self) -> u32 {
+        self.get_proto().get_number() as u32
+    }
+
     /// JSON field name.
     ///
     /// Can be different from `.proto` field name.

--- a/protobuf/src/reflect/value/value_ref.rs
+++ b/protobuf/src/reflect/value/value_ref.rs
@@ -146,6 +146,14 @@ impl<'a> ReflectValueRef<'a> {
         }
     }
 
+    /// Take enum value.
+    pub fn to_enum_value(&self) -> Option<i32> {
+        match *self {
+            ReflectValueRef::Enum(_, v) => Some(v),
+            _ => None
+        }
+    }
+
     /// Take message value.
     pub fn to_message(&self) -> Option<MessageRef<'a>> {
         match self {

--- a/protobuf/src/reflect/value/value_ref.rs
+++ b/protobuf/src/reflect/value/value_ref.rs
@@ -150,7 +150,7 @@ impl<'a> ReflectValueRef<'a> {
     pub fn to_enum_value(&self) -> Option<i32> {
         match *self {
             ReflectValueRef::Enum(_, v) => Some(v),
-            _ => None
+            _ => None,
         }
     }
 

--- a/protobuf/src/reflect/value/value_ref.rs
+++ b/protobuf/src/reflect/value/value_ref.rs
@@ -58,7 +58,7 @@ impl<'a> ReflectValueRef<'a> {
     }
 
     /// Value is "non-zero"?
-    pub(crate) fn _is_non_zero(&self) -> bool {
+    pub(crate) fn is_non_zero(&self) -> bool {
         match self {
             ReflectValueRef::U32(v) => *v != 0,
             ReflectValueRef::U64(v) => *v != 0,

--- a/protobuf/src/reflect/value/value_ref.rs
+++ b/protobuf/src/reflect/value/value_ref.rs
@@ -58,7 +58,7 @@ impl<'a> ReflectValueRef<'a> {
     }
 
     /// Value is "non-zero"?
-    fn _is_non_zero(&self) -> bool {
+    pub(crate) fn _is_non_zero(&self) -> bool {
         match self {
             ReflectValueRef::U32(v) => *v != 0,
             ReflectValueRef::U64(v) => *v != 0,

--- a/protoc-rust/src/lib.rs
+++ b/protoc-rust/src/lib.rs
@@ -149,7 +149,12 @@ impl Codegen {
         protoc.check()?;
 
         let temp_dir = tempfile::Builder::new().prefix("protoc-rust").tempdir()?;
-        let temp_file = temp_dir.path().join("descriptor.pbbin");
+        let temp_path = if self.customize.file_descriptor_set_out.unwrap_or(false) {
+            &self.out_dir
+        } else {
+            temp_dir.path()
+        };
+        let temp_file = temp_path.join("descriptor.pbbin");
 
         protoc
             .descriptor_set_out_args()


### PR DESCRIPTION
Greetings!

We are really glad to see that Dynamic Message has taken shape in version 3.0. As we are working on a project heavily depends on this feature, we have improved some parts based on the existing framework.

Mainly, changes are:
- [protoc-rust] Add a customize option to dump the FileDescriptorSet `pbbin` file into output directory
- [protobuf] Implement Message trait for DynamicMessage

Mainly missing parts are:
- lack of unknown field support
- no Map field support
- lack of WireType check