### PR TITLE
feat: add support for repeated fields in constants

### DIFF
--- a/protobuf-parse/src/pure/model.rs
+++ b/protobuf-parse/src/pure/model.rs
@@ -426,11 +426,11 @@ impl fmt::Display for ProtobufConstant {
 impl ProtobufConstantMessage {
     pub fn format(&self) -> String {
         let mut s = String::new();
-        write!(s, "{{").unwrap();
+        write!(s, "{{ ").unwrap();
         for (n, v) in &self.fields {
             match v {
                 ProtobufConstant::Message(m) => write!(s, "{} {}", n, m.format()).unwrap(),
-                v => write!(s, "{}: {}", n, v.format()).unwrap(),
+                v => write!(s, "{}: {} ", n, v.format()).unwrap(),
             }
         }
         write!(s, "}}").unwrap();

--- a/protobuf-support/src/lexer/tokenizer.rs
+++ b/protobuf-support/src/lexer/tokenizer.rs
@@ -198,7 +198,8 @@ impl<'a> Tokenizer<'a> {
         self.next_token_if(|token| match token {
             Token::Symbol(c) if symbols.contains(c) => true,
             _ => false,
-        }).map(|token| token.is_some())
+        })
+        .map(|token| token.is_some())
     }
 
     pub fn next_symbol_if_eq(&mut self, symbol: char) -> TokenizerResult<bool> {

--- a/protobuf-support/src/lexer/tokenizer.rs
+++ b/protobuf-support/src/lexer/tokenizer.rs
@@ -194,11 +194,15 @@ impl<'a> Tokenizer<'a> {
         Ok(())
     }
 
-    pub fn next_symbol_if_eq(&mut self, symbol: char) -> TokenizerResult<bool> {
-        Ok(self.next_token_if(|token| match token {
-            &Token::Symbol(c) if c == symbol => true,
+    pub fn next_symbol_if_in(&mut self, symbols: &[char]) -> TokenizerResult<bool> {
+        self.next_token_if(|token| match token {
+            Token::Symbol(c) if symbols.contains(c) => true,
             _ => false,
-        })? != None)
+        }).map(|token| token.is_some())
+    }
+
+    pub fn next_symbol_if_eq(&mut self, symbol: char) -> TokenizerResult<bool> {
+        self.next_symbol_if_in(&[symbol])
     }
 
     pub fn next_symbol_expect_eq(


### PR DESCRIPTION
This adds support for repeated fields in constants. Until now the following was failing with a parsing error:

```protobuf
optional uint64 my_field = 1 [ (my_option) = { my_option_repeated_field: ["foo", "bar"] } ];
```

This is valid for `protoc` and it's covered in the specification, but the parser wasn't accepting the `["foo", "bar"]`
syntax for assigning a value to the repeated field.

Some refactoring was required to implement this. Particularly, the functions `option_value_field_to_unknown_value`
and `option_value_message_to_unknown_value`, which returned `UnknownValue`, now receive a mutable `UnknownFields`
and add new fields to it. These function where renamed to more appropriate names.

Additionally, this fixes an issue while parsing constant messages that use commas or semicolons as field separators.
For instance, all the following variants that are accepted by the official compiler`protoc` were being rejected by the parser

```
{foo: 1,bar: 2,baz: 3,}
{foo: 1;bar: 2;baz: 3;}
{foo: 1 bar: 2 baz: 3}
{foo: 1,bar: 2;baz: 3}
{foo: 1,bar: 2 baz: 3}
```