### PR TITLE
Add supports of conversion between string and enum

### DIFF
--- a/protobuf-codegen/src/gen/enums.rs
+++ b/protobuf-codegen/src/gen/enums.rs
@@ -245,6 +245,28 @@ impl<'a> EnumGen<'a> {
         );
     }
 
+    fn write_impl_enum_fn_from_str(&self, w: &mut CodeWriter) {
+        w.def_fn(
+            &format!(
+                "from_str(str: &str) -> ::std::option::Option<{}>",
+                self.type_name
+            ),
+            |w| {
+                w.match_expr("str", |w| {
+                    let values = self.values_unique();
+                    for value in values {
+                        w.write_line(&format!(
+                            "stringify!({}) => ::std::option::Option::Some({}),",
+                            value.rust_name_inner(),
+                            value.rust_name_outer()
+                        ));
+                    }
+                    w.write_line(&format!("_ => {}", EXPR_NONE));
+                });
+            },
+        );
+    }
+
     fn write_impl_enum_const_values(&self, w: &mut CodeWriter) {
         w.write_line(&format!("const VALUES: &'static [{}] = &[", self.type_name));
         w.indented(|w| {
@@ -265,6 +287,8 @@ impl<'a> EnumGen<'a> {
                 self.write_impl_enum_fn_value(w);
                 w.write_line("");
                 self.write_impl_enum_fn_from_i32(w);
+                w.write_line("");
+                self.write_impl_enum_fn_from_str(w);
                 w.write_line("");
                 self.write_impl_enum_const_values(w);
             },

--- a/protobuf-codegen/src/gen/enums.rs
+++ b/protobuf-codegen/src/gen/enums.rs
@@ -139,6 +139,8 @@ impl<'a> EnumGen<'a> {
         w.write_line("");
         self.write_impl_default(w);
         w.write_line("");
+        self.write_impl_display(w);
+        w.write_line("");
         self.write_impl_self(w);
     }
 
@@ -409,5 +411,14 @@ impl<'a> EnumGen<'a> {
                 });
             },
         );
+    }
+
+    fn write_impl_display(&self, w: &mut CodeWriter) {
+        w.impl_for_block("::std::fmt::Display", &format!("{}", self.type_name), |w| {
+            w.def_fn(
+                "fmt(&self, f: &mut ::std::fmt::Formatter) -> ::std::fmt::Result",
+                |w| w.write_line(&format!("::std::fmt::Debug::fmt(self, f)")),
+            )
+        })
     }
 }

--- a/protobuf/src/descriptor.rs
+++ b/protobuf/src/descriptor.rs
@@ -2223,6 +2223,30 @@ pub mod field_descriptor_proto {
                 _ => ::std::option::Option::None
             }
         }
+        
+        fn from_str(str: &str) -> ::std::option::Option<Type> {
+            match str {
+                stringify!(TYPE_DOUBLE) => ::std::option::Option::Some(Type::TYPE_DOUBLE),
+                stringify!(TYPE_FLOAT) => ::std::option::Option::Some(Type::TYPE_FLOAT),
+                stringify!(TYPE_INT64) => ::std::option::Option::Some(Type::TYPE_INT64),
+                stringify!(TYPE_UINT64) => ::std::option::Option::Some(Type::TYPE_UINT64),
+                stringify!(TYPE_INT32) => ::std::option::Option::Some(Type::TYPE_INT32),
+                stringify!(TYPE_FIXED64) => ::std::option::Option::Some(Type::TYPE_FIXED64),
+                stringify!(TYPE_FIXED32) => ::std::option::Option::Some(Type::TYPE_FIXED32),
+                stringify!(TYPE_BOOL) => ::std::option::Option::Some(Type::TYPE_BOOL),
+                stringify!(TYPE_STRING) => ::std::option::Option::Some(Type::TYPE_STRING),
+                stringify!(TYPE_GROUP) => ::std::option::Option::Some(Type::TYPE_GROUP),
+                stringify!(TYPE_MESSAGE) => ::std::option::Option::Some(Type::TYPE_MESSAGE),
+                stringify!(TYPE_BYTES) => ::std::option::Option::Some(Type::TYPE_BYTES),
+                stringify!(TYPE_UINT32) => ::std::option::Option::Some(Type::TYPE_UINT32),
+                stringify!(TYPE_ENUM) => ::std::option::Option::Some(Type::TYPE_ENUM),
+                stringify!(TYPE_SFIXED32) => ::std::option::Option::Some(Type::TYPE_SFIXED32),
+                stringify!(TYPE_SFIXED64) => ::std::option::Option::Some(Type::TYPE_SFIXED64),
+                stringify!(TYPE_SINT32) => ::std::option::Option::Some(Type::TYPE_SINT32),
+                stringify!(TYPE_SINT64) => ::std::option::Option::Some(Type::TYPE_SINT64),
+                _ => ::std::option::Option::None
+            }
+        }
 
         const VALUES: &'static [Type] = &[
             Type::TYPE_DOUBLE,
@@ -2313,6 +2337,15 @@ pub mod field_descriptor_proto {
                 1 => ::std::option::Option::Some(Label::LABEL_OPTIONAL),
                 2 => ::std::option::Option::Some(Label::LABEL_REQUIRED),
                 3 => ::std::option::Option::Some(Label::LABEL_REPEATED),
+                _ => ::std::option::Option::None
+            }
+        }
+
+        fn from_str(str: &str) -> ::std::option::Option<Label> {
+            match str {
+                stringify!(LABEL_OPTIONAL) => ::std::option::Option::Some(Label::LABEL_OPTIONAL),
+                stringify!(LABEL_REQUIRED) => ::std::option::Option::Some(Label::LABEL_REQUIRED),
+                stringify!(LABEL_REPEATED) => ::std::option::Option::Some(Label::LABEL_REPEATED),
                 _ => ::std::option::Option::None
             }
         }
@@ -4908,6 +4941,15 @@ pub mod file_options {
             }
         }
 
+        fn from_str(str: &str) -> ::std::option::Option<OptimizeMode> {
+            match str {
+                stringify!(SPEED) => ::std::option::Option::Some(OptimizeMode::SPEED),
+                stringify!(CODE_SIZE) => ::std::option::Option::Some(OptimizeMode::CODE_SIZE),
+                stringify!(LITE_RUNTIME) => ::std::option::Option::Some(OptimizeMode::LITE_RUNTIME),
+                _ => ::std::option::Option::None
+            }
+        }
+
         const VALUES: &'static [OptimizeMode] = &[
             OptimizeMode::SPEED,
             OptimizeMode::CODE_SIZE,
@@ -5668,6 +5710,15 @@ pub mod field_options {
             }
         }
 
+        fn from_str(str: &str) -> ::std::option::Option<CType> {
+            match str {
+                stringify!(STRING) => ::std::option::Option::Some(CType::STRING),
+                stringify!(CORD) => ::std::option::Option::Some(CType::CORD),
+                stringify!(STRING_PIECE) => ::std::option::Option::Some(CType::STRING_PIECE),
+                _ => ::std::option::Option::None
+            }
+        }
+
         const VALUES: &'static [CType] = &[
             CType::STRING,
             CType::CORD,
@@ -5722,6 +5773,15 @@ pub mod field_options {
                 0 => ::std::option::Option::Some(JSType::JS_NORMAL),
                 1 => ::std::option::Option::Some(JSType::JS_STRING),
                 2 => ::std::option::Option::Some(JSType::JS_NUMBER),
+                _ => ::std::option::Option::None
+            }
+        }
+
+        fn from_str(str: &str) -> ::std::option::Option<JSType> {
+            match str {
+                stringify!(JS_NORMAL) => ::std::option::Option::Some(JSType::JS_NORMAL),
+                stringify!(JS_STRING) => ::std::option::Option::Some(JSType::JS_STRING),
+                stringify!(JS_NUMBER) => ::std::option::Option::Some(JSType::JS_NUMBER),
                 _ => ::std::option::Option::None
             }
         }
@@ -6674,6 +6734,15 @@ pub mod method_options {
                 0 => ::std::option::Option::Some(IdempotencyLevel::IDEMPOTENCY_UNKNOWN),
                 1 => ::std::option::Option::Some(IdempotencyLevel::NO_SIDE_EFFECTS),
                 2 => ::std::option::Option::Some(IdempotencyLevel::IDEMPOTENT),
+                _ => ::std::option::Option::None
+            }
+        }
+
+        fn from_str(str: &str) -> ::std::option::Option<IdempotencyLevel> {
+            match str {
+                stringify!(IDEMPOTENCY_UNKNOWN) => ::std::option::Option::Some(IdempotencyLevel::IDEMPOTENCY_UNKNOWN),
+                stringify!(NO_SIDE_EFFECTS) => ::std::option::Option::Some(IdempotencyLevel::NO_SIDE_EFFECTS),
+                stringify!(IDEMPOTENT) => ::std::option::Option::Some(IdempotencyLevel::IDEMPOTENT),
                 _ => ::std::option::Option::None
             }
         }

--- a/protobuf/src/enums.rs
+++ b/protobuf/src/enums.rs
@@ -19,6 +19,10 @@ pub trait Enum: Eq + Sized + Copy + fmt::Debug + Default + Send + Sync + 'static
     /// Return `None` if value is unknown.
     fn from_i32(v: i32) -> Option<Self>;
 
+    /// Try to create an enum from `&str` value.
+    /// Return `None` if str is unknown.
+    fn from_str(s: &str) -> Option<Self>;
+
     /// All enum values for enum type.
     const VALUES: &'static [Self] = &[];
 }

--- a/protobuf/src/plugin.rs
+++ b/protobuf/src/plugin.rs
@@ -1127,6 +1127,14 @@ pub mod code_generator_response {
             }
         }
 
+        fn from_str(str: &str) -> ::std::option::Option<Feature> {
+            match str {
+                stringify!(FEATURE_NONE) => ::std::option::Option::Some(Feature::FEATURE_NONE),
+                stringify!(FEATURE_PROTO3_OPTIONAL) => ::std::option::Option::Some(Feature::FEATURE_PROTO3_OPTIONAL),
+                _ => ::std::option::Option::None
+            }
+        }
+
         const VALUES: &'static [Feature] = &[
             Feature::FEATURE_NONE,
             Feature::FEATURE_PROTO3_OPTIONAL,

--- a/protobuf/src/well_known_types/struct_.rs
+++ b/protobuf/src/well_known_types/struct_.rs
@@ -810,6 +810,13 @@ impl crate::Enum for NullValue {
         }
     }
 
+    fn from_str(str: &str) -> ::std::option::Option<NullValue> {
+        match str {
+            stringify!(NULL_VALUE) => ::std::option::Option::Some(NullValue::NULL_VALUE),
+            _ => ::std::option::Option::None
+        }
+    }
+
     const VALUES: &'static [NullValue] = &[
         NullValue::NULL_VALUE,
     ];

--- a/protobuf/src/well_known_types/type_.rs
+++ b/protobuf/src/well_known_types/type_.rs
@@ -619,6 +619,31 @@ pub mod field {
             }
         }
 
+        fn from_str(str: &str) -> ::std::option::Option<Kind> {
+            match str {
+                stringify!(TYPE_UNKNOWN) => ::std::option::Option::Some(Kind::TYPE_UNKNOWN),
+                stringify!(TYPE_DOUBLE) => ::std::option::Option::Some(Kind::TYPE_DOUBLE),
+                stringify!(TYPE_FLOAT) => ::std::option::Option::Some(Kind::TYPE_FLOAT),
+                stringify!(TYPE_INT64) => ::std::option::Option::Some(Kind::TYPE_INT64),
+                stringify!(TYPE_UINT64) => ::std::option::Option::Some(Kind::TYPE_UINT64),
+                stringify!(TYPE_INT32) => ::std::option::Option::Some(Kind::TYPE_INT32),
+                stringify!(TYPE_FIXED64) => ::std::option::Option::Some(Kind::TYPE_FIXED64),
+                stringify!(TYPE_FIXED32) => ::std::option::Option::Some(Kind::TYPE_FIXED32),
+                stringify!(TYPE_BOOL) => ::std::option::Option::Some(Kind::TYPE_BOOL),
+                stringify!(TYPE_STRING) => ::std::option::Option::Some(Kind::TYPE_STRING),
+                stringify!(TYPE_GROUP) => ::std::option::Option::Some(Kind::TYPE_GROUP),
+                stringify!(TYPE_MESSAGE) => ::std::option::Option::Some(Kind::TYPE_MESSAGE),
+                stringify!(TYPE_BYTES) => ::std::option::Option::Some(Kind::TYPE_BYTES),
+                stringify!(TYPE_UINT32) => ::std::option::Option::Some(Kind::TYPE_UINT32),
+                stringify!(TYPE_ENUM) => ::std::option::Option::Some(Kind::TYPE_ENUM),
+                stringify!(TYPE_SFIXED32) => ::std::option::Option::Some(Kind::TYPE_SFIXED32),
+                stringify!(TYPE_SFIXED64) => ::std::option::Option::Some(Kind::TYPE_SFIXED64),
+                stringify!(TYPE_SINT32) => ::std::option::Option::Some(Kind::TYPE_SINT32),
+                stringify!(TYPE_SINT64) => ::std::option::Option::Some(Kind::TYPE_SINT64),
+                _ => ::std::option::Option::None
+            }
+        }
+
         const VALUES: &'static [Kind] = &[
             Kind::TYPE_UNKNOWN,
             Kind::TYPE_DOUBLE,
@@ -693,6 +718,16 @@ pub mod field {
                 1 => ::std::option::Option::Some(Cardinality::CARDINALITY_OPTIONAL),
                 2 => ::std::option::Option::Some(Cardinality::CARDINALITY_REQUIRED),
                 3 => ::std::option::Option::Some(Cardinality::CARDINALITY_REPEATED),
+                _ => ::std::option::Option::None
+            }
+        }
+
+        fn from_str(str: &str) -> ::std::option::Option<Cardinality> {
+            match str {
+                stringify!(CARDINALITY_UNKNOWN) => ::std::option::Option::Some(Cardinality::CARDINALITY_UNKNOWN),
+                stringify!(CARDINALITY_OPTIONAL) => ::std::option::Option::Some(Cardinality::CARDINALITY_OPTIONAL),
+                stringify!(CARDINALITY_REQUIRED) => ::std::option::Option::Some(Cardinality::CARDINALITY_REQUIRED),
+                stringify!(CARDINALITY_REPEATED) => ::std::option::Option::Some(Cardinality::CARDINALITY_REPEATED),
                 _ => ::std::option::Option::None
             }
         }
@@ -1268,6 +1303,14 @@ impl crate::Enum for Syntax {
         match value {
             0 => ::std::option::Option::Some(Syntax::SYNTAX_PROTO2),
             1 => ::std::option::Option::Some(Syntax::SYNTAX_PROTO3),
+            _ => ::std::option::Option::None
+        }
+    }
+
+    fn from_str(str: &str) -> ::std::option::Option<Syntax> {
+        match str {
+            stringify!(SYNTAX_PROTO2) => ::std::option::Option::Some(Syntax::SYNTAX_PROTO2),
+            stringify!(SYNTAX_PROTO3) => ::std::option::Option::Some(Syntax::SYNTAX_PROTO3),
             _ => ::std::option::Option::None
         }
     }


### PR DESCRIPTION
To support converting from &str to Enum and converting from Enum to String, add `from_str()` and implement `Display` for trait Enum respectively.