### PR TITLE
Derive Hash for EnumOrUnknown

### DIFF
--- a/protobuf/src/enum_or_unknown.rs
+++ b/protobuf/src/enum_or_unknown.rs
@@ -9,7 +9,7 @@ use crate::Enum;
 use crate::EnumFull;
 
 /// Protobuf enums with possibly unknown values are preserved in this struct.
-#[derive(Eq, PartialEq, Ord, PartialOrd, Copy, Clone)]
+#[derive(Eq, PartialEq, Ord, PartialOrd, Copy, Clone, Hash)]
 #[repr(transparent)]
 // This should be <E: ProtobufEnum> when it no longer prevents using const fns.
 pub struct EnumOrUnknown<E> {


### PR DESCRIPTION
Since EnumOrUnknown does not have a protoc insertion point, additional derives cannot be added via the api. At the same time, EnumOrUnknown are simple values that are likely to be stored in a hash collection, such as a map or set. This single word commit adds the derive for the Hash trait to EnumOrUnknown.