### PR TITLE
add support for proto2 groups

### DIFF
--- a/protobuf-codegen/src/gen/field/accessor.rs
+++ b/protobuf-codegen/src/gen/field/accessor.rs
@@ -155,9 +155,11 @@ impl FieldGen<'_> {
                 type_params: vec!["_".to_owned()],
                 callback_params: self.make_accessor_fns_lambda(),
             },
-            FieldElem::Group => {
-                unreachable!("no accessor for group field");
-            }
+            FieldElem::Group(m) => AccessorFn {
+                name: "make_message_field_accessor".to_owned(),
+                type_params: vec![format!("{}", m.rust_name_relative(&self.file_and_mod()))],
+                callback_params: self.make_accessor_fns_lambda(),
+            },
         }
     }
 

--- a/protobuf-codegen/src/gen/field/type_ext.rs
+++ b/protobuf-codegen/src/gen/field/type_ext.rs
@@ -37,7 +37,7 @@ impl TypeExt for Type {
 
     fn is_copy(&self) -> bool {
         match self {
-            Type::TYPE_MESSAGE | Type::TYPE_STRING | Type::TYPE_BYTES => false,
+            Type::TYPE_GROUP | Type::TYPE_MESSAGE | Type::TYPE_STRING | Type::TYPE_BYTES => false,
             _ => true,
         }
     }

--- a/protobuf-codegen/src/gen/message.rs
+++ b/protobuf-codegen/src/gen/message.rs
@@ -271,7 +271,7 @@ impl<'a> MessageGen<'a> {
                 self.rust_name()
             ),
             |w| {
-                for f in &self.fields_except_oneof_and_group() {
+                for f in self.fields_except_oneof() {
                     w.field_entry(
                         &f.rust_name.to_string(),
                         &f.kind
@@ -310,6 +310,31 @@ impl<'a> MessageGen<'a> {
         );
     }
 
+    fn write_merge_delimited(&self, w: &mut CodeWriter) {
+        let sig = format!(
+            "merge_delimited(&mut self, is: &mut {}::CodedInputStream<'_>, end_tag: u32) -> {}::Result<()>",
+            protobuf_crate_path(&self.customize.for_elem),
+            protobuf_crate_path(&self.customize.for_elem),
+        );
+        w.comment("read and merge values from the stream, stopping when `end_tag` tag is reached");
+        w.pub_fn(&sig, |w| {
+            w.while_block("let Some(tag) = is.read_raw_tag_or_eof()?", |w| {
+                w.if_stmt("tag == end_tag", |w| {
+                    w.write_line("return ::std::result::Result::Ok(());");
+                });
+                w.match_block("tag", |w| {
+                    for f in &self.fields {
+                        f.write_merge_from_field_case_block(w);
+                    }
+                    w.case_block("tag", |w| {
+                        w.write_line(&format!("{}::rt::read_unknown(tag, is, self.special_fields.mut_unknown_fields())?;", protobuf_crate_path(&self.customize.for_elem)));
+                    });
+                });
+            });
+            w.write_line("::std::result::Result::Ok(())");
+        });
+    }
+
     fn write_compute_size(&self, w: &mut CodeWriter) {
         // Append sizes of messages in the tree to the specified vector.
         // First appended element is size of self, and then nested message sizes.
@@ -320,7 +345,7 @@ impl<'a> MessageGen<'a> {
         w.def_fn("compute_size(&self) -> u64", |w| {
             // To have access to its methods but not polute the name space.
             w.write_line("let mut my_size = 0;");
-            for field in self.fields_except_oneof_and_group() {
+            for field in &self.fields_except_oneof() {
                 field.write_message_compute_field_size("my_size", w);
             }
             self.write_match_each_oneof_variant(w, |w, variant, v| {
@@ -338,7 +363,7 @@ impl<'a> MessageGen<'a> {
     }
 
     fn write_field_accessors(&self, w: &mut CodeWriter) {
-        for f in self.fields_except_group() {
+        for f in &self.fields {
             f.write_message_single_field_accessors(w);
         }
     }
@@ -350,6 +375,9 @@ impl<'a> MessageGen<'a> {
             });
 
             self.write_field_accessors(w);
+
+            w.write_line("");
+            self.write_merge_delimited(w);
 
             if !self.lite_runtime {
                 w.write_line("");
@@ -385,11 +413,11 @@ impl<'a> MessageGen<'a> {
         w.def_fn(&sig, |w| {
             w.while_block("let Some(tag) = is.read_raw_tag_or_eof()?", |w| {
                 w.match_block("tag", |w| {
-                    for f in &self.fields_except_group() {
+                    for f in &self.fields {
                         f.write_merge_from_field_case_block(w);
                     }
                     w.case_block("tag", |w| {
-                        w.write_line(&format!("{}::rt::read_unknown_or_skip_group(tag, is, self.special_fields.mut_unknown_fields())?;", protobuf_crate_path(&self.customize.for_elem)));
+                        w.write_line(&format!("{}::rt::read_unknown(tag, is, self.special_fields.mut_unknown_fields())?;", protobuf_crate_path(&self.customize.for_elem)));
                     });
                 });
             });

--- a/protobuf-codegen/src/gen/rust_types_values.rs
+++ b/protobuf-codegen/src/gen/rust_types_values.rs
@@ -58,8 +58,6 @@ pub(crate) enum RustType {
     Bytes,
     // chars::Chars
     Chars,
-    // group
-    Group,
 }
 
 impl RustType {
@@ -101,7 +99,6 @@ impl RustType {
                 protobuf_crate_path(customize),
                 name
             ),
-            RustType::Group => format!("<group>"),
             RustType::Bytes => format!("::bytes::Bytes"),
             RustType::Chars => format!("{}::Chars", protobuf_crate_path(customize)),
         }

--- a/protobuf/src/coded_output_stream/mod.rs
+++ b/protobuf/src/coded_output_stream/mod.rs
@@ -416,6 +416,7 @@ impl<'a> CodedOutputStream<'a> {
             UnknownValueRef::Fixed32(fixed32) => self.write_raw_little_endian32(fixed32),
             UnknownValueRef::Varint(varint) => self.write_raw_varint64(varint),
             UnknownValueRef::LengthDelimited(bytes) => self.write_bytes_no_tag(bytes),
+            UnknownValueRef::Group(bytes) => self.write_bytes_no_tag(bytes),
         }
     }
 

--- a/protobuf/src/rt/mod.rs
+++ b/protobuf/src/rt/mod.rs
@@ -36,6 +36,7 @@ pub use singular::sint64_size;
 pub use singular::string_size;
 pub use singular::uint32_size;
 pub use singular::uint64_size;
+pub use unknown_or_group::read_unknown;
 pub use unknown_or_group::read_unknown_or_skip_group;
 pub use unknown_or_group::skip_field_for_tag;
 pub use unknown_or_group::unknown_fields_size;
@@ -59,4 +60,9 @@ pub(crate) fn compute_raw_varint32_size(value: u32) -> u64 {
 #[inline]
 pub fn tag_size(field_number: u32) -> u64 {
     encoded_varint64_len((field_number as u64) << 3) as u64
+}
+
+/// Sets the `WireType` of a raw tag to `WireType::EndGroup`.
+pub fn set_wire_type_to_end_group(tag: u32) -> u32 {
+    tag & !crate::wire_format::TAG_TYPE_MASK | (WireType::EndGroup as u32)
 }

--- a/protobuf/src/wire_format.rs
+++ b/protobuf/src/wire_format.rs
@@ -35,9 +35,9 @@ pub enum WireType {
     Fixed64 = 1,
     /// Length-delimited field
     LengthDelimited = 2,
-    /// Groups are not supported in rust-protobuf
+    /// Denotes the beginning of a group
     StartGroup = 3,
-    /// Groups are not supported in rust-protobuf
+    /// Denotes the end of a group
     EndGroup = 4,
     /// 32-bit field (e. g. `fixed32` or `float`)
     Fixed32 = 5,
@@ -55,6 +55,11 @@ impl WireType {
             5 => Some(WireType::Fixed32),
             _ => None,
         }
+    }
+
+    /// Indicates whether the `WireType` is a `StartGroup` or `EndGroup`.
+    pub fn is_group(&self) -> bool {
+        matches!(self, WireType::StartGroup | WireType::EndGroup)
     }
 
     #[doc(hidden)]
@@ -78,7 +83,7 @@ impl WireType {
             Type::TYPE_STRING => WireType::LengthDelimited,
             Type::TYPE_BYTES => WireType::LengthDelimited,
             Type::TYPE_MESSAGE => WireType::LengthDelimited,
-            Type::TYPE_GROUP => WireType::LengthDelimited, // not true
+            Type::TYPE_GROUP => WireType::StartGroup,
         }
     }
 }
@@ -131,7 +136,7 @@ impl Tag {
     }
 
     /// Get wire type
-    fn wire_type(self) -> WireType {
+    pub(crate) fn wire_type(self) -> WireType {
         self.wire_type
     }
 


### PR DESCRIPTION
Hello. Thanks for your work on this repo. I'm interested in maximizing support for protobufs in rust.

In the interest of increasing protobuf conformance score, this pull request adds support for the deprecated proto2 group syntax.

Groups are generated similarly to messages; a rust struct is created to match the contents of the group.

Groups use a delimited merge operation when reading from a `CodedInputStream`. To avoid making a change to the public `Message` trait, an inherent method is generated in each group- and message-derived struct called `merge_delimited`, which takes an `end_tag`, and merges into the struct until that end tag is found. The Message impl for a struct leverages the inherent `merge_delimited` method on its message field for groups. Example:
```proto
syntax = "proto2";
message Foo {
  repeated group Data = 1 {
    optional int32 group_int32 = 2;
    required uint32 group_uint32 = 3;
  }
}
```
```rs
    // <Foo as Message>::merge_from
    pub fn merge_from(&mut self, is: &mut ::protobuf::CodedInputStream<'_>) -> ::protobuf::Result<()> { 
        while let Some(tag) = is.read_raw_tag_or_eof()? {
            match tag {
                11 => {
                    let end_tag = ::protobuf::rt::set_wire_type_to_end_group(tag);
                    let mut data = foo::Data::default();
                    data.merge_delimited(is, end_tag)?; // <-- `foo::Data::merge_delimited` inherent method
                    self.data.push(data);
                },
```

When an unknown type is encountered, if the tag is of type StartGroup, a `CodedOutputStream` is created on top of a `Vec<u8>`, and all values are written to it until the corresponding end tag is found. The `CodedOutputStream` is then flushed, and the raw bytes returned for storage.

The computed serialized size of a group is the size of the message plus twice the size of the tag.

Generated code compiles with `repeated`, `required`, and `optional` groups. 

This pull request addresses and provides a fix for [Issue#742](https://github.com/stepancheg/rust-protobuf/issues/742).

This feature addition covers a large surface area and I am happy to incorporate any feedback. Please let me know if I missed anything or if my implementation does not suit the coding style of this project.