### PR TITLE
Signal that plugin supports proto3 optionals

### DIFF
--- a/protobuf-codegen/src/compiler_plugin.rs
+++ b/protobuf-codegen/src/compiler_plugin.rs
@@ -33,6 +33,7 @@ where
         parameter: req.parameter(),
     })?;
     let mut resp = CodeGeneratorResponse::new();
+    resp.set_supported_features(code_generator_response::Feature::FEATURE_PROTO3_OPTIONAL as u64);
     resp.file = result
         .iter()
         .map(|file| {


### PR DESCRIPTION
fixes https://github.com/stepancheg/rust-protobuf/issues/625

Not sure how to go about adding a test. If a test is needed I'll need some pointers.

Tested this locally via `cargo install --path .` and then running against a protobuf definition containing an optional field via `protoc --rust_out=out test.proto` where test.proto contained:
```proto
syntax = "proto3";

message Test {
  optional string value = 1;
}
```

The generated code includes the following (note the optional field):
```rust
pub struct Test {
    // message fields
    // @@protoc_insertion_point(field:Test.value)
    pub value: ::std::option::Option<::std::string::String>,
    // special fields
    // @@protoc_insertion_point(special_field:Test.special_fields)
    pub special_fields: ::protobuf::SpecialFields,
}
```