### PR TITLE
Remove use of box_pointers lint

### DIFF
--- a/protobuf-codegen/src/gen/code_writer.rs
+++ b/protobuf-codegen/src/gen/code_writer.rs
@@ -85,7 +85,6 @@ impl<'a> CodeWriter<'a> {
         self.write_line("#![allow(unused_attributes)]");
         self.write_line("#![cfg_attr(rustfmt, rustfmt::skip)]");
         self.write_line("");
-        self.write_line("#![allow(box_pointers)]");
         self.write_line("#![allow(dead_code)]");
         self.write_line("#![allow(missing_docs)]");
         self.write_line("#![allow(non_camel_case_types)]");

--- a/protobuf/src/descriptor.rs
+++ b/protobuf/src/descriptor.rs
@@ -9,7 +9,6 @@
 #![allow(unused_attributes)]
 #![cfg_attr(rustfmt, rustfmt::skip)]
 
-#![allow(box_pointers)]
 #![allow(dead_code)]
 #![allow(missing_docs)]
 #![allow(non_camel_case_types)]

--- a/protobuf/src/doctest_pb.rs
+++ b/protobuf/src/doctest_pb.rs
@@ -9,7 +9,6 @@
 #![allow(unused_attributes)]
 #![cfg_attr(rustfmt, rustfmt::skip)]
 
-#![allow(box_pointers)]
 #![allow(dead_code)]
 #![allow(missing_docs)]
 #![allow(non_camel_case_types)]

--- a/protobuf/src/plugin.rs
+++ b/protobuf/src/plugin.rs
@@ -9,7 +9,6 @@
 #![allow(unused_attributes)]
 #![cfg_attr(rustfmt, rustfmt::skip)]
 
-#![allow(box_pointers)]
 #![allow(dead_code)]
 #![allow(missing_docs)]
 #![allow(non_camel_case_types)]

--- a/protobuf/src/rustproto.rs
+++ b/protobuf/src/rustproto.rs
@@ -9,7 +9,6 @@
 #![allow(unused_attributes)]
 #![cfg_attr(rustfmt, rustfmt::skip)]
 
-#![allow(box_pointers)]
 #![allow(dead_code)]
 #![allow(missing_docs)]
 #![allow(non_camel_case_types)]

--- a/protobuf/src/well_known_types/any.rs
+++ b/protobuf/src/well_known_types/any.rs
@@ -9,7 +9,6 @@
 #![allow(unused_attributes)]
 #![cfg_attr(rustfmt, rustfmt::skip)]
 
-#![allow(box_pointers)]
 #![allow(dead_code)]
 #![allow(missing_docs)]
 #![allow(non_camel_case_types)]

--- a/protobuf/src/well_known_types/api.rs
+++ b/protobuf/src/well_known_types/api.rs
@@ -9,7 +9,6 @@
 #![allow(unused_attributes)]
 #![cfg_attr(rustfmt, rustfmt::skip)]
 
-#![allow(box_pointers)]
 #![allow(dead_code)]
 #![allow(missing_docs)]
 #![allow(non_camel_case_types)]

--- a/protobuf/src/well_known_types/duration.rs
+++ b/protobuf/src/well_known_types/duration.rs
@@ -9,7 +9,6 @@
 #![allow(unused_attributes)]
 #![cfg_attr(rustfmt, rustfmt::skip)]
 
-#![allow(box_pointers)]
 #![allow(dead_code)]
 #![allow(missing_docs)]
 #![allow(non_camel_case_types)]

--- a/protobuf/src/well_known_types/empty.rs
+++ b/protobuf/src/well_known_types/empty.rs
@@ -9,7 +9,6 @@
 #![allow(unused_attributes)]
 #![cfg_attr(rustfmt, rustfmt::skip)]
 
-#![allow(box_pointers)]
 #![allow(dead_code)]
 #![allow(missing_docs)]
 #![allow(non_camel_case_types)]

--- a/protobuf/src/well_known_types/field_mask.rs
+++ b/protobuf/src/well_known_types/field_mask.rs
@@ -9,7 +9,6 @@
 #![allow(unused_attributes)]
 #![cfg_attr(rustfmt, rustfmt::skip)]
 
-#![allow(box_pointers)]
 #![allow(dead_code)]
 #![allow(missing_docs)]
 #![allow(non_camel_case_types)]

--- a/protobuf/src/well_known_types/source_context.rs
+++ b/protobuf/src/well_known_types/source_context.rs
@@ -9,7 +9,6 @@
 #![allow(unused_attributes)]
 #![cfg_attr(rustfmt, rustfmt::skip)]
 
-#![allow(box_pointers)]
 #![allow(dead_code)]
 #![allow(missing_docs)]
 #![allow(non_camel_case_types)]

--- a/protobuf/src/well_known_types/struct_.rs
+++ b/protobuf/src/well_known_types/struct_.rs
@@ -9,7 +9,6 @@
 #![allow(unused_attributes)]
 #![cfg_attr(rustfmt, rustfmt::skip)]
 
-#![allow(box_pointers)]
 #![allow(dead_code)]
 #![allow(missing_docs)]
 #![allow(non_camel_case_types)]

--- a/protobuf/src/well_known_types/timestamp.rs
+++ b/protobuf/src/well_known_types/timestamp.rs
@@ -9,7 +9,6 @@
 #![allow(unused_attributes)]
 #![cfg_attr(rustfmt, rustfmt::skip)]
 
-#![allow(box_pointers)]
 #![allow(dead_code)]
 #![allow(missing_docs)]
 #![allow(non_camel_case_types)]

--- a/protobuf/src/well_known_types/type_.rs
+++ b/protobuf/src/well_known_types/type_.rs
@@ -9,7 +9,6 @@
 #![allow(unused_attributes)]
 #![cfg_attr(rustfmt, rustfmt::skip)]
 
-#![allow(box_pointers)]
 #![allow(dead_code)]
 #![allow(missing_docs)]
 #![allow(non_camel_case_types)]

--- a/protobuf/src/well_known_types/wrappers.rs
+++ b/protobuf/src/well_known_types/wrappers.rs
@@ -9,7 +9,6 @@
 #![allow(unused_attributes)]
 #![cfg_attr(rustfmt, rustfmt::skip)]
 
-#![allow(box_pointers)]
 #![allow(dead_code)]
 #![allow(missing_docs)]
 #![allow(non_camel_case_types)]


### PR DESCRIPTION
Presence of this lint in generated rust files causes warnings on beta.

(I use -Dwarnings in CI so noticed early.)

See https://github.com/rust-lang/rust/pull/126018 for rationale. TL;DR: it's a useless lint.