### PR TITLE
optimize the fixed32 and fixed64 encoding

### DIFF
--- a/test-crates/perftest/misc/benches/coded_output_stream.rs
+++ b/test-crates/perftest/misc/benches/coded_output_stream.rs
@@ -63,3 +63,33 @@ fn bench_write_raw_varint_32(b: &mut Bencher) {
         v.len()
     })
 }
+
+#[bench]
+fn bench_write_raw_fixed32(b: &mut Bencher) {
+    let mut v = Vec::with_capacity(10_000);
+    b.iter(|| {
+        v.clear();
+        {
+            let mut os = CodedOutputStream::new(&mut v);
+            for i in 0..1000 {
+                os.write_fixed32_no_tag(i * 139 % 1000).unwrap();
+            }
+        }
+        v.len()
+    })
+}
+
+#[bench]
+fn bench_write_raw_fixed64(b: &mut Bencher) {
+    let mut v = Vec::with_capacity(10_000);
+    b.iter(|| {
+        v.clear();
+        {
+            let mut os = CodedOutputStream::new(&mut v);
+            for i in 0..1000 {
+                os.write_fixed64_no_tag(i * 12345678 % 100000000).unwrap();
+            }
+        }
+        v.len()
+    })
+}


### PR DESCRIPTION
The current implementation of write_raw_little_endian32 is just using self.write_raw_bytes. 

As this go through the function boundaries, the compiler is not smart enough to simplify the data copy, and end-up calling memcpy.

This inlined implementation is twice as fast as the previous according to the attached bench.

```
test bench_write_raw_fixed32   ... bench:       5,860.52 ns/iter (+/- 62.51)
test bench_write_raw_fixed64   ... bench:       4,303.08 ns/iter (+/- 29.47)
test bench_write_raw_varint_32 ... bench:       2,555.20 ns/iter (+/- 126.98)
```

now fixed32/64 is as expected a bit faster than varint

```
test bench_write_raw_fixed32   ... bench:       2,143.48 ns/iter (+/- 21.70)
test bench_write_raw_fixed64   ... bench:       2,209.28 ns/iter (+/- 32.42)
test bench_write_raw_varint_32 ... bench:       2,480.89 ns/iter (+/- 88.95)
```

