### PR TITLE
Fix invalid aliasing and uninint memory in streams

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -276,6 +276,7 @@ jobs:
         env:
             RUST_BACKTRACE: 1
             RUST_TEST_THREADS: 1
+            MIRIFLAGS: -Zmiri-tag-raw-pointers
         steps:
             - name: Checkout sources
               uses: actions/checkout@v2

--- a/ci-gen/src/main.rs
+++ b/ci-gen/src/main.rs
@@ -186,6 +186,7 @@ fn miri_test_job() -> Job {
     let env = vec![
         ("RUST_BACKTRACE".to_owned(), "1".to_owned()),
         ("RUST_TEST_THREADS".to_owned(), "1".to_owned()),
+        ("MIRIFLAGS".to_owned(), "-Zmiri-tag-raw-pointers".to_owned()),
     ];
     Job {
         id,

--- a/protobuf/src/buf_read_iter.rs
+++ b/protobuf/src/buf_read_iter.rs
@@ -455,6 +455,7 @@ mod test_bytes {
     }
 
     #[test]
+    #[cfg_attr(miri, ignore)] // bytes violates SB, see https://github.com/tokio-rs/bytes/issues/522
     fn read_exact_bytes_from_slice() {
         let bytes = make_long_string(100);
         let mut bri = BufReadIter::from_byte_slice(&bytes[..]);
@@ -463,6 +464,7 @@ mod test_bytes {
     }
 
     #[test]
+    #[cfg_attr(miri, ignore)] // bytes violates SB, see https://github.com/tokio-rs/bytes/issues/522
     fn read_exact_bytes_from_bytes() {
         let bytes = Bytes::from(make_long_string(100));
         let mut bri = BufReadIter::from_bytes(&bytes);

--- a/protobuf/src/chars.rs
+++ b/protobuf/src/chars.rs
@@ -103,6 +103,7 @@ mod test {
     use super::Chars;
 
     #[test]
+    #[cfg_attr(miri, ignore)] // bytes violates SB, see https://github.com/tokio-rs/bytes/issues/522
     fn test_display_and_debug() {
         let s = "test";
         let string: String = s.into();

--- a/protobuf/src/varint.rs
+++ b/protobuf/src/varint.rs
@@ -1,16 +1,18 @@
+use std::mem::MaybeUninit;
+
 /// Encode u64 as varint.
 /// Panics if buffer length is less than 10.
 #[inline]
-pub fn encode_varint64(mut value: u64, buf: &mut [u8]) -> usize {
+pub fn encode_varint64(mut value: u64, buf: &mut [MaybeUninit<u8>]) -> usize {
     assert!(buf.len() >= 10);
 
-    fn iter(value: &mut u64, byte: &mut u8) -> bool {
+    fn iter(value: &mut u64, byte: &mut MaybeUninit<u8>) -> bool {
         if (*value & !0x7F) > 0 {
-            *byte = ((*value & 0x7F) | 0x80) as u8;
+            byte.write(((*value & 0x7F) | 0x80) as u8);
             *value >>= 7;
             true
         } else {
-            *byte = *value as u8;
+            byte.write(*value as u8);
             false
         }
     }
@@ -45,23 +47,23 @@ pub fn encode_varint64(mut value: u64, buf: &mut [u8]) -> usize {
     if !iter(&mut value, &mut buf[8]) {
         return 9;
     };
-    buf[9] = value as u8;
+    buf[9].write(value as u8);
     10
 }
 
 /// Encode u32 value as varint.
 /// Panics if buffer length is less than 5.
 #[inline]
-pub fn encode_varint32(mut value: u32, buf: &mut [u8]) -> usize {
+pub fn encode_varint32(mut value: u32, buf: &mut [MaybeUninit<u8>]) -> usize {
     assert!(buf.len() >= 5);
 
-    fn iter(value: &mut u32, byte: &mut u8) -> bool {
+    fn iter(value: &mut u32, byte: &mut MaybeUninit<u8>) -> bool {
         if (*value & !0x7F) > 0 {
-            *byte = ((*value & 0x7F) | 0x80) as u8;
+            byte.write(((*value & 0x7F) | 0x80) as u8);
             *value >>= 7;
             true
         } else {
-            *byte = *value as u8;
+            byte.write(*value as u8);
             false
         }
     }
@@ -81,6 +83,6 @@ pub fn encode_varint32(mut value: u32, buf: &mut [u8]) -> usize {
     if !iter(&mut value, &mut buf[3]) {
         return 4;
     };
-    buf[4] = value as u8;
+    buf[4].write(value as u8);
     5
 }


### PR DESCRIPTION
In its current state, running `cargo miri test` on this codebase flags a number of problems. This PR fixes all of those. It unfortunately does _not_ make `MIRIFLAGS="-Zmiri-tag-raw-pointers" cargo miri test` pass completely, because `bytes` has a soundness problem which I've also put up a PR to address, and is in another aspect unanalyzable (currently?) for miri.

Using `remove_lifetime_mut` to construct then hold on to both a `Vec` and a mutable slice into it violates the existing Rust aliasing rules in this particular usage pattern, because both `&mut` and `Unique<T>` (which is used to implement `Vec`) assert unique access to their contents. Though at the moment Stacked Borrows is experimental, the aforementioned properties are already relied upon by rustc, because it emits the LLVM `noalias` attribute for these types.

The only sound way to get write access beyond the end of a `Vec` is to offset a pointer from the `Vec`, and access the data either through a raw pointer or as a reference to `MaybeUninit<T>` because slices require that their contents must be properly initialized. Additionally, this access cannot be done through `get_unchecked_mut` because that method comes from the `Deref` impl on `Vec`, so it is a precondition violation to use that method to access between `len` and `capacity`.

I've tried to be somewhat surgical in what I'm changing here. Sometimes unsound constructs are used because they look simpler, so please do let me know if I should adapt the code to accomodate the valid implementation technique(s).