### PR TITLE
Add an option to print 64-bit integers without quotes

### DIFF
--- a/protobuf-json-mapping/src/print.rs
+++ b/protobuf-json-mapping/src/print.rs
@@ -130,6 +130,9 @@ impl PrintableToJson for f64 {
 impl PrintableToJson for u64 {
     fn print_to_json(&self, w: &mut Printer) -> PrintResult<()> {
         // 64-bit integers are quoted by default
+        if w.print_options.unquoted_64bit_integers {
+            return Ok(write!(w.buf, "{}", self)?);
+        }
         Ok(write!(w.buf, "\"{}\"", self)?)
     }
 }
@@ -137,6 +140,9 @@ impl PrintableToJson for u64 {
 impl PrintableToJson for i64 {
     fn print_to_json(&self, w: &mut Printer) -> PrintResult<()> {
         // 64-bit integers are quoted by default
+        if w.print_options.unquoted_64bit_integers {
+            return Ok(write!(w.buf, "{}", self)?);
+        }
         Ok(write!(w.buf, "\"{}\"", self)?)
     }
 }
@@ -563,6 +569,8 @@ pub struct PrintOptions {
     pub proto_field_name: bool,
     /// Output field default values.
     pub always_output_default_values: bool,
+    /// Do not quote 64-bit integers.
+    pub unquoted_64bit_integers: bool,
     /// Prevent initializing `PrintOptions` enumerating all field.
     pub _future_options: (),
 }


### PR DESCRIPTION
I appreciate the fact that this is done because it is described as such in the [ProtoJSON](https://protobuf.dev/programming-guides/json/) specification, but it prevents using the generated JSON in (most) other systems as it's not following [RFC8259](https://www.rfc-editor.org/rfc/rfc8259#page-7) which does not specify nor require 64-bit integers to be quoted.

By adding this option people still get the `ProtoJSON` output by default, but have the option to opt-out from the quoted 64-bit integers in order for the output to be more inline with `RFC8259`.

Hope this is something you are willing to merge as it will allow us to use the `protobuf-json-mapping` crate for our use cases. Thanks!