### PR TITLE
impl From for MessageField for convenience

### DIFF
--- a/protobuf/src/message_field.rs
+++ b/protobuf/src/message_field.rs
@@ -192,6 +192,12 @@ impl<T> Default for MessageField<T> {
     }
 }
 
+// impl<T> From<T> for MessageField<T> {
+//     fn from(other: T) -> Self {
+//         MessageField::some(other)
+//     }
+// }
+
 /// We don't have `From<Option<Box<T>>> for MessageField<T>` because
 /// it would make type inference worse.
 impl<T> From<Option<T>> for MessageField<T> {


### PR DESCRIPTION
I have found that constructing various messages often leads to creating `MessageField` types explicitly.  For example, the following struct may be generated:
```rust
struct MyStruct {
    pub some_field: MessageField<MyOtherStruct>,
    ...
    pub special_fields: SpecialFields
}
```

I often initialize this as follows:
```rust
let s =  MyStruct {
    some_field: MessageField::some(MyOtherStruct { <blah> }),
   ...
};
```

This PR would allow users to use the blanket provided implementation of `Into` by deriving `From`, enabling this simpler syntax:
```rust
let s =  MyStruct {
    some_field: MyOtherStruct { <blah> }.into(),
    ...
};
```