### PR TITLE
Add new end-to-end example

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,6 +8,7 @@ members = [
     "protobuf-codegen",
     "protobuf-examples/customize-serde",
     "protobuf-examples/dynamic",
+    "protobuf-examples/end-to-end",
     "protobuf-examples/pure-vs-protoc",
     "protobuf-examples/vs-prost",
     "protobuf-examples/issue-614",

--- a/protobuf-examples/end-to-end/Cargo.toml
+++ b/protobuf-examples/end-to-end/Cargo.toml
@@ -1,0 +1,13 @@
+[package]
+name = "protobuf-examples-end-to-end"
+version = "0.0.1"
+authors = ["Jeff Garzik"]
+edition = "2021"
+publish = false
+
+[dependencies]
+protobuf = { path = "../../protobuf" }
+
+[build-dependencies]
+protobuf = { path = "../../protobuf" }
+protobuf-codegen = { path = "../../protobuf-codegen" }

--- a/protobuf-examples/end-to-end/README.md
+++ b/protobuf-examples/end-to-end/README.md
@@ -1,0 +1,38 @@
+# End-to-End Example
+
+A fork-and-go example of using protobufs.
+
+## Motivation
+
+Simple and obvious examples for using `rust-protobuf` module were
+lacking, so this was created.
+
+## Dependencies
+
+protoc (Protobuf Compiler)
+
+[Installation instructions](https://grpc.io/docs/protoc-installation)
+
+### Installing Protoc on Ubuntu (and similar)
+
+`sudo apt install protobuf-compiler`
+
+## Look here
+
+Key files to read are:
+
+* src/protos/example.proto
+* src/main.rs
+* build.rs
+
+## Using
+
+Standard rust package:
+```
+$ cargo build
+$ cargo run
+```
+
+## Contributions
+
+Contributions are welcome. File an issue or PR.

--- a/protobuf-examples/end-to-end/build.rs
+++ b/protobuf-examples/end-to-end/build.rs
@@ -1,0 +1,7 @@
+fn main() {
+    protobuf_codegen::Codegen::new()
+        .cargo_out_dir("protos")
+        .include("src")
+        .input("src/protos/example.proto")
+        .run_from_script();
+}

--- a/protobuf-examples/end-to-end/src/main.rs
+++ b/protobuf-examples/end-to-end/src/main.rs
@@ -1,0 +1,46 @@
+use protobuf::{EnumOrUnknown, Message};
+
+include!(concat!(env!("OUT_DIR"), "/protos/mod.rs"));
+
+use example::{get_response, GetRequest, GetResponse};
+
+fn main() {
+    // Encode example request
+    let mut out_msg = GetRequest::new();
+    out_msg.name = "John Smith".to_string();
+    out_msg.age = 25;
+    out_msg.features.push("one".to_string());
+    out_msg.features.push("two".to_string());
+    println!("Message request:\nout_msg {:#?}", out_msg);
+
+    let out_bytes: Vec<u8> = out_msg.write_to_bytes().unwrap();
+    println!("Message request in bytes:\nout_bytes {:?}", out_bytes);
+
+    // Decode example request
+    let in_msg = GetRequest::parse_from_bytes(&out_bytes).unwrap();
+
+    assert_eq!(in_msg.name, out_msg.name);
+    assert_eq!(in_msg.age, out_msg.age);
+    assert_eq!(in_msg.features, out_msg.features);
+
+    //////////////////////////////////
+
+    // Encode example response
+    let mut out_resp = GetResponse::new();
+    out_resp.status = EnumOrUnknown::new(get_response::Status::OK);
+    out_resp.address = "1243 main street".to_string();
+    out_resp.city = "anytown".to_string();
+    out_resp.zipcode = 54321;
+    println!("\nMessage response:\nout_msg {:#?}", out_resp);
+
+    let out_bytes: Vec<u8> = out_resp.write_to_bytes().unwrap();
+    println!("Message response in bytes:\nout_bytes {:?}", out_bytes);
+
+    // Decode example response
+    let in_resp = GetResponse::parse_from_bytes(&out_bytes).unwrap();
+
+    assert_eq!(in_resp.status, out_resp.status);
+    assert_eq!(in_resp.address, out_resp.address);
+    assert_eq!(in_resp.city, out_resp.city);
+    assert_eq!(in_resp.zipcode, out_resp.zipcode);
+}

--- a/protobuf-examples/end-to-end/src/protos/example.proto
+++ b/protobuf-examples/end-to-end/src/protos/example.proto
@@ -1,0 +1,20 @@
+syntax = "proto3";
+
+message GetRequest {
+  string name = 1;
+  int32 age = 2;
+  repeated string features = 3;
+}
+
+message GetResponse {
+  enum Status {
+    OK = 0;
+    ERR = 1;
+    NOT_FOUND = 2;
+  }
+  Status status = 1;
+  string address = 2;
+  string city = 3;
+  int32 zipcode = 4;
+}
+


### PR DESCRIPTION
Five years ago, I created a fork-and-go working protobufs example: https://github.com/jgarzik/rust-protobuf-example  Periodically, users will request that this example be merged into this upstream repo.

This PR adds this full end-to-end working example.

The goal in this example is to demonstrate the common case of encoding and decoding a set of mock API requests.

Happy to revise this as requested by the rust-protobuf maintainers.  
