### PR TITLE
Specify MSRV in protobuf crate

### DIFF
--- a/protobuf/Cargo.toml
+++ b/protobuf/Cargo.toml
@@ -11,6 +11,7 @@ documentation = "https://github.com/stepancheg/rust-protobuf/blob/master/README.
 description = """
 Rust implementation of Google protocol buffers
 """
+rust-version = "1.74.0"
 
 [lib]
 bench = false


### PR DESCRIPTION
The protobuf-codegen crate fails to compile
with Rust 1.71.0 due to code in this crate,
so mark the MSRV in this crate correctly.

[rust-version docs](https://doc.rust-lang.org/cargo/reference/manifest.html#the-rust-version-field)

Error message on compiling with older versions:

```
error[E0445]: crate-private trait `MapFieldAccessor` in public interface
   --> /Users/varun/.local/share/mise/installs/rust/1.71.0/registry/src/index.crates.io-6f17d22bba15001f/protobuf-3.7.1/src/reflect/acc/v2/map.rs:115:1
    |
17  |   pub(crate) trait MapFieldAccessor: Send + Sync + 'static {
    |   -------------------------------------------------------- `MapFieldAccessor` declared as crate-private
...
115 | / pub fn make_map_simpler_accessor_new<M, T>(
116 | |     name: &'static str,
117 | |     get_field: for<'a> fn(&'a M) -> &'a T,
118 | |     mut_field: for<'a> fn(&'a mut M) -> &'a mut T,
...   |
121 | |     M: MessageFull,
122 | |     MapFieldAccessorImpl<M, T>: MapFieldAccessor,
    | |_________________________________________________^ can't leak crate-private trait

error[E0446]: private type `MapFieldAccessorImpl<M, T>` in public interface
   --> /Users/varun/.local/share/mise/installs/rust/1.71.0/registry/src/index.crates.io-6f17d22bba15001f/protobuf-3.7.1/src/reflect/acc/v2/map.rs:115:1
    |
33  |   struct MapFieldAccessorImpl<M, T>
    |   --------------------------------- `MapFieldAccessorImpl<M, T>` declared as private
...
115 | / pub fn make_map_simpler_accessor_new<M, T>(
116 | |     name: &'static str,
117 | |     get_field: for<'a> fn(&'a M) -> &'a T,
118 | |     mut_field: for<'a> fn(&'a mut M) -> &'a mut T,
...   |
121 | |     M: MessageFull,
122 | |     MapFieldAccessorImpl<M, T>: MapFieldAccessor,
    | |_________________________________________________^ can't leak private type

Some errors have detailed explanations: E0445, E0446.
For more information about an error, try `rustc --explain E0445`.
```

Originally detected in https://github.com/sourcegraph/scip/issues/284#issuecomment-2418476422