### PR TITLE
Fixes unnecessary copy of print_to_string_internal and incorrect prost link in readme.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ See [CHANGELOG.md](CHANGELOG.md) for a list of changes and compatility issues be
 
 ## Related projects
 
-* [prost](https://github.com/danburkert/prost) — another protobuf implementation in Rust, also has gRPC implementation
+* [prost](https://github.com/tokio-rs/prost) — another protobuf implementation in Rust, also has gRPC implementation
 * [quick-protobuf](https://github.com/tafia/quick-protobuf) — alternative protobuf implementation in Rust
 * [grpc-rs](https://github.com/pingcap/grpc-rs/) — another gRPC implementation for Rust
 * [grpc-rust](https://github.com/stepancheg/grpc-rust) — incomplete implementation of gRPC based on this library

--- a/protobuf/src/text_format/print.rs
+++ b/protobuf/src/text_format/print.rs
@@ -167,7 +167,7 @@ pub fn print_to(m: &dyn MessageDyn, buf: &mut String) {
 fn print_to_string_internal(m: &dyn MessageDyn, pretty: bool) -> String {
     let mut r = String::new();
     print_to_internal(&MessageRef::from(m), &mut r, pretty, 0);
-    r.to_string()
+    r
 }
 
 /// Text-format


### PR DESCRIPTION
@stepancheg Please kindly review.
fixes https://github.com/stepancheg/rust-protobuf/issues/680 
fixes https://github.com/stepancheg/rust-protobuf/issues/669 