### PR TITLE
feat: make DynamicMessage public

### DIFF
--- a/protobuf/src/reflect/dynamic/mod.rs
+++ b/protobuf/src/reflect/dynamic/mod.rs
@@ -96,7 +96,7 @@ impl DynamicFieldValue {
 }
 
 #[derive(Debug, Clone)]
-pub(crate) struct DynamicMessage {
+pub struct DynamicMessage {
     descriptor: MessageDescriptor,
     /// Fields by index in the description.
     /// This field is lazy-init: it is empty when created.
@@ -127,7 +127,7 @@ impl DynamicMessage {
         }
     }
 
-    pub(crate) fn get_reflect<'a>(&'a self, field: &FieldDescriptor) -> ReflectFieldRef<'a> {
+    pub fn get_reflect<'a>(&'a self, field: &FieldDescriptor) -> ReflectFieldRef<'a> {
         let (descriptor, index) = field.regular();
         assert_eq!(self.descriptor, descriptor);
         if self.fields.is_empty() {

--- a/protobuf/src/reflect/mod.rs
+++ b/protobuf/src/reflect/mod.rs
@@ -14,7 +14,7 @@
 //! Some minor adjustements are made to make code more idiomatic to rust.
 
 mod acc;
-mod dynamic;
+pub mod dynamic;
 mod enums;
 pub(crate) mod error;
 mod field;


### PR DESCRIPTION
This PR aims to help with decoding dynamic messages.
Encoding is already supported, but decoding is not so straight-forward and to actually get any field's value, you would need to downcast the `Box<dyn Message>` that you decode into the actual `FullMessage` that you do not have, as you have to do it at runtime.

The next example exemplifies this:

```rust
#[test]
fn test_decode_dynamic_message() {
    use protobuf::descriptor::FileDescriptorProto;
    use protobuf::{
        self,
        reflect::{dynamic::DynamicMessage, FileDescriptor},
    };

    // Hello markus
    let bytes: Vec<u8> = vec![
        10, 12, 72, 101, 108, 108, 111, 32, 109, 97, 114, 107, 117, 115,
    ];

    let message_proto = r#"
syntax = "proto3";
message Message {
  string message = 1;
}
"#;

    let temp_dir = tempfile::tempdir().unwrap();
    let tempfile = temp_dir.path().join("CUSTOM_FILE.proto");
    std::fs::write(&tempfile, message_proto).unwrap();
    let mut file_descriptor_protos = protobuf_parse::Parser::new()
        .pure()
        .includes(&[temp_dir.path().to_path_buf()])
        .input(&tempfile)
        .parse_and_typecheck()
        .unwrap()
        .file_descriptors;

    let file_descriptor_proto: FileDescriptorProto = file_descriptor_protos.pop().unwrap();
    let file_descriptor: FileDescriptor =
        FileDescriptor::new_dynamic(file_descriptor_proto, &[]).unwrap();

    let msg_descriptor = file_descriptor
        .message_by_package_relative_name("Message")
        .unwrap();

    let msg = msg_descriptor.parse_from_bytes(&bytes).unwrap();

    // we need DynamicMessage public so that we can cast it here
    let dynamic_msg = msg.downcast_box::<DynamicMessage>().unwrap();

    let field_ref = dynamic_msg.get_reflect(&msg_descriptor.field_by_name("message").unwrap());
    if let protobuf::reflect::ReflectFieldRef::Optional(field) = field_ref {
        println!("{:?}", field.value()); // <- this prints 'Some(String("Hello markus"))'
    };
}
```