### PR TITLE
Propagate oneofs_nonexhaustive value to descendant contexts

### DIFF
--- a/protobuf-codegen/src/customize/mod.rs
+++ b/protobuf-codegen/src/customize/mod.rs
@@ -190,31 +190,45 @@ impl Customize {
 
     /// Update fields of self with fields defined in other customize
     pub fn update_with(&mut self, that: &Customize) {
-        if let Some(v) = &that.before {
-            self.before = Some(v.clone());
+        // Intentionally exhaustive destructuring ensures that if fields are
+        // added but not at least mentioned here, this code won't compile.
+        let Customize {
+            before,
+            generate_accessors,
+            generate_getter,
+            tokio_bytes,
+            tokio_bytes_for_string,
+            oneofs_non_exhaustive,
+            lite_runtime,
+            gen_mod_rs,
+            inside_protobuf,
+            btreemap,
+        } = that.clone();
+        if let Some(v) = before {
+            self.before = Some(v);
         }
-        if let Some(v) = that.generate_accessors {
+        if let Some(v) = generate_accessors {
             self.generate_accessors = Some(v);
         }
-        if let Some(v) = that.generate_getter {
+        if let Some(v) = generate_getter {
             self.generate_getter = Some(v);
         }
-        if let Some(v) = that.tokio_bytes {
+        if let Some(v) = tokio_bytes {
             self.tokio_bytes = Some(v);
         }
-        if let Some(v) = that.tokio_bytes_for_string {
+        if let Some(v) = tokio_bytes_for_string {
             self.tokio_bytes_for_string = Some(v);
         }
-        if let Some(v) = that.lite_runtime {
+        if let Some(v) = lite_runtime {
             self.lite_runtime = Some(v);
         }
-        if let Some(v) = that.gen_mod_rs {
+        if let Some(v) = gen_mod_rs {
             self.gen_mod_rs = Some(v);
         }
-        if let Some(v) = that.inside_protobuf {
+        if let Some(v) = inside_protobuf {
             self.inside_protobuf = Some(v);
         }
-        if let Some(v) = that.btreemap {
+        if let Some(v) = btreemap {
             self.btreemap = Some(v);
         }
     }

--- a/protobuf-codegen/src/customize/mod.rs
+++ b/protobuf-codegen/src/customize/mod.rs
@@ -231,6 +231,9 @@ impl Customize {
         if let Some(v) = btreemap {
             self.btreemap = Some(v);
         }
+        if let Some(v) = oneofs_non_exhaustive {
+            self.oneofs_non_exhaustive = Some(v);
+        }
     }
 
     /// Update unset fields of self with fields from other customize


### PR DESCRIPTION
Copy the value of `Customize::oneofs_non_exhaustive` to the context for fields so that it actually works as expected. Change the code to make it harder to introduce this sort of bug in the future.

Fixes #747