### PR TITLE
Adds serde_rename_all extension to enum options

### DIFF
--- a/proto/rustproto.proto
+++ b/proto/rustproto.proto
@@ -64,3 +64,8 @@ extend google.protobuf.FieldOptions {
     // Use `bytes::Bytes` for `string` fields
     optional bool carllerche_bytes_for_string_field = 17012;
 }
+
+extend google.protobuf.EnumOptions {
+    // use rename_all attribute for serde
+    optional string serde_rename_all = 17032;
+}

--- a/protobuf-codegen/src/customize.rs
+++ b/protobuf-codegen/src/customize.rs
@@ -1,6 +1,7 @@
 use protobuf::descriptor::FieldOptions;
 use protobuf::descriptor::FileOptions;
 use protobuf::descriptor::MessageOptions;
+use protobuf::descriptor::EnumOptions;
 use protobuf::rustproto;
 
 /// Specifies style of generated code.
@@ -24,6 +25,8 @@ pub struct Customize {
     pub serde_derive: Option<bool>,
     /// When `serde_derive` is set, serde annotations will be guarded with `#[cfg(cfg, ...)]`.
     pub serde_derive_cfg: Option<String>,
+    /// When `serde_derive` is set, use attribute rename_all
+    pub serde_rename_all: Option<String>,
     /// Enable lite runtime
     pub lite_runtime: Option<bool>,
     /// Generate `mod.rs` in the output directory.
@@ -78,6 +81,9 @@ impl Customize {
         if let Some(ref v) = that.serde_derive_cfg {
             self.serde_derive_cfg = Some(v.clone());
         }
+        if let Some(ref v) = that.serde_rename_all {
+            self.serde_rename_all = Some(v.clone());
+        }
         if let Some(v) = that.lite_runtime {
             self.lite_runtime = Some(v);
         }
@@ -129,6 +135,8 @@ impl Customize {
                 r.serde_derive = Some(parse_bool(v)?);
             } else if n == "serde_derive_cfg" {
                 r.serde_derive_cfg = Some(v.to_owned());
+            } else if n == "serde_rename_all" {
+                r.serde_rename_all = Some(v.to_owned());
             } else if n == "lite_runtime" {
                 r.lite_runtime = Some(parse_bool(v)?);
             } else if n == "gen_mod_rs" {
@@ -157,6 +165,7 @@ pub fn customize_from_rustproto_for_message(source: &MessageOptions) -> Customiz
     let lite_runtime = None;
     let gen_mod_rs = None;
     let inside_protobuf = None;
+    let serde_rename_all = None;
     Customize {
         expose_oneof,
         expose_fields,
@@ -166,11 +175,19 @@ pub fn customize_from_rustproto_for_message(source: &MessageOptions) -> Customiz
         carllerche_bytes_for_string,
         serde_derive,
         serde_derive_cfg,
+        serde_rename_all,
         lite_runtime,
         gen_mod_rs,
         inside_protobuf,
         _future_options: (),
     }
+}
+
+pub fn customize_from_rustproto_for_enum(source: &EnumOptions) -> Customize {
+    let serde_rename_all = rustproto::exts::serde_rename_all.get(source);
+    let mut r = Customize::default();
+    r.serde_rename_all = serde_rename_all;
+    return r;
 }
 
 pub fn customize_from_rustproto_for_field(source: &FieldOptions) -> Customize {
@@ -181,6 +198,7 @@ pub fn customize_from_rustproto_for_field(source: &FieldOptions) -> Customize {
     let carllerche_bytes_for_bytes = rustproto::exts::carllerche_bytes_for_bytes_field.get(source);
     let carllerche_bytes_for_string =
         rustproto::exts::carllerche_bytes_for_string_field.get(source);
+    let serde_rename_all = None;
     let serde_derive = None;
     let serde_derive_cfg = None;
     let lite_runtime = None;
@@ -195,6 +213,7 @@ pub fn customize_from_rustproto_for_field(source: &FieldOptions) -> Customize {
         carllerche_bytes_for_string,
         serde_derive,
         serde_derive_cfg,
+        serde_rename_all,
         lite_runtime,
         gen_mod_rs,
         inside_protobuf,
@@ -214,6 +233,7 @@ pub fn customize_from_rustproto_for_file(source: &FileOptions) -> Customize {
     let lite_runtime = rustproto::exts::lite_runtime_all.get(source);
     let gen_mod_rs = None;
     let inside_protobuf = None;
+    let serde_rename_all = None;
     Customize {
         expose_oneof,
         expose_fields,
@@ -223,6 +243,7 @@ pub fn customize_from_rustproto_for_file(source: &FileOptions) -> Customize {
         carllerche_bytes_for_string,
         serde_derive,
         serde_derive_cfg,
+        serde_rename_all,
         lite_runtime,
         inside_protobuf,
         gen_mod_rs,

--- a/protobuf-parse/src/proto/rustproto.proto
+++ b/protobuf-parse/src/proto/rustproto.proto
@@ -64,3 +64,8 @@ extend google.protobuf.FieldOptions {
     // Use `bytes::Bytes` for `string` fields
     optional bool carllerche_bytes_for_string_field = 17012;
 }
+
+extend google.protobuf.EnumOptions {
+    // use rename_all attribute for serde
+    optional string serde_rename_all = 17032;
+}

--- a/protobuf/src/rustproto.rs
+++ b/protobuf/src/rustproto.rs
@@ -58,6 +58,8 @@ pub mod exts {
 
     pub const serde_derive_cfg: crate::ext::ExtFieldOptional<crate::descriptor::MessageOptions, crate::reflect::types::ProtobufTypeString> = crate::ext::ExtFieldOptional { field_number: 17031, phantom: ::std::marker::PhantomData };
 
+    pub const serde_rename_all: crate::ext::ExtFieldOptional<crate::descriptor::EnumOptions, crate::reflect::types::ProtobufTypeString> = crate::ext::ExtFieldOptional { field_number: 17032, phantom: ::std::marker::PhantomData };
+
     pub const expose_fields_field: crate::ext::ExtFieldOptional<crate::descriptor::FieldOptions, crate::reflect::types::ProtobufTypeBool> = crate::ext::ExtFieldOptional { field_number: 17003, phantom: ::std::marker::PhantomData };
 
     pub const generate_accessors_field: crate::ext::ExtFieldOptional<crate::descriptor::FieldOptions, crate::reflect::types::ProtobufTypeBool> = crate::ext::ExtFieldOptional { field_number: 17004, phantom: ::std::marker::PhantomData };


### PR DESCRIPTION
so as to have serde's rename all for an Enum

Tested with 
```
    enum SigProto {
        option allow_alias = true;
        option (rustproto.serde_rename_all) = "kebab-case";
        ip = 0;
        pkthdr = 0;
        tcp = 1;
        tcp_pkt = 2;
        tcp_stream = 3;
        udp = 4;
        icmpv4 = 5;
        icmpv6 = 6;
        icmp = 7;
        sctp = 8;
        ipv4 = 9;
        ip4 = 9;
        ipv6 = 10;
        ip6 = 10;
        http = 11;
        http1 = 12;
        http2 = 13;
        ftp = 14;
        ftp_data = 15;
        tftp = 16;
        smtp = 17;
        tls = 18;
        ssh = 19;
        imap = 20;
        jabber = 21;
        smb = 22;
        dcerpc = 23;
        irc = 24;
        dns = 25;
        modbus = 26;
        enip = 27;
        dnp3 = 28;
        nfs = 29;
        ntp = 30;
        ike = 31;
        krb5 = 32;
        dhcp = 33;
        snmp = 34;
        sip = 35;
        rfb = 36;
        mqtt = 37;
        template = 38;
        template_rust = 39;
        rdp = 40;
      }
```