### PR TITLE
WIP: Codegen option to create module hierarchy

### DIFF
--- a/protobuf-codegen/src/customize/mod.rs
+++ b/protobuf-codegen/src/customize/mod.rs
@@ -106,6 +106,9 @@ pub struct Customize {
     ///
     /// This option will likely be on by default in rust-protobuf version 3.
     pub(crate) gen_mod_rs: Option<bool>,
+    /// Generate `mod.rs` in a hierarchy in the output directory assuming that
+    /// this name is the crate-relative Rust path to the output directory.
+    pub(crate) gen_mod_rs_hierarchy_out_dir_mod_name: Option<String>,
     /// Used internally to generate protos bundled in protobuf crate
     /// like `descriptor.proto`
     pub(crate) inside_protobuf: Option<bool>,
@@ -165,6 +168,15 @@ impl Customize {
         self
     }
 
+    /// Generate `mod.rs` with all the generated modules in a Rust mod
+    /// hierarchy.
+    ///
+    /// This option is on by default in rust-protobuf version 3.
+    pub fn gen_mod_rs_hierarchy_out_dir_mod_name(mut self, gen_mod_rs_hierarchy_out_dir_mod_name: String) -> Self {
+        self.gen_mod_rs_hierarchy_out_dir_mod_name = Some(gen_mod_rs_hierarchy_out_dir_mod_name);
+        self
+    }
+
     /// Generate code bundled in protobuf crate. Regular users don't need this option.
     pub fn inside_protobuf(mut self, inside_protobuf: bool) -> Self {
         self.inside_protobuf = Some(inside_protobuf);
@@ -193,6 +205,9 @@ impl Customize {
         }
         if let Some(v) = that.gen_mod_rs {
             self.gen_mod_rs = Some(v);
+        }
+        if let Some(v) = &that.gen_mod_rs_hierarchy_out_dir_mod_name {
+            self.gen_mod_rs_hierarchy_out_dir_mod_name = Some(v.to_owned());
         }
         if let Some(v) = that.inside_protobuf {
             self.inside_protobuf = Some(v);
@@ -236,6 +251,8 @@ impl Customize {
                 r.lite_runtime = Some(parse_bool(v)?);
             } else if n == "gen_mod_rs" {
                 r.gen_mod_rs = Some(parse_bool(v)?);
+            } else if n == "gen_mod_rs_hierarchy_out_dir_mod_name" {
+                r.gen_mod_rs_hierarchy_out_dir_mod_name = Some(v.to_owned());
             } else if n == "inside_protobuf" {
                 r.inside_protobuf = Some(parse_bool(v)?);
             } else if n == "lite" {

--- a/protobuf-codegen/src/customize/rustproto_proto.rs
+++ b/protobuf-codegen/src/customize/rustproto_proto.rs
@@ -14,6 +14,7 @@ pub(crate) fn customize_from_rustproto_for_message(source: &MessageOptions) -> C
     let tokio_bytes_for_string = rustproto::exts::tokio_bytes_for_string.get(source);
     let lite_runtime = None;
     let gen_mod_rs = None;
+    let gen_mod_rs_hierarchy_out_dir_mod_name = None;
     let inside_protobuf = None;
     Customize {
         before,
@@ -23,6 +24,7 @@ pub(crate) fn customize_from_rustproto_for_message(source: &MessageOptions) -> C
         tokio_bytes_for_string,
         lite_runtime,
         gen_mod_rs,
+        gen_mod_rs_hierarchy_out_dir_mod_name,
         inside_protobuf,
     }
 }
@@ -39,6 +41,7 @@ pub(crate) fn customize_from_rustproto_for_field(source: &FieldOptions) -> Custo
     let tokio_bytes_for_string = rustproto::exts::tokio_bytes_for_string_field.get(source);
     let lite_runtime = None;
     let gen_mod_rs = None;
+    let gen_mod_rs_hierarchy_out_dir_mod_name = None;
     let inside_protobuf = None;
     Customize {
         before,
@@ -48,6 +51,7 @@ pub(crate) fn customize_from_rustproto_for_field(source: &FieldOptions) -> Custo
         tokio_bytes_for_string,
         lite_runtime,
         gen_mod_rs,
+        gen_mod_rs_hierarchy_out_dir_mod_name,
         inside_protobuf,
     }
 }
@@ -60,6 +64,7 @@ pub(crate) fn customize_from_rustproto_for_file(source: &FileOptions) -> Customi
     let tokio_bytes_for_string = rustproto::exts::tokio_bytes_for_string_all.get(source);
     let lite_runtime = rustproto::exts::lite_runtime_all.get(source);
     let gen_mod_rs = None;
+    let gen_mod_rs_hierarchy_out_dir_mod_name = None;
     let inside_protobuf = None;
     Customize {
         before,
@@ -70,5 +75,6 @@ pub(crate) fn customize_from_rustproto_for_file(source: &FileOptions) -> Customi
         lite_runtime,
         inside_protobuf,
         gen_mod_rs,
+        gen_mod_rs_hierarchy_out_dir_mod_name,
     }
 }

--- a/protobuf-codegen/src/gen/enums.rs
+++ b/protobuf-codegen/src/gen/enums.rs
@@ -70,6 +70,9 @@ impl<'a> EnumGen<'a> {
         path: &'a [i32],
         info: Option<&'a SourceCodeInfo>,
     ) -> EnumGen<'a> {
+        let enum_proto = enum_with_scope.en.proto();
+        eprintln!("EnumGen::parse enum.name: {}", enum_proto.name());        
+
         let customize = customize.child(
             &customize_from_rustproto_for_enum(enum_with_scope.en.proto().options.get_or_default()),
             &enum_with_scope.en,

--- a/protobuf-codegen/src/gen/field/elem.rs
+++ b/protobuf-codegen/src/gen/field/elem.rs
@@ -65,6 +65,8 @@ impl<'a> FieldElemMessage<'a> {
     }
 
     fn rust_type(&self, reference: &FileAndMod) -> RustType {
+        eprintln!("FieldElemMessage::rust_type message.mod_name: {}", self.message.mod_name().to_string());
+        eprintln!("FieldElemMessage::rust_type message.name: {}", self.message.message.name());
         RustType::Message(self.rust_name_relative(reference))
     }
 }

--- a/protobuf-codegen/src/gen/field/mod.rs
+++ b/protobuf-codegen/src/gen/field/mod.rs
@@ -145,6 +145,12 @@ impl<'a> FieldGen<'a> {
         path: Vec<i32>,
         info: Option<&'a SourceCodeInfo>,
     ) -> anyhow::Result<FieldGen<'a>> {
+        let message_proto = field.message.message.proto();
+        eprintln!("FieldGen::parse message.name: {}", message_proto.name());
+        eprintln!("FieldGen::parse field.name: {}", field.field.proto().name());
+        eprintln!("FieldGen::parse field.type.protobuf_name: {}", field.field.proto().type_().protobuf_name());
+        eprintln!("FieldGen::parse field.type_name: {}", field.field.proto().type_name());
+        
         let customize = parent_customize
             .child(
                 &customize_from_rustproto_for_field(field.field.proto().options.get_or_default()),
@@ -336,6 +342,8 @@ impl<'a> FieldGen<'a> {
 
     // for field `foo`, return type of `fn foo(..)`
     fn getter_return_type(&self) -> RustType {
+        eprintln!("FieldGen::getter_return_type");
+
         let reference = self
             .proto_field
             .message

--- a/protobuf-codegen/src/gen/file.rs
+++ b/protobuf-codegen/src/gen/file.rs
@@ -14,6 +14,7 @@ use crate::gen::extensions::write_extensions;
 use crate::gen::file_descriptor::write_file_descriptor_data;
 use crate::gen::inside::protobuf_crate_path;
 use crate::gen::message::MessageGen;
+use crate::gen::paths::file_descriptor_to_hierarchical_rs;
 use crate::gen::paths::proto_path_to_rust_mod;
 use crate::gen::scope::FileScope;
 use crate::gen::scope::RootScope;
@@ -141,7 +142,11 @@ pub(crate) fn gen_file(
 
     Ok(GenFileResult {
         compiler_plugin_result: compiler_plugin::GenResult {
-            name: proto_name_to_rs(file_descriptor.proto().name()),
+            name: if customize.for_elem.gen_mod_rs_hierarchy_out_dir_mod_name.is_some() {
+                file_descriptor_to_hierarchical_rs(file_descriptor.proto())
+            } else {
+                proto_name_to_rs(file_descriptor.proto().name())
+            },
             content: v.into_bytes(),
         },
         mod_name: proto_path_to_rust_mod(file_descriptor.proto().name()).into_string(),

--- a/protobuf-codegen/src/gen/oneof.rs
+++ b/protobuf-codegen/src/gen/oneof.rs
@@ -176,6 +176,8 @@ impl<'a> OneofGen<'a> {
         oneof: OneofWithContext<'a>,
         parent_customize: &CustomizeElemCtx<'a>,
     ) -> OneofGen<'a> {
+        let message_proto = message.message.message.proto();
+        eprintln!("OneofGen::parse message.name: {}", message_proto.name());        
         let customize = parent_customize.child(&Customize::default(), &oneof.oneof);
         let lite_runtime = customize.for_elem.lite_runtime.unwrap_or_else(|| {
             oneof

--- a/protobuf-codegen/src/gen/paths.rs
+++ b/protobuf-codegen/src/gen/paths.rs
@@ -40,8 +40,8 @@ pub(crate) fn proto_path_to_rust_mod(path: &str) -> RustIdent {
 }
 
 /// Used in protobuf-codegen-identical-test
-pub fn proto_name_to_rs(proto_file_path: &str) -> String {
-    format!("{}.rs", proto_path_to_rust_mod(proto_file_path))
+pub fn proto_name_to_rs(proto_name: &str) -> String {
+    format!("{}.rs", proto_path_to_rust_mod(proto_name))
 }
 
 pub(crate) fn proto_path_to_fn_file_descriptor(

--- a/protobuf-codegen/src/gen/paths.rs
+++ b/protobuf-codegen/src/gen/paths.rs
@@ -1,3 +1,5 @@
+use protobuf::descriptor::FileDescriptorProto;
+
 use crate::gen::inside::protobuf_crate_path;
 use crate::gen::rust::ident::RustIdent;
 use crate::gen::rust::path::RustPath;
@@ -74,16 +76,19 @@ pub(crate) fn proto_path_to_fn_file_descriptor(
         s => {
             if let Some(mod_path) = &customize.gen_mod_rs_hierarchy_out_dir_mod_name {
                 let mut rust_path = RustPath::from("crate");
+                eprintln!("Forming path wth rust_path: {}", rust_path);
                 for mod_part in mod_path.split("::") {
                     rust_path = rust_path.append_ident(RustIdent::from(mod_part));
+                    eprintln!("Forming path wth rust_path: {}", rust_path);
                 }
                 for component in proto_path.split("/").filter(|p| !p.ends_with(".proto")) {
                     rust_path = rust_path.append_ident(RustIdent::from(component));
+                    eprintln!("Forming path wth rust_path: {}", rust_path);
                 }
                 rust_path.append_ident("file_descriptor".into())
             } else {
                 RustPath::super_path()
-            .append_ident(proto_path_to_rust_mod(s))
+                    .append_ident(proto_path_to_rust_mod(s))
                     .append_ident("file_descriptor".into())
             }
         }

--- a/protobuf-codegen/src/gen/rust_types_values.rs
+++ b/protobuf-codegen/src/gen/rust_types_values.rs
@@ -512,6 +512,17 @@ pub(crate) fn message_or_enum_to_rust_relative(
             protobuf_crate_path(&current.customize),
             message_or_enum.rust_name_to_file()
         ))
+    } else if let Some(mod_name) = &current.customize.gen_mod_rs_hierarchy_out_dir_mod_name {
+        let mut rust_name = format!("crate::{}", mod_name.to_owned());
+        for component in message_or_enum
+            .name_absolute()
+            .trim_start_matches(':')
+            .split('.')
+            .filter(|s| !s.is_empty())
+        {
+            rust_name.push_str(&format!("::{}", component.replace('-', "_")));
+        }
+        RustIdentWithPath::from(rust_name)
     } else {
         current
             .relative_mod

--- a/protobuf-codegen/src/gen/scope.rs
+++ b/protobuf-codegen/src/gen/scope.rs
@@ -277,6 +277,11 @@ impl<'a> Scope<'a> {
     }
 
     pub fn file_and_mod(&self, customize: Customize) -> FileAndMod {
+        let d = self.file_scope.file_descriptor.proto();
+        eprintln!("Scope::file_and_mod package: package: {}", d.package());
+        eprintln!("Scope::file_and_mod package: name: {}", d.name());
+        eprintln!("Scope::file_and_mod package: rust_path_to_file: {}", self.rust_path_to_file());
+        eprintln!("Scope::file_and_mod package: path_str: {}", self.path_str());
         FileAndMod {
             file: self.file_scope.file_descriptor.proto().name().to_owned(),
             relative_mod: self.rust_path_to_file(),

--- a/protobuf-codegen/src/gen_and_write.rs
+++ b/protobuf-codegen/src/gen_and_write.rs
@@ -1,6 +1,7 @@
 #![doc(hidden)]
 
 use std::fs;
+use std::fs::create_dir_all;
 use std::io;
 use std::path::Path;
 
@@ -19,6 +20,8 @@ enum Error {
     OutputDoesNotExistOrNotAccssible(String, #[source] io::Error),
     #[error("failed to create file `{0}`: {1}")]
     FailedToWriteFile(String, #[source] io::Error),
+    #[error("failed to create directory hierarchy for path `{0}`")]
+    FailedToCreateDirectoryHierarchy(String, #[source] io::Error),
 }
 
 #[doc(hidden)]
@@ -54,6 +57,13 @@ pub fn gen_and_write(
     for r in &results {
         let mut file_path = out_dir.to_owned();
         file_path.push(&r.name);
+        if customize.gen_mod_rs_hierarchy_out_dir_mod_name.is_some() {
+            if let Some(parent) = file_path.parent() {
+                create_dir_all(parent).map_err(|error| {
+                    Error::FailedToCreateDirectoryHierarchy(parent.display().to_string(), error)
+                })?;
+            }
+        }
         fs::write(&file_path, r.content.as_slice())
             .map_err(|e| Error::FailedToWriteFile(file_path.display().to_string(), e))?;
     }


### PR DESCRIPTION
Work-in-progress PR for generating protobufs in a module hierarchy

- resolves #260 
- resolves #438 
- resolves #644
- prerequisite #687,

TODO:

- add tests
- code generate the `mod.rs` files I'm currently writing by hand when testing in a another repo which uses a `build.rs` snippet like:

```rust
let manifest_dir = PathBuf::from(env::var("CARGO_MANIFEST_DIR")?);
let out_dir = manifest_dir.join("src").join("test_pb");
codegen.out_dir(out_dir);
codegen.customize(
    Customize::default()
        .gen_mod_rs_hierarchy_out_dir_mod_name("test_pb".to_owned())
        .gen_mod_rs(false),
);
```

Need guidance on:

- intended usage of `ident`s, `component`s in `RustPath`-like structures