### PR TITLE
Add alternative protobuf source information

### DIFF
--- a/protobuf-codegen/src/lib.rs
+++ b/protobuf-codegen/src/lib.rs
@@ -31,7 +31,8 @@
 //! I never saw anyone using them, but you have been warned.
 //!
 //! Note `protoc` command can be obtained from
-//! [`protoc-bin-vendored`](https://docs.rs/protoc-bin-vendored) crate.
+//! [`protoc-bin-vendored`](https://docs.rs/protoc-bin-vendored) crate
+//! or [`protoc-prebuilt`](https://docs.rs/protoc-prebuilt) crate.
 //!
 //! # Example
 //!
@@ -41,12 +42,21 @@
 //! #       unimplemented!()
 //! #   }
 //! # }
+//! # mod protoc_prebuilt {
+//! #   pub fn init(
+//! #       version: &str
+//! #   ) -> Result<(std::path::PathBuf, std::path::PathBuf), std::io::Error> {
+//! #       unimplemented!()
+//! #   }
+//! # }
 //! // Use this in build.rs
 //! protobuf_codegen::Codegen::new()
 //!     // Use `protoc` parser, optional.
 //!     .protoc()
 //!     // Use `protoc-bin-vendored` bundled protoc command, optional.
 //!     .protoc_path(&protoc_bin_vendored::protoc_bin_path().unwrap())
+//!     // Or use `protoc-prebuilt` bundled protoc command, optional.
+//!     // .protoc_path(&protoc_prebuilt::init("22.0").unwrap().0)
 //!     // All inputs and imports from the inputs must reside in `includes` directories.
 //!     .includes(&["src/protos"])
 //!     // Inputs must reside in some of include paths.

--- a/protobuf/src/lib.rs
+++ b/protobuf/src/lib.rs
@@ -23,6 +23,8 @@
 //!   can be used to rust code from `.proto` crates.
 //! * [`protoc-bin-vendored`](https://docs.rs/protoc-bin-vendored)
 //!   contains `protoc` command packed into the crate.
+//! * [`protoc-prebuilt`](https://docs.rs/protoc-prebuilt)
+//!   can be used to install specified version of `protoc` pre-built binaries into the crate.
 //! * [`protobuf-parse`](https://docs.rs/protobuf-parse) contains
 //!   `.proto` file parser. Rarely need to be used directly,
 //!   but can be used for mechanical processing of `.proto` files.


### PR DESCRIPTION
I create crate which allow to install `protoc` pre-built binaries of required version from protobuf team. I add information about it to `protobuf` and `protobuf-codegen` crates documentation.