### PR TITLE
Allow access to `bytes::Bytes` from `protobuf::Chars`

### DIFF
--- a/protobuf/src/chars.rs
+++ b/protobuf/src/chars.rs
@@ -83,7 +83,7 @@ impl Borrow<str> for Chars {
 }
 
 impl AsRef<Bytes> for Chars {
-    fn borrow(&self) -> &Bytes {
+    fn as_ref(&self) -> &Bytes {
         &self.0
     }
 }

--- a/protobuf/src/chars.rs
+++ b/protobuf/src/chars.rs
@@ -4,6 +4,7 @@ use std::borrow::Borrow;
 use std::fmt;
 use std::ops::Deref;
 use std::str;
+use std::convert::AsRef;
 
 use bytes::Bytes;
 
@@ -78,6 +79,12 @@ impl Deref for Chars {
 impl Borrow<str> for Chars {
     fn borrow(&self) -> &str {
         &*self
+    }
+}
+
+impl AsRef<Bytes> for Chars {
+    fn borrow(&self) -> &Bytes {
+        &self.0
     }
 }
 

--- a/protobuf/src/reflect/runtime_types.rs
+++ b/protobuf/src/reflect/runtime_types.rs
@@ -3,6 +3,7 @@
 use std::collections::HashMap;
 use std::fmt;
 use std::marker;
+use std::ops::Deref;
 
 #[cfg(feature = "bytes")]
 use bytes::Bytes;
@@ -738,7 +739,7 @@ impl RuntimeTypeTrait for RuntimeTypeTokioChars {
     }
 
     fn as_ref(value: &Chars) -> ReflectValueRef {
-        ReflectValueRef::String(value.as_ref())
+        ReflectValueRef::String(<Chars as Deref>::deref(value))
     }
 
     fn is_non_zero(value: &Chars) -> bool {


### PR DESCRIPTION
Added `AsRef<bytes::Bytes>` to `protobuf::Chars` to allow access to inner type.

As per #720 

There is an issue of this being a breaking change to anyone who uses the `Deref -> AsRef<_>` impl.
Perhaps a 'getter' function might be a better way to go around this to keep the API compatible?