### PR TITLE
Signal proto3 optional fields supporting for 2.27

### DIFF
--- a/protobuf/src/compiler_plugin.rs
+++ b/protobuf/src/compiler_plugin.rs
@@ -38,6 +38,7 @@ where
         parameter: req.get_parameter(),
     });
     let mut resp = CodeGeneratorResponse::new();
+    resp.set_supported_features(CodeGeneratorResponse_Feature::FEATURE_PROTO3_OPTIONAL as u64);
     resp.set_file(
         result
             .iter()


### PR DESCRIPTION
It's a backport of #626

fixes #625 

Tested this locally via `cargo install --force --path .` and then running against a protobuf definition containing an optional field via `protoc --rust_out=. test.proto` where `test.proto` contained:

```
syntax = "proto3";

message Test {
  optional string value = 1;
}
```

The generated code includes the following (note the optional field):
```
#[derive(PartialEq,Clone,Default)]
pub struct Test {
    // message oneof groups
    pub _value: ::std::option::Option<Test_oneof__value>,
    // special fields
    pub unknown_fields: ::protobuf::UnknownFields,
    pub cached_size: ::protobuf::CachedSize,
}

#[derive(Clone,PartialEq,Debug)]
pub enum Test_oneof__value {
    value(::std::string::String),
}
```