### PR TITLE
MessageDyn: Do not omit zero values on fields containing oneof

### DIFF
--- a/protobuf/src/reflect/dynamic/mod.rs
+++ b/protobuf/src/reflect/dynamic/mod.rs
@@ -229,7 +229,7 @@ impl DynamicMessage {
                 RuntimeFieldType::Singular(..) => {
                     if let Some(v) = field_desc.get_singular(self) {
                         // Ignore default value for proto3.
-                        if !is_proto3 || v.is_non_zero() {
+                        if !is_proto3 || v.is_non_zero() || field_desc.containing_oneof() {
                             handler.field(field_desc.proto().type_(), field_number, &v)?;
                         }
                     }


### PR DESCRIPTION
Omitting zeros on singular fields only make sense if it's not in oneof
For example, omitting zero on the following oneof will make it ambiguous
```proto
oneof int_or_string {
  int32 int = 1;
  string str = 1;
}
```

if either int or str is zero, both of the fields will be missing.
Now it's not possible to know which field was originally filled