### PR TITLE
Allow leading zeros in JSON scientific notation

### DIFF
--- a/protobuf/src/text_format/lexer/lexer_impl.rs
+++ b/protobuf/src/text_format/lexer/lexer_impl.rs
@@ -605,7 +605,7 @@ impl<'a> Lexer<'a> {
             if let Some(c) = self.next_char_if_in("+-") {
                 s.push(c);
             }
-            s.push(self.next_char_expect(is_digit_1_9, LexerError::IncorrectJsonNumber)?);
+            s.push(self.next_char_expect(is_digit, LexerError::IncorrectJsonNumber)?);
             while let Some(c) = self.next_char_if(is_digit) {
                 s.push(c);
             }


### PR DESCRIPTION
I encountered a JSON file in the wild I couldn't parse using the JSON module, because it had a number with an exponent with a leading zero. According to https://stackoverflow.com/questions/19554972/json-standard-floating-point-numbers this should be allowed.