### PR TITLE
Codegen: option to use BTreeMap as map representation

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,8 +8,14 @@ jobs:
     linux-stable-default-features:
         name: linux stable (default features)
         runs-on: ubuntu-latest
+        strategy:
+            matrix:
+                map_representation:
+                    - btreemap
+                    - hashmap
         env:
             RUST_BACKTRACE: 1
+            MAP_REPRESENTATION: ${{ matrix.map_representation }}
         steps:
             - name: Checkout sources
               uses: actions/checkout@v2
@@ -53,8 +59,14 @@ jobs:
     linux-beta-default-features:
         name: linux beta (default features)
         runs-on: ubuntu-latest
+        strategy:
+            matrix:
+                map_representation:
+                    - btreemap
+                    - hashmap
         env:
             RUST_BACKTRACE: 1
+            MAP_REPRESENTATION: ${{ matrix.map_representation }}
         steps:
             - name: Checkout sources
               uses: actions/checkout@v2
@@ -98,8 +110,14 @@ jobs:
     linux-stable-with-bytes:
         name: linux stable (with-bytes)
         runs-on: ubuntu-latest
+        strategy:
+            matrix:
+                map_representation:
+                    - btreemap
+                    - hashmap
         env:
             RUST_BACKTRACE: 1
+            MAP_REPRESENTATION: ${{ matrix.map_representation }}
         steps:
             - name: Checkout sources
               uses: actions/checkout@v2
@@ -140,8 +158,14 @@ jobs:
     linux-nightly-all-features:
         name: linux nightly (all features)
         runs-on: ubuntu-latest
+        strategy:
+            matrix:
+                map_representation:
+                    - btreemap
+                    - hashmap
         env:
             RUST_BACKTRACE: 1
+            MAP_REPRESENTATION: ${{ matrix.map_representation }}
         steps:
             - name: Checkout sources
               uses: actions/checkout@v2
@@ -183,8 +207,14 @@ jobs:
     windows-stable-default-features:
         name: windows stable (default features)
         runs-on: windows-latest
+        strategy:
+            matrix:
+                map_representation:
+                    - btreemap
+                    - hashmap
         env:
             RUST_BACKTRACE: 1
+            MAP_REPRESENTATION: ${{ matrix.map_representation }}
             VCPKGRS_DYNAMIC: 1
         steps:
             - name: Checkout sources

--- a/ci-gen/src/ghwf.rs
+++ b/ci-gen/src/ghwf.rs
@@ -121,6 +121,7 @@ pub struct Job {
     pub id: String,
     pub name: String,
     pub runs_on: Env,
+    pub strategy: Option<Strategy>,
     pub steps: Vec<Step>,
     pub timeout_minutes: Option<u64>,
     pub env: Vec<(String, String)>,
@@ -141,6 +142,9 @@ impl Into<(String, Yaml)> for Job {
             ("name", Yaml::string(self.name)),
             ("runs-on", Yaml::string(format!("{}", self.runs_on))),
         ];
+        if let Some(strategy) = self.strategy {
+            entries.push(("strategy", strategy.into()));
+        }
         if let Some(timeout_minutes) = self.timeout_minutes {
             entries.push((
                 "timeout-minutes",
@@ -152,5 +156,28 @@ impl Into<(String, Yaml)> for Job {
         }
         entries.push(("steps", Yaml::list(self.steps)));
         (self.id, Yaml::map(entries))
+    }
+}
+
+pub struct Strategy {
+    pub matrix: Matrix,
+}
+
+impl Into<Yaml> for Strategy {
+    fn into(self) -> Yaml {
+        Yaml::map(vec![("matrix".to_owned(), self.matrix)])
+    }
+}
+
+pub struct Matrix {
+    pub map_representation: Vec<String>,
+}
+
+impl Into<Yaml> for Matrix {
+    fn into(self) -> Yaml {
+        Yaml::map(vec![(
+            "map_representation".to_owned(),
+            Yaml::list(self.map_representation),
+        )])
     }
 }

--- a/ci-gen/src/main.rs
+++ b/ci-gen/src/main.rs
@@ -16,7 +16,9 @@ use crate::actions::RustToolchain;
 use crate::cargo_sync_readme::cargo_sync_readme_job;
 use crate::ghwf::Env;
 use crate::ghwf::Job;
+use crate::ghwf::Matrix;
 use crate::ghwf::Step;
+use crate::ghwf::Strategy;
 use crate::yaml::Yaml;
 use crate::yaml::YamlWriter;
 
@@ -155,7 +157,13 @@ fn job(channel: RustToolchain, os: Os, features: Features) -> Job {
         }
     }
 
-    let mut env = vec![("RUST_BACKTRACE".to_owned(), "1".to_owned())];
+    let mut env = vec![
+        ("RUST_BACKTRACE".to_owned(), "1".to_owned()),
+        (
+            "MAP_REPRESENTATION".to_owned(),
+            "${{ matrix.map_representation }}".to_owned(),
+        ),
+    ];
     if os == WINDOWS {
         env.push(("VCPKGRS_DYNAMIC".to_owned(), "1".to_owned()));
     };
@@ -167,6 +175,11 @@ fn job(channel: RustToolchain, os: Os, features: Features) -> Job {
         runs_on: os.ghwf.to_owned(),
         steps,
         env,
+        strategy: Some(Strategy {
+            matrix: Matrix {
+                map_representation: vec!["btreemap".to_owned(), "hashmap".to_owned()],
+            },
+        }),
         ..Default::default()
     }
 }

--- a/protobuf-codegen/src/customize/mod.rs
+++ b/protobuf-codegen/src/customize/mod.rs
@@ -109,6 +109,8 @@ pub struct Customize {
     /// Used internally to generate protos bundled in protobuf crate
     /// like `descriptor.proto`
     pub(crate) inside_protobuf: Option<bool>,
+    /// When true, protobuf maps are represented with `std::collections::BTreeMap`
+    pub(crate) btreemaps: Option<bool>,
 }
 
 #[derive(Debug, thiserror::Error)]
@@ -171,6 +173,14 @@ impl Customize {
         self
     }
 
+    /// Use btreemaps for maps representation
+    pub fn btreemaps(self, use_btreemaps: bool) -> Self {
+        Self {
+            btreemaps: Some(use_btreemaps),
+            ..self
+        }
+    }
+
     /// Update fields of self with fields defined in other customize
     pub fn update_with(&mut self, that: &Customize) {
         if let Some(v) = &that.before {
@@ -196,6 +206,9 @@ impl Customize {
         }
         if let Some(v) = that.inside_protobuf {
             self.inside_protobuf = Some(v);
+        }
+        if let Some(v) = that.btreemaps {
+            self.btreemaps = Some(v);
         }
     }
 

--- a/protobuf-codegen/src/customize/rustproto_proto.rs
+++ b/protobuf-codegen/src/customize/rustproto_proto.rs
@@ -15,6 +15,7 @@ pub(crate) fn customize_from_rustproto_for_message(source: &MessageOptions) -> C
     let lite_runtime = None;
     let gen_mod_rs = None;
     let inside_protobuf = None;
+    let btreemaps = None;
     Customize {
         before,
         generate_accessors,
@@ -24,6 +25,7 @@ pub(crate) fn customize_from_rustproto_for_message(source: &MessageOptions) -> C
         lite_runtime,
         gen_mod_rs,
         inside_protobuf,
+        btreemaps,
     }
 }
 
@@ -40,6 +42,7 @@ pub(crate) fn customize_from_rustproto_for_field(source: &FieldOptions) -> Custo
     let lite_runtime = None;
     let gen_mod_rs = None;
     let inside_protobuf = None;
+    let btreemaps = None;
     Customize {
         before,
         generate_accessors,
@@ -49,6 +52,7 @@ pub(crate) fn customize_from_rustproto_for_field(source: &FieldOptions) -> Custo
         lite_runtime,
         gen_mod_rs,
         inside_protobuf,
+        btreemaps,
     }
 }
 
@@ -61,6 +65,7 @@ pub(crate) fn customize_from_rustproto_for_file(source: &FileOptions) -> Customi
     let lite_runtime = rustproto::exts::lite_runtime_all.get(source);
     let gen_mod_rs = None;
     let inside_protobuf = None;
+    let btreemaps = None;
     Customize {
         before,
         generate_accessors,
@@ -70,5 +75,6 @@ pub(crate) fn customize_from_rustproto_for_file(source: &FileOptions) -> Customi
         lite_runtime,
         inside_protobuf,
         gen_mod_rs,
+        btreemaps,
     }
 }

--- a/protobuf-codegen/src/gen/field/accessor.rs
+++ b/protobuf-codegen/src/gen/field/accessor.rs
@@ -66,7 +66,7 @@ impl FieldGen<'_> {
         let MapField { .. } = map_field;
         AccessorFn {
             name: "make_map_simpler_accessor".to_owned(),
-            type_params: vec![format!("_"), format!("_")],
+            type_params: vec![format!("_")],
             callback_params: self.make_accessor_fns_lambda(),
         }
     }

--- a/protobuf-codegen/src/gen/field/mod.rs
+++ b/protobuf-codegen/src/gen/field/mod.rs
@@ -276,7 +276,7 @@ impl<'a> FieldGen<'a> {
             FieldKind::Repeated(ref repeated) => repeated.rust_type(reference),
             FieldKind::Map(MapField {
                 ref key, ref value, ..
-            }) => RustType::HashMap(
+            }) => RustType::Map(
                 Box::new(key.rust_storage_elem_type(reference)),
                 Box::new(value.rust_storage_elem_type(reference)),
             ),

--- a/protobuf/src/reflect/acc/v2/map.rs
+++ b/protobuf/src/reflect/acc/v2/map.rs
@@ -1,4 +1,4 @@
-use std::collections::HashMap;
+use std::collections::{BTreeMap, HashMap};
 use std::fmt;
 use std::hash::Hash;
 
@@ -8,12 +8,12 @@ use crate::reflect::acc::v2::AccessorV2;
 use crate::reflect::acc::FieldAccessor;
 use crate::reflect::map::ReflectMapMut;
 use crate::reflect::map::ReflectMapRef;
-use crate::reflect::runtime_types::RuntimeTypeHashable;
+use crate::reflect::runtime_types::RuntimeTypeMapKey;
 use crate::reflect::runtime_types::RuntimeTypeTrait;
 use crate::reflect::ProtobufValue;
 use crate::reflect::RuntimeType;
 
-pub(crate) trait MapFieldAccessor: Send + Sync + 'static {
+pub trait MapFieldAccessor: Send + Sync + 'static {
     fn get_reflect<'a>(&self, m: &'a dyn MessageDyn) -> ReflectMapRef<'a>;
     fn mut_reflect<'a>(&self, m: &'a mut dyn MessageDyn) -> ReflectMapMut<'a>;
     fn element_type(&self) -> (RuntimeType, RuntimeType);
@@ -29,21 +29,46 @@ impl<'a> fmt::Debug for MapFieldAccessorHolder {
     }
 }
 
-struct MapFieldAccessorImpl<M, K, V>
+pub struct MapFieldAccessorImpl<M, T>
 where
     M: MessageFull,
-    K: ProtobufValue,
-    V: ProtobufValue,
 {
-    get_field: fn(&M) -> &HashMap<K, V>,
-    mut_field: fn(&mut M) -> &mut HashMap<K, V>,
+    get_field: fn(&M) -> &T,
+    mut_field: fn(&mut M) -> &mut T,
 }
 
-impl<M, K, V> MapFieldAccessor for MapFieldAccessorImpl<M, K, V>
+impl<M, K, V> MapFieldAccessor for MapFieldAccessorImpl<M, HashMap<K, V>>
 where
     M: MessageFull,
     K: ProtobufValue + Eq + Hash,
-    K::RuntimeType: RuntimeTypeHashable,
+    K::RuntimeType: RuntimeTypeMapKey,
+    V: ProtobufValue,
+{
+    fn get_reflect<'a>(&self, m: &'a dyn MessageDyn) -> ReflectMapRef<'a> {
+        let m = m.downcast_ref().unwrap();
+        let map = (self.get_field)(m);
+        ReflectMapRef::new(map)
+    }
+
+    fn mut_reflect<'a>(&self, m: &'a mut dyn MessageDyn) -> ReflectMapMut<'a> {
+        let m = m.downcast_mut().unwrap();
+        let map = (self.mut_field)(m);
+        ReflectMapMut::new(map)
+    }
+
+    fn element_type(&self) -> (RuntimeType, RuntimeType) {
+        (
+            K::RuntimeType::runtime_type_box(),
+            V::RuntimeType::runtime_type_box(),
+        )
+    }
+}
+
+impl<M, K, V> MapFieldAccessor for MapFieldAccessorImpl<M, BTreeMap<K, V>>
+where
+    M: MessageFull,
+    K: ProtobufValue + Ord,
+    K::RuntimeType: RuntimeTypeMapKey,
     V: ProtobufValue,
 {
     fn get_reflect<'a>(&self, m: &'a dyn MessageDyn) -> ReflectMapRef<'a> {
@@ -67,21 +92,19 @@ where
 }
 
 /// Make accessor for map field
-pub fn make_map_simpler_accessor<M, K, V>(
+pub fn make_map_simpler_accessor<M, T>(
     name: &'static str,
-    get_field: for<'a> fn(&'a M) -> &'a HashMap<K, V>,
-    mut_field: for<'a> fn(&'a mut M) -> &'a mut HashMap<K, V>,
+    get_field: for<'a> fn(&'a M) -> &'a T,
+    mut_field: for<'a> fn(&'a mut M) -> &'a mut T,
 ) -> FieldAccessor
 where
-    M: MessageFull + 'static,
-    K: ProtobufValue + Hash + Eq,
-    K::RuntimeType: RuntimeTypeHashable,
-    V: ProtobufValue,
+    M: MessageFull,
+    MapFieldAccessorImpl<M, T>: MapFieldAccessor,
 {
     FieldAccessor::new(
         name,
         AccessorV2::Map(MapFieldAccessorHolder {
-            accessor: Box::new(MapFieldAccessorImpl::<M, K, V> {
+            accessor: Box::new(MapFieldAccessorImpl::<M, T> {
                 get_field,
                 mut_field,
             }),

--- a/protobuf/src/reflect/map/mod.rs
+++ b/protobuf/src/reflect/map/mod.rs
@@ -12,7 +12,7 @@ use crate::reflect::RuntimeType;
 mod empty;
 mod generated;
 
-/// Implemented for `HashMap` with appropriate keys and values
+/// Implemented for `HashMap`, `BTreeMap` with appropriate keys and values
 pub(crate) trait ReflectMap: Debug + Send + Sync + 'static {
     fn reflect_iter(&self) -> ReflectMapIter;
 

--- a/protobuf/src/well_known_types/struct_.rs
+++ b/protobuf/src/well_known_types/struct_.rs
@@ -55,7 +55,7 @@ impl Struct {
     fn generated_message_descriptor_data() -> crate::reflect::GeneratedMessageDescriptorData {
         let mut fields = ::std::vec::Vec::with_capacity(1);
         let mut oneofs = ::std::vec::Vec::with_capacity(0);
-        fields.push(crate::reflect::rt::v2::make_map_simpler_accessor::<_, _, _>(
+        fields.push(crate::reflect::rt::v2::make_map_simpler_accessor::<_, _>(
             "fields",
             |m: &Struct| { &m.fields },
             |m: &mut Struct| { &mut m.fields },

--- a/test-crates/protobuf-codegen-protoc-test/build.rs
+++ b/test-crates/protobuf-codegen-protoc-test/build.rs
@@ -30,7 +30,11 @@ fn gen_in_dir(dir: &str, include_dir: &str) {
                 .out_dir(out_dir)
                 .inputs(input)
                 .includes(&["../../proto", include_dir])
-                .customize(customize)
+                .customize(
+                    customize.btreemaps(
+                        env::var("MAP_REPRESENTATION").unwrap_or_default() == "btreemap",
+                    ),
+                )
                 .run_from_script()
         },
     );

--- a/test-crates/protobuf-codegen-protoc-test/src/common/v2/test_reflect_clear.rs
+++ b/test-crates/protobuf-codegen-protoc-test/src/common/v2/test_reflect_clear.rs
@@ -1,5 +1,3 @@
-use std::collections::HashMap;
-
 use protobuf::reflect::ReflectValueBox;
 use protobuf::MessageFull;
 
@@ -7,7 +5,7 @@ use super::test_reflect_clear_pb::*;
 
 #[test]
 fn test_generated() {
-    let mut map = HashMap::new();
+    let mut map = TestMessage::default().e().clone();
     map.insert("key".to_string(), "value".to_string());
 
     let mut msg = TestMessage::default();
@@ -45,7 +43,7 @@ fn test_dynamic() {
 
     let mut msg = msg_desc.new_instance();
 
-    let mut map = HashMap::new();
+    let mut map = TestMessage::default().e().clone();
     map.insert("key".to_string(), "value".to_string());
 
     a_field.set_singular_field(msg.as_mut(), 1.into());


### PR DESCRIPTION
As of now, protobuf maps are represented with
[std::collections::HashMap](https://doc.rust-lang.org/stable/std/collections/struct.HashMap.html), which serves as a robust default. In rarer instances, opting for a different implementation, such as BTreeMap, might be desirable, e.g. for deterministic serialization.

This change

* adds `btreemaps` codegen option to generate [std::collections::BTreeMap](https://doc.rust-lang.org/std/collections/struct.BTreeMap.html) for maps representation.