### PR TITLE
Default to packed for repeated primitives in proto3.

### DIFF
--- a/protobuf-codegen/src/gen/field/mod.rs
+++ b/protobuf-codegen/src/gen/field/mod.rs
@@ -198,12 +198,12 @@ impl<'a> FieldGen<'a> {
                     | Type::TYPE_SFIXED32
                     | Type::TYPE_SFIXED64
                     | Type::TYPE_SINT32
-                    | Type::TYPE_SINT64 => true,
+                    | Type::TYPE_SINT64
+                    | Type::TYPE_ENUM => true,
                     Type::TYPE_STRING
                     | Type::TYPE_GROUP
                     | Type::TYPE_MESSAGE
-                    | Type::TYPE_BYTES
-                    | Type::TYPE_ENUM => false,
+                    | Type::TYPE_BYTES => false,
                 };
                 let packed = field
                     .field

--- a/protobuf-codegen/src/gen/field/mod.rs
+++ b/protobuf-codegen/src/gen/field/mod.rs
@@ -188,7 +188,36 @@ impl<'a> FieldGen<'a> {
 
                 FieldKind::Repeated(RepeatedField {
                     elem,
-                    packed: field.field.proto().options.get_or_default().packed(),
+                    packed: field
+                        .field
+                        .proto()
+                        .options
+                        .get_or_default()
+                        .packed
+                        .unwrap_or(match field.message.scope.file_scope.syntax() {
+                            Syntax::Proto2 => false,
+                            // in proto3, repeated primitive types are packed by default
+                            Syntax::Proto3 => match field.field.proto().type_() {
+                                Type::TYPE_DOUBLE
+                                | Type::TYPE_FLOAT
+                                | Type::TYPE_INT64
+                                | Type::TYPE_UINT64
+                                | Type::TYPE_INT32
+                                | Type::TYPE_FIXED64
+                                | Type::TYPE_FIXED32
+                                | Type::TYPE_BOOL
+                                | Type::TYPE_UINT32
+                                | Type::TYPE_SFIXED32
+                                | Type::TYPE_SFIXED64
+                                | Type::TYPE_SINT32
+                                | Type::TYPE_SINT64 => true,
+                                Type::TYPE_STRING
+                                | Type::TYPE_GROUP
+                                | Type::TYPE_MESSAGE
+                                | Type::TYPE_BYTES
+                                | Type::TYPE_ENUM => false,
+                            },
+                        }),
                 })
             }
             RuntimeFieldType::Singular(..) => {

--- a/protobuf-codegen/src/gen/field/mod.rs
+++ b/protobuf-codegen/src/gen/field/mod.rs
@@ -185,40 +185,43 @@ impl<'a> FieldGen<'a> {
             }
             RuntimeFieldType::Repeated(..) => {
                 let elem = field_elem(&field, root_scope, &customize);
-
-                FieldKind::Repeated(RepeatedField {
-                    elem,
-                    packed: field
-                        .field
-                        .proto()
-                        .options
-                        .get_or_default()
-                        .packed
-                        .unwrap_or(match field.message.scope.file_scope.syntax() {
-                            Syntax::Proto2 => false,
-                            // in proto3, repeated primitive types are packed by default
-                            Syntax::Proto3 => match field.field.proto().type_() {
-                                Type::TYPE_DOUBLE
-                                | Type::TYPE_FLOAT
-                                | Type::TYPE_INT64
-                                | Type::TYPE_UINT64
-                                | Type::TYPE_INT32
-                                | Type::TYPE_FIXED64
-                                | Type::TYPE_FIXED32
-                                | Type::TYPE_BOOL
-                                | Type::TYPE_UINT32
-                                | Type::TYPE_SFIXED32
-                                | Type::TYPE_SFIXED64
-                                | Type::TYPE_SINT32
-                                | Type::TYPE_SINT64 => true,
-                                Type::TYPE_STRING
-                                | Type::TYPE_GROUP
-                                | Type::TYPE_MESSAGE
-                                | Type::TYPE_BYTES
-                                | Type::TYPE_ENUM => false,
-                            },
-                        }),
-                })
+                let primitive = match field.field.proto().type_() {
+                    Type::TYPE_DOUBLE
+                    | Type::TYPE_FLOAT
+                    | Type::TYPE_INT64
+                    | Type::TYPE_UINT64
+                    | Type::TYPE_INT32
+                    | Type::TYPE_FIXED64
+                    | Type::TYPE_FIXED32
+                    | Type::TYPE_BOOL
+                    | Type::TYPE_UINT32
+                    | Type::TYPE_SFIXED32
+                    | Type::TYPE_SFIXED64
+                    | Type::TYPE_SINT32
+                    | Type::TYPE_SINT64 => true,
+                    Type::TYPE_STRING
+                    | Type::TYPE_GROUP
+                    | Type::TYPE_MESSAGE
+                    | Type::TYPE_BYTES
+                    | Type::TYPE_ENUM => false,
+                };
+                let packed = field
+                    .field
+                    .proto()
+                    .options
+                    .get_or_default()
+                    .packed
+                    .unwrap_or(match field.message.scope.file_scope.syntax() {
+                        Syntax::Proto2 => false,
+                        // in proto3, repeated primitive types are packed by default
+                        Syntax::Proto3 => primitive,
+                    });
+                if packed && !primitive {
+                    anyhow::bail!(
+                        "[packed = true] can only be specified for repeated primitive fields"
+                    );
+                }
+                FieldKind::Repeated(RepeatedField { elem, packed })
             }
             RuntimeFieldType::Singular(..) => {
                 let elem = field_elem(&field, root_scope, &customize);

--- a/test-crates/protobuf-codegen-protoc-test/src/common/v2/test_repeated_packed.rs
+++ b/test-crates/protobuf-codegen-protoc-test/src/common/v2/test_repeated_packed.rs
@@ -1,3 +1,5 @@
+use protobuf::reflect::Syntax;
+use protobuf::MessageFull;
 use protobuf_test_common::*;
 
 use super::test_repeated_packed_pb::*;
@@ -82,4 +84,17 @@ fn test_issue_281() {
     let mut test = TestIssue281::new();
     test.values = (0..100).collect();
     test_serialize_deserialize_no_hex(&test);
+}
+
+#[test]
+fn test_write_packed_default() {
+    let mut test = TestPackedDefault::new();
+    test.varints = vec![0, 1, 2, 3, 4, 5];
+
+    // Proto3 packs primitives by default, proto2 does not.
+    let expected_hex = match TestPackedDefault::descriptor().file_descriptor().syntax() {
+        Syntax::Proto2 => "08 00 08 01 08 02 08 03 08 04 08 05",
+        Syntax::Proto3 => "0a 06 00 01 02 03 04 05",
+    };
+    test_serialize_deserialize(expected_hex, &test);
 }

--- a/test-crates/protobuf-codegen-protoc-test/src/common/v2/test_repeated_packed_pb.proto
+++ b/test-crates/protobuf-codegen-protoc-test/src/common/v2/test_repeated_packed_pb.proto
@@ -13,3 +13,7 @@ message TestUnpacked {
 message TestIssue281 {
     repeated fixed32 values = 1 [packed=true];
 }
+
+message TestPackedDefault {
+    repeated uint32 varints = 1;
+}


### PR DESCRIPTION
Fixes #704.
Fixes #706.

I wasn't sure how to add tests for either.
For #704, I didn't see a way to distinguish which syntax was being used in a test.
For #706, I didn't see a way to have an invalid proto in a test (the parser fails before you get to the test).

I'm not sure I handled the error correctly, the output looks like:

```
--- stderr
codegen failed: [packed = true] can only be specified for repeated primitive fields
```

As opposed to other errors, that have multiple layers:
```
--- stderr
codegen failed: parse and typecheck

Caused by:
    0: using pure parser
    1: error in `api.proto`: object is not found by path `tring` in scope `.api.Example`
    2: object is not found by path `tring` in scope `.api.Example`
```

There's also no line/column number, but I'm not sure if that's expected.
