### PR TITLE
Select log version 0.4

### DIFF
--- a/protobuf-parse/Cargo.toml
+++ b/protobuf-parse/Cargo.toml
@@ -16,7 +16,7 @@ Files are parsed into a `protobuf::descriptor::FileDescriptorSet` object using e
 
 [dependencies]
 tempfile  = "3.2.0"
-log       = "0.*"
+log       = "0.4"
 which     = "4.0"
 anyhow    = "1.0.53"
 thiserror = "1.0.30"

--- a/test-crates/protobuf-codegen-protoc-test/Cargo.toml
+++ b/test-crates/protobuf-codegen-protoc-test/Cargo.toml
@@ -17,7 +17,7 @@ with-bytes = ["bytes", "protobuf/with-bytes", "protobuf-test-common/with-bytes"]
 
 [build-dependencies]
 glob        = "0.2"
-log         = "0.*"
+log         = "0.4"
 env_logger  = "0.5.*"
 
 protoc-bin-vendored = "=3.0.0"

--- a/test-crates/protobuf-codegen-pure-test/Cargo.toml
+++ b/test-crates/protobuf-codegen-pure-test/Cargo.toml
@@ -19,7 +19,7 @@ with-bytes = ["bytes", "protobuf/with-bytes", "protobuf-test-common/with-bytes"]
 protobuf-codegen = { path = "../../protobuf-codegen" }
 protobuf-test-common = { path = "../../test-crates/protobuf-test-common" }
 glob        = "0.2"
-log         = "0.*"
+log         = "0.4"
 env_logger  = "0.5.*"
 
 [dependencies]

--- a/test-crates/protobuf-fuzz/Cargo.toml
+++ b/test-crates/protobuf-fuzz/Cargo.toml
@@ -17,7 +17,7 @@ with-bytes = ["bytes", "protobuf/with-bytes", "protobuf-test-common/with-bytes"]
 protobuf-codegen = { path = "../../protobuf-codegen" }
 protobuf-test-common = { path = "../../test-crates/protobuf-test-common" }
 glob        = "0.2"
-log         = "0.*"
+log         = "0.4"
 env_logger  = "0.5.*"
 
 [dependencies]

--- a/test-crates/protobuf-test-common/Cargo.toml
+++ b/test-crates/protobuf-test-common/Cargo.toml
@@ -20,7 +20,7 @@ with-bytes = ["bytes", "protobuf/with-bytes"]
 [dependencies]
 anyhow    = "1.0.53"
 glob         = "0.2"
-log          = "0.*"
+log          = "0.4"
 env_logger   = "0.5.*"
 tempfile     = "3.0"
 bytes = { version = "1.1", optional = true }


### PR DESCRIPTION
`0.*` is essentially the same as `*` since `0.1`, `0.2`, etc. do not have to have a compatible API. Every other crate using logging depends on `0.4`. Do the same here for consistency.

Using `0.*` is also incompatible with `-Z minimal-versions` because it selects `0.1` which does not compile with any post 1.0 rust compiler.