### PR TITLE
Remove "master only" comment in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -120,9 +120,6 @@ from `Bytes` object, fields of these types get subslices of original `Bytes` obj
 instead of being allocated on heap.
 
 ## serde_derive support
-
-(Only in master, not released yet)
-
 Rust-protobuf can be used with [serde](https://github.com/serde-rs/serde).
 
 To enable `serde` you need to:


### PR DESCRIPTION
This feature has been released just looking at 2.25.2, this removes any potential confusion, just speaking for myself, I was almost going to not use it because of reading that this support was not available in a release.